### PR TITLE
[AI] Align backend compatibility fixes

### DIFF
--- a/MoviePilot-TV/Models/Models.swift
+++ b/MoviePilot-TV/Models/Models.swift
@@ -1025,6 +1025,10 @@ struct MediaServerPlayItem: Codable, Identifiable, Equatable {
 
   /// 真实接口返回的原始 ID（保留，以便未来跳转或 API 请求使用）
   let raw_id: FlexibleString?
+  /// 媒体服务器项目 ID
+  let item_id: FlexibleString?
+  /// 媒体服务器 ID
+  let server_id: FlexibleString?
   /// SwiftUI 需要的稳定唯一表示符（组合原始 id 和 link）
   let id: String
   /// 标题
@@ -1047,12 +1051,14 @@ struct MediaServerPlayItem: Codable, Identifiable, Equatable {
 
   enum CodingKeys: String, CodingKey {
     case raw_id = "id"
-    case title, subtitle, type, image, link, use_cookies, server_type
+    case item_id, server_id, title, subtitle, type, image, link, use_cookies, server_type
   }
 
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     raw_id = try container.decodeIfPresent(FlexibleString.self, forKey: .raw_id)
+    item_id = try container.decodeIfPresent(FlexibleString.self, forKey: .item_id)
+    server_id = try container.decodeIfPresent(FlexibleString.self, forKey: .server_id)
     title = try container.decode(String.self, forKey: .title)
     subtitle = try container.decodeIfPresent(String.self, forKey: .subtitle)
     type = try container.decodeIfPresent(String.self, forKey: .type)
@@ -1082,6 +1088,8 @@ struct MediaServerPlayItem: Codable, Identifiable, Equatable {
     link: String? = nil, use_cookies: FlexibleBool? = nil, server_type: MediaServerType? = nil
   ) {
     self.raw_id = FlexibleString(id)
+    self.item_id = nil
+    self.server_id = nil
     self.id = "playitem-\(id)-\(link ?? "")"
     self.title = title
     self.subtitle = subtitle

--- a/MoviePilot-TV/Services/APIService.swift
+++ b/MoviePilot-TV/Services/APIService.swift
@@ -44,6 +44,50 @@ nonisolated private func encodeURIComponent(_ value: String) -> String? {
   return value.addingPercentEncoding(withAllowedCharacters: allowed)
 }
 
+nonisolated private func isBangumiImageURL(_ value: String) -> Bool {
+  if let host = URLComponents(string: value)?.host?.lowercased() {
+    return host == "lain.bgm.tv" || host.hasSuffix(".lain.bgm.tv")
+  }
+  return value.contains("lain.bgm.tv")
+}
+
+nonisolated private func displayImageURL(
+  _ value: String?,
+  baseURL: String,
+  useImageCache: Bool
+) -> URL? {
+  guard let value, !value.isEmpty else {
+    return nil
+  }
+
+  let lowercasedValue = value.lowercased()
+  guard lowercasedValue.hasPrefix("http://") || lowercasedValue.hasPrefix("https://") else {
+    return URL(string: value)
+  }
+
+  guard let encodedUrl = encodeURIComponent(value) else {
+    return nil
+  }
+
+  if isBangumiImageURL(value) {
+    var urlString = "\(baseURL)/api/v1/system/img/1?imgurl=\(encodedUrl)"
+    if useImageCache {
+      urlString += "&cache=true"
+    }
+    return URL(string: urlString)
+  }
+
+  if useImageCache {
+    return URL(string: "\(baseURL)/api/v1/system/cache/image?url=\(encodedUrl)")
+  }
+
+  if value.contains("doubanio.com") {
+    return URL(string: "\(baseURL)/api/v1/system/img/0?imgurl=\(encodedUrl)")
+  }
+
+  return URL(string: value)
+}
+
 nonisolated private func decodeOrUnwrapSync<T: Decodable>(from data: Data) throws -> T {
   let firstByte = firstNonWhitespaceByte(in: data)
 
@@ -101,44 +145,14 @@ nonisolated private func posterImageURL(posterPath: String?, config: MediaImageU
     }
   }
 
-  if let currentUrl = url, currentUrl.contains("doubanio.com") {
-    guard
-      let encodedUrl = encodeURIComponent(currentUrl)
-    else {
-      return nil
-    }
-    return URL(string: "\(config.baseURL)/api/v1/system/img/0?imgurl=\(encodedUrl)")
-  }
-
-  if config.useImageCache, let currentUrl = url {
-    guard
-      let encodedUrl = encodeURIComponent(currentUrl)
-    else {
-      return nil
-    }
-    return URL(string: "\(config.baseURL)/api/v1/system/cache/image?url=\(encodedUrl)")
-  }
-
-  if let finalUrl = url {
-    return URL(string: finalUrl)
-  }
-  return nil
+  return displayImageURL(url, baseURL: config.baseURL, useImageCache: config.useImageCache)
 }
 
 nonisolated private func backdropImageURL(backdropPath: String?, config: MediaImageURLConfig)
   -> URL?
 {
   guard let url = backdropPath, !url.isEmpty else { return nil }
-
-  if config.useImageCache {
-    guard let encodedUrl = encodeURIComponent(url)
-    else {
-      return nil
-    }
-    return URL(string: "\(config.baseURL)/api/v1/system/cache/image?url=\(encodedUrl)")
-  }
-
-  return URL(string: url)
+  return displayImageURL(url, baseURL: config.baseURL, useImageCache: config.useImageCache)
 }
 
 /// 泛型轻量级接口缓存，带过期及淘汰策略
@@ -1578,17 +1592,7 @@ class APIService: ObservableObject {
   }
 
   func getSubscribePosterImageUrl(poster: String?) -> URL? {
-    guard let url = poster, !url.isEmpty else { return nil }
-
-    if useImageCache {
-      guard let encodedUrl = encodeURIComponent(url)
-      else {
-        return nil
-      }
-      return URL(string: "\(baseURL)/api/v1/system/cache/image?url=\(encodedUrl)")
-    }
-
-    return URL(string: url)
+    return displayImageURL(poster, baseURL: baseURL, useImageCache: useImageCache)
   }
 
   /// 获取订阅分享的海报图片 URL
@@ -1611,30 +1615,7 @@ class APIService: ObservableObject {
       }
     }
 
-    // 2. 如果地址中包含 douban 则使用中转代理 (豆瓣必须中转)
-    if let currentUrl = url, currentUrl.contains("doubanio.com") {
-      guard
-        let encodedUrl = encodeURIComponent(currentUrl)
-      else {
-        return nil
-      }
-      return URL(string: "\(baseURL)/api/v1/system/img/0?imgurl=\(encodedUrl)")
-    }
-
-    // 2. 否则根据设置判断是否使用图片缓存
-    if useImageCache, let currentUrl = url {
-      guard
-        let encodedUrl = encodeURIComponent(currentUrl)
-      else {
-        return nil
-      }
-      return URL(string: "\(baseURL)/api/v1/system/cache/image?url=\(encodedUrl)")
-    }
-
-    if let finalUrl = url {
-      return URL(string: finalUrl)
-    }
-    return nil
+    return displayImageURL(url, baseURL: baseURL, useImageCache: useImageCache)
   }
 
   /// 获取媒体背景图片 URL
