### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     name: Build tvOS app
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build tvOS app
+  test:
+    name: Build and test tvOS app
     runs-on: macos-26
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Checkout
@@ -31,6 +31,9 @@ jobs:
 
       - name: List project schemes
         run: xcodebuild -list -project "MoviePilot-TV.xcodeproj"
+
+      - name: List available tvOS simulators
+        run: xcrun simctl list devices tvOS available
 
       - name: Resolve Swift packages
         run: |
@@ -46,6 +49,18 @@ jobs:
             -scheme "MoviePilot-TV" \
             -configuration Debug \
             -destination "generic/platform=tvOS" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            -skipPackagePluginValidation
+
+      - name: Test
+        run: |
+          xcodebuild test \
+            -project "MoviePilot-TV.xcodeproj" \
+            -scheme "MoviePilot-TV" \
+            -configuration Debug \
+            -destination "platform=tvOS Simulator,name=Apple TV" \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build tvOS app
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show Xcode version
+        run: |
+          xcodebuild -version
+          xcodebuild -showsdks
+
+      - name: List project schemes
+        run: xcodebuild -list -project "MoviePilot-TV.xcodeproj"
+
+      - name: Resolve Swift packages
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project "MoviePilot-TV.xcodeproj" \
+            -scheme "MoviePilot-TV" \
+            -skipPackagePluginValidation
+
+      - name: Build
+        run: |
+          xcodebuild clean build \
+            -project "MoviePilot-TV.xcodeproj" \
+            -scheme "MoviePilot-TV" \
+            -configuration Debug \
+            -destination "generic/platform=tvOS" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            -skipPackagePluginValidation


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow for CI
- Build the tvOS app on pushes, pull requests, and manual dispatch
- Resolve Swift package dependencies before building
- Disable code signing for CI builds to avoid requiring Apple signing assets

## Notes

This workflow uses `macos-latest` and builds the `MoviePilot-TV` scheme with a generic tvOS destination. The workflow logs include `xcodebuild -version` and `xcodebuild -showsdks` to make runner/Xcode issues easy to diagnose.