### PR TITLE
Run CI only for PRs and add unsigned IPA release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unsigned-ipa:
+    name: Build unsigned tvOS IPA
+    runs-on: macos-26
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show Xcode version
+        run: |
+          xcodebuild -version
+          xcodebuild -showsdks
+
+      - name: Resolve Swift packages
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project "MoviePilot-TV.xcodeproj" \
+            -scheme "MoviePilot-TV" \
+            -skipPackagePluginValidation
+
+      - name: Build unsigned app
+        run: |
+          xcodebuild clean build \
+            -project "MoviePilot-TV.xcodeproj" \
+            -scheme "MoviePilot-TV" \
+            -configuration Release \
+            -destination "generic/platform=tvOS" \
+            -derivedDataPath build/DerivedData \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            -skipPackagePluginValidation
+
+      - name: Package unsigned IPA
+        run: |
+          set -euo pipefail
+          APP_PATH="build/DerivedData/Build/Products/Release-appletvos/MoviePilot-TV.app"
+          IPA_PATH="build/MoviePilot-TV-unsigned.ipa"
+
+          if [ ! -d "$APP_PATH" ]; then
+            echo "App bundle not found: $APP_PATH"
+            find build/DerivedData/Build/Products -maxdepth 3 -type d -name "*.app" -print
+            exit 1
+          fi
+
+          rm -rf build/Payload "$IPA_PATH"
+          mkdir -p build/Payload
+          cp -R "$APP_PATH" build/Payload/
+          (cd build && zip -qry "MoviePilot-TV-unsigned.ipa" Payload)
+          ls -lh "$IPA_PATH"
+
+      - name: Upload IPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: MoviePilot-TV-unsigned-ipa
+          path: build/MoviePilot-TV-unsigned.ipa
+          if-no-files-found: error
+
+      - name: Upload IPA to GitHub Release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" build/MoviePilot-TV-unsigned.ipa --clobber


### PR DESCRIPTION
## Summary

- Stop running CI on every push to `main`; CI now runs for pull requests and manual dispatch only
- Add a release workflow that builds an unsigned tvOS IPA
- Upload the unsigned IPA as a workflow artifact
- Upload the unsigned IPA to the GitHub Release when triggered by a published release

## Notes

The generated IPA is unsigned. It is useful as a release artifact for later re-signing, but it is not directly installable on Apple TV without signing.