@@ -1643,18 +1624,7 @@ class APIService: ObservableObject {
   }
 
   func getBackdropImageUrl(backdropPath: String?) -> URL? {
-    guard let url = backdropPath, !url.isEmpty else { return nil }
-
-    // 使用图片缓存
-    if useImageCache {
-      guard let encodedUrl = encodeURIComponent(url)
-      else {
-        return nil
-      }
-      return URL(string: "\(baseURL)/api/v1/system/cache/image?url=\(encodedUrl)")
-    }
-
-    return URL(string: url)
+    return displayImageURL(backdropPath, baseURL: baseURL, useImageCache: useImageCache)
   }
 
   /// 获取下载 Card 中的背景图片
@@ -1767,14 +1737,6 @@ class APIService: ObservableObject {
       return nil
     }
 
-    if useImageCache {
-      guard let encodedUrl = encodeURIComponent(url)
-      else {
-        return nil
-      }
-      return URL(string: "\(baseURL)/api/v1/system/cache/image?url=\(encodedUrl)")
-    }
-
-    return URL(string: url)
+    return displayImageURL(url, baseURL: baseURL, useImageCache: useImageCache)
   }
 }

--- a/MoviePilot-TV/ViewModels/HomeViewModel.swift
+++ b/MoviePilot-TV/ViewModels/HomeViewModel.swift
@@ -235,8 +235,18 @@ class HomeViewModel: ObservableObject {
     }
   }
 
