### PR TITLE
[AI] fix/renew: remove unsupported renewal threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,11 @@
    ```sh
    BUNDLE_ID="com.yourname.MoviePilotTV" bash scripts/apple-tv-renew.sh
    BUNDLE_ID="com.yourname.MoviePilotTV" bash scripts/apple-tv-renew.sh --force
-   RENEW_THRESHOLD_SECONDS=86400 BUNDLE_ID="com.yourname.MoviePilotTV" bash scripts/apple-tv-renew.sh
    ```
 
-   **注意：** 脚本默认只检查本机 DerivedData 中构建产物的 `embedded.mobileprovision`，不会确认 Apple TV 设备端是否仍安装成功；如果本机构建产物里的签名配置仍未过期，脚本会直接跳过。放进 crontab 定时保活时，更稳妥的是定期加 `--force` 重新构建并安装。
+   **注意：** 脚本默认只检查本机 DerivedData 中构建产物的 `embedded.mobileprovision`，不会确认 Apple TV 设备端是否仍安装成功；如果本机构建产物里的签名配置仍未过期，脚本会直接跳过。`--force` 会忽略这个本地未过期检查，直接重新构建并安装到已配对的 Apple TV，适合放进 crontab 定时保活或怀疑设备端安装状态异常时使用。
 
-   `RENEW_THRESHOLD_SECONDS` 可以尝试在剩余时间低于阈值时重新构建/安装，但 Xcode 自动签名不保证一定会在旧的 Xcode-managed provisioning profile 过期前生成新的 profile。因此“提前续签”可以作为尝试，不能当成确定的续期机制。
+   `--force` 只强制执行构建和安装流程，不代表 Xcode/Apple 一定会在旧的 Xcode-managed provisioning profile 过期前签发新的 profile；如果 Apple 仍复用未过期的 profile，应用的实际到期时间不会被提前延长。
 
 ## 后端兼容性测试（可选）
 

--- a/scripts/apple-tv-renew.sh
+++ b/scripts/apple-tv-renew.sh
@@ -39,7 +39,6 @@ Configure with environment variables:
   PROJECT_DIR, PROJECT_FILE, WORKSPACE, SCHEME, CONFIGURATION
   BUNDLE_ID, DEVELOPMENT_TEAM, DEVICE_ID, DEVICE_NAME_CONTAINS
   CLEAR_PROFILE_CACHE=1, MIN_VALID_SECONDS=432000
-  RENEW_THRESHOLD_SECONDS=0
 
 Example:
   BUNDLE_ID="com.example.MoviePilotTV" ./scripts/apple-tv-renew.sh
@@ -76,7 +75,6 @@ DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-}"
 ALLOW_PROVISIONING_DEVICE_REGISTRATION="${ALLOW_PROVISIONING_DEVICE_REGISTRATION:-1}"
 CLEAR_PROFILE_CACHE="${CLEAR_PROFILE_CACHE:-0}"
 MIN_VALID_SECONDS="${MIN_VALID_SECONDS:-432000}" # 5 days
-RENEW_THRESHOLD_SECONDS="${RENEW_THRESHOLD_SECONDS:-0}" # default: renew only when expired
 LOG_FILE="${LOG_FILE:-$PROJECT_DIR/renew.log}"
 
 log() {
@@ -200,8 +198,12 @@ profile = app / 'embedded.mobileprovision'
 if not profile.exists():
     print(json.dumps({'ok': False, 'error': 'embedded.mobileprovision not found', 'path': str(profile)}))
     sys.exit(0)
-data = subprocess.check_output(['security', 'cms', '-D', '-i', str(profile)], stderr=subprocess.DEVNULL)
-p = plistlib.loads(data)
+try:
+    data = subprocess.check_output(['security', 'cms', '-D', '-i', str(profile)], stderr=subprocess.DEVNULL)
+    p = plistlib.loads(data)
+except Exception as exc:
+    print(json.dumps({'ok': False, 'error': str(exc), 'path': str(profile)}, ensure_ascii=False))
+    sys.exit(0)
 ent = p.get('Entitlements') or {}
 exp = p.get('ExpirationDate')
 if exp and exp.tzinfo is None:
@@ -277,19 +279,18 @@ log "Configuration: $CONFIGURATION"
 log "Development team: ${DEVELOPMENT_TEAM:-<project/default>}"
 log "Bundle ID override: ${BUNDLE_ID:-<project default>}"
 log "Force renew: $FORCE_RENEW"
-log "Renew threshold seconds: $RENEW_THRESHOLD_SECONDS"
 
 if [ "$FORCE_RENEW" != "1" ]; then
   if APP_PATH="$(app_path_from_build_settings 2>/dev/null)" && [ -d "$APP_PATH" ]; then
     profile_json="$(profile_info_for_app "$APP_PATH")"
     if [ "$(profile_ok "$profile_json")" = "yes" ]; then
       remaining="$(profile_seconds_remaining "$profile_json")"
-      if [ "$remaining" -gt "$RENEW_THRESHOLD_SECONDS" ]; then
+      if [ "$remaining" -gt 0 ]; then
         log "Existing profile is still valid (${remaining}s remaining); skipping. Use --force to build/install anyway."
         printf '%s\n' "$profile_json"
         exit 0
       fi
-      log "Existing profile is within renewal window (${remaining}s remaining); renewing."
+      log "Existing profile is expired or has no valid expiration (${remaining}s remaining); renewing."
     else
       log "Existing app profile is missing or unreadable; renewing."
     fi
@@ -331,6 +332,7 @@ xcrun devicectl device install app --device "$DEVICE_ID" "$APP_PATH" 2>&1 | tee 
 log "=== Validate embedded provisioning profile ==="
 profile_json=$(profile_info_for_app "$APP_PATH")
 log "Profile: $profile_json"
+[ "$(profile_ok "$profile_json")" = "yes" ] || fail "profile validation failed: $profile_json"
 remaining=$(python3 - "$profile_json" <<'PY'
 import json, sys
 print(json.loads(sys.argv[1]).get('secondsRemaining') or -1)


### PR DESCRIPTION
## Summary
- remove unsupported RENEW_THRESHOLD_SECONDS handling from the Apple TV renew script
- make profile parsing failures structured and fail final validation with a non-zero exit code
- clarify README --force behavior for crontab use and profile reuse limits

## Verification
- git diff --check -- README.md scripts/apple-tv-renew.sh
- bash -n scripts/apple-tv-renew.sh
- bash scripts/apple-tv-renew.sh --help