+  private func validLinkValue(_ value: String?) -> String? {
+    guard let value else { return nil }
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    if ["none", "null", "undefined"].contains(trimmed.lowercased()) {
+      return nil
+    }
+    return trimmed
+  }
+
   func openMediaItem(_ item: MediaServerPlayItem, using openURL: OpenURLAction) {
-    guard let link = item.link, let originalUrl = URL(string: link) else { return }
+    guard let link = validLinkValue(item.link), let originalUrl = URL(string: link) else { return }
 
     var finalUrl: URL? = nil
 
@@ -251,22 +261,34 @@ class HomeViewModel: ObservableObject {
       // 如果是 Emby 服务器，则尝试构建深度链接，目前 Emby 2.0.3(2) 还不支持跳转到媒体
       // 后端链接格式: https://your-emby-server/web/index.html#!/item?id=xxxx&serverId=...
       // emby://items?serverId={your_server_id}&itemId={your_item_id}
+      var itemId = validLinkValue(item.item_id?.value)
+      var serverId = validLinkValue(item.server_id?.value)
       if let fragment = cleanFragment,
         let components = URLComponents(string: "https://dummy.com" + fragment)
       {
         let queryItems = components.queryItems ?? []
-        let itemId = queryItems.first { $0.name == "id" }?.value
-        let serverId = queryItems.first { $0.name == "serverId" }?.value
-        if let itemId = itemId, let serverId = serverId {
-          var deepLinkComponents = URLComponents()
-          deepLinkComponents.scheme = "emby"
-          deepLinkComponents.host = "items"
-          deepLinkComponents.queryItems = [
-            URLQueryItem(name: "serverId", value: serverId),
-            URLQueryItem(name: "itemId", value: itemId),
-          ]
-          finalUrl = deepLinkComponents.url
+        if itemId == nil {
+          itemId =
+            validLinkValue(queryItems.first { $0.name == "id" }?.value)
+            ?? validLinkValue(queryItems.first { $0.name == "parentId" }?.value)
         }
+        if serverId == nil {
+          serverId = validLinkValue(queryItems.first { $0.name == "serverId" }?.value)
+        }
+      }
+
+      if let itemId {
+        var queryItems = [URLQueryItem]()
+        if let serverId {
+          queryItems.append(URLQueryItem(name: "serverId", value: serverId))
+        }
+        queryItems.append(URLQueryItem(name: "itemId", value: itemId))
+
+        var deepLinkComponents = URLComponents()
+        deepLinkComponents.scheme = "emby"
+        deepLinkComponents.host = "items"
+        deepLinkComponents.queryItems = queryItems
+        finalUrl = deepLinkComponents.url
       }
 
     case .plex:
@@ -276,7 +298,9 @@ class HomeViewModel: ObservableObject {
         let components = URLComponents(string: "https://dummy.com" + fragment)
       {
         let pathParts = components.path.split(separator: "/")
-        if pathParts.count >= 2, pathParts[0] == "media", let rawId = item.raw_id?.value {
+        if pathParts.count >= 2, pathParts[0] == "media",
+          let rawId = validLinkValue(item.raw_id?.value)
+        {
           let serverId = String(pathParts[1])
           let metadataKey = "/library/metadata/\(rawId)"
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/CHANTXU64/MoviePilot-TV/releases"><img src="https://img.shields.io/badge/Release-v0.3.1-blue?style=flat-square" alt="release"></a>
-  <a href="https://github.com/jxxghp/MoviePilot"><img src="https://img.shields.io/badge/MoviePilot-v2.13.2-darkviolet?style=flat-square" alt="MoviePilot Backend Version"></a>
+  <a href="https://github.com/jxxghp/MoviePilot"><img src="https://img.shields.io/badge/MoviePilot-v2.13.5--1-darkviolet?style=flat-square" alt="MoviePilot Backend Version"></a>
   <img src="https://img.shields.io/badge/platform-tvOS_17%2B-lightgrey.svg" alt="Platform">
   <img src="https://img.shields.io/badge/language-Swift-orange.svg?style=flat-square" alt="Language">
   <img src="https://img.shields.io/badge/UI-SwiftUI-blue.svg?style=flat-square" alt="UI Framework">
@@ -43,7 +43,7 @@
 ## ⚠️ 兼容性与已知问题
 
 - **tvOS 版本**: 支持 **tvOS 17.0+**。本项目主要在 **tvOS 26.0+** 环境下开发，UI 效果在该版本上表现最佳。
-- **后端版本**: 当前测试兼容的 MoviePilot 版本限定为：`v2.13.2`。由于 API 可能发生破坏性变更，其他版本后端可能出现功能异常或闪退。
+- **后端版本**: 当前测试兼容的 MoviePilot 版本限定为：`v2.13.5-1`。由于 API 可能发生破坏性变更，其他版本后端可能出现功能异常或闪退。
 - **账号登录**: **不支持**已开启双因素认证 (MFA/2FA) 的账号，请在关闭双因素认证后再登录。
 - **应用更新**: 本应用不对旧版 API 或已知 Bug 进行向下兼容修复。更新频率可能低于 MoviePilot 原版。
 - **兼容原则**: TV 端以 MoviePilot Web 前端和 MoviePilot 后端当前行为为准；如果 Web 本来也不显示或后端/第三方数据源同样异常，本项目不会在 TV 端额外兜底修复。


### PR DESCRIPTION
## Summary
- Align TV image URL generation with MoviePilot Web getDisplayImageUrl behavior for Bangumi, cache, and Douban proxy handling
- Decode backend media server item_id/server_id and use them for Emby deep links without changing Plex fallback behavior
- Update README compatible backend version to v2.13.5-1

## Notes
- This PR keeps Douban default image filtering as-is and does not add TV-side fallbacks for images or upstream data that MP Web also does not display.
- Test-only changes remain in PR #11 and are not included here.

## Validation
- xcodebuild -resolvePackageDependencies -project MoviePilot-TV.xcodeproj -scheme MoviePilot-TV -skipPackagePluginValidation
- xcodebuild clean build -project MoviePilot-TV.xcodeproj -scheme MoviePilot-TV -configuration Debug -destination "platform=tvOS Simulator,name=Apple TV" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipPackagePluginValidation
- xcodebuild test -project MoviePilot-TV.xcodeproj -scheme MoviePilot-TV -configuration Debug -destination "platform=tvOS Simulator,name=Apple TV" -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipPackagePluginValidation -only-testing:MoviePilot-TV-Tests/ImageProxyEncodingTests
- xcodebuild test -project MoviePilot-TV.xcodeproj -scheme MoviePilot-TV -configuration Debug -destination "platform=tvOS Simulator,name=Apple TV" -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipPackagePluginValidation -only-testing:MoviePilot-TV-Tests/BackendCompatibilityReadOnlyTests
- xcodebuild test -project MoviePilot-TV.xcodeproj -scheme MoviePilot-TV -configuration Debug -destination "platform=tvOS Simulator,name=Apple TV" -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipPackagePluginValidation

Results: full XCTest passed: 43 tests, 2 skipped, 0 failures.