### PR TITLE
[AI] fix/emby: allow deeplink from structured media ids

### DIFF
--- a/MoviePilot-TV-Tests/HomeViewModelMediaServerLinkTests.swift
+++ b/MoviePilot-TV-Tests/HomeViewModelMediaServerLinkTests.swift
@@ -49,6 +49,20 @@ final class HomeViewModelMediaServerLinkTests: XCTestCase {
     XCTAssertEqual(queryItems["itemId"], "emby-item-2")
   }
 
+  func testPlexDoesNotOpenFallbackWhenLinkIsInvalid() throws {
+    let item = try decodePlayItem(
+      """
+      {
+        "id": "plex-raw-1",
+        "title": "Plex Item",
+        "link": "none",
+        "server_type": "plex"
+      }
+      """)
+
+    XCTAssertNil(openMediaItem(item))
+  }
+
   private func openMediaItem(_ item: MediaServerPlayItem) -> URL? {
     var openedURL: URL?
     let action = OpenURLAction { url in

--- a/MoviePilot-TV-Tests/HomeViewModelMediaServerLinkTests.swift
+++ b/MoviePilot-TV-Tests/HomeViewModelMediaServerLinkTests.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import XCTest
+
+@testable import MoviePilot_TV
+
+@MainActor
+final class HomeViewModelMediaServerLinkTests: XCTestCase {
+  func testEmbyDeepLinkUsesStructuredIdsWhenLinkIsInvalid() throws {
+    let item = try decodePlayItem(
+      """
+      {
+        "id": "legacy-id",
+        "item_id": "emby-item-1",
+        "server_id": "emby-server-1",
+        "title": "Emby Item",
+        "link": "none",
+        "server_type": "emby"
+      }
+      """)
+
+    let openedURL = openMediaItem(item)
+    let components = try XCTUnwrap(URLComponents(url: try XCTUnwrap(openedURL), resolvingAgainstBaseURL: false))
+    let queryItems = queryItemMap(from: components)
+
+    XCTAssertEqual(components.scheme, "emby")
+    XCTAssertEqual(components.host, "items")
+    XCTAssertEqual(queryItems["serverId"], "emby-server-1")
+    XCTAssertEqual(queryItems["itemId"], "emby-item-1")
+  }
+
+  func testEmbyDeepLinkFallsBackToLinkFragmentWhenStructuredIdsAreMissing() throws {
+    let item = try decodePlayItem(
+      """
+      {
+        "id": "legacy-id",
+        "title": "Emby Item",
+        "link": "https://emby.local/web/index.html#!/item?id=emby-item-2&context=home&serverId=emby-server-2",
+        "server_type": "emby"
+      }
+      """)
+
+    let openedURL = openMediaItem(item)
+    let components = try XCTUnwrap(URLComponents(url: try XCTUnwrap(openedURL), resolvingAgainstBaseURL: false))
+    let queryItems = queryItemMap(from: components)
+
+    XCTAssertEqual(components.scheme, "emby")
+    XCTAssertEqual(components.host, "items")
+    XCTAssertEqual(queryItems["serverId"], "emby-server-2")
+    XCTAssertEqual(queryItems["itemId"], "emby-item-2")
+  }
+
+  private func openMediaItem(_ item: MediaServerPlayItem) -> URL? {
+    var openedURL: URL?
+    let action = OpenURLAction { url in
+      openedURL = url
+      return .handled
+    }
+    HomeViewModel(apiService: APIService.shared).openMediaItem(item, using: action)
+    return openedURL
+  }
+
+  private func decodePlayItem(_ json: String) throws -> MediaServerPlayItem {
+    let data = try XCTUnwrap(json.data(using: .utf8))
+    return try JSONDecoder().decode(MediaServerPlayItem.self, from: data)
+  }
+
+  private func queryItemMap(from components: URLComponents) -> [String: String] {
+    Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+  }
+}

--- a/MoviePilot-TV/ViewModels/HomeViewModel.swift
+++ b/MoviePilot-TV/ViewModels/HomeViewModel.swift
@@ -246,19 +246,19 @@ class HomeViewModel: ObservableObject {
   }
 
   func openMediaItem(_ item: MediaServerPlayItem, using openURL: OpenURLAction) {
-    guard let link = validLinkValue(item.link), let originalUrl = URL(string: link) else { return }
+    let originalUrl = validLinkValue(item.link).flatMap { URL(string: $0) }
 
     var finalUrl: URL? = nil
 
     // 统一处理 Fragment 解析：有些后端返回 #!/item... 有些返回 #/item...
     let cleanFragment: String? = {
-      guard let fragment = originalUrl.fragment else { return nil }
+      guard let fragment = originalUrl?.fragment else { return nil }
       return fragment.starts(with: "!") ? String(fragment.dropFirst(1)) : fragment
     }()
 
     switch item.server_type {
     case .emby:
-      // 如果是 Emby 服务器，则尝试构建深度链接，目前 Emby 2.0.3(2) 还不支持跳转到媒体
+      // Emby for Apple TV 2.0.6+ 开始支持跳转到媒体项目。
       // 后端链接格式: https://your-emby-server/web/index.html#!/item?id=xxxx&serverId=...
       // emby://items?serverId={your_server_id}&itemId={your_item_id}
       var itemId = validLinkValue(item.item_id?.value)
@@ -336,7 +336,8 @@ class HomeViewModel: ObservableObject {
         print(accepted ? "成功打开深度链接: \(finalUrl)" : "无法打开深度链接: \(finalUrl)")
       }
     } else if let serverType = item.server_type {
-      print("未能生成 \(serverType.rawValue) 的有效深度链接: \(originalUrl)")
+      let source = originalUrl?.absoluteString ?? item.link ?? "<无链接>"
+      print("未能生成 \(serverType.rawValue) 的有效深度链接: \(source)")
     }
   }
 }

--- a/MoviePilot-TV/ViewModels/HomeViewModel.swift
+++ b/MoviePilot-TV/ViewModels/HomeViewModel.swift
@@ -247,6 +247,7 @@ class HomeViewModel: ObservableObject {
 
   func openMediaItem(_ item: MediaServerPlayItem, using openURL: OpenURLAction) {
     let originalUrl = validLinkValue(item.link).flatMap { URL(string: $0) }
+    guard originalUrl != nil || item.server_type == .emby else { return }
 
     var finalUrl: URL? = nil
 


### PR DESCRIPTION
## 变更

- 允许 Emby 跳转在 `link` 为 `none`、空值或无效值时继续使用后端下发的 `item_id` / `server_id`。
- 保留旧逻辑：当结构化字段缺失时，继续从 `link` fragment 里解析 `item_id` / `server_id`。
- 限制无有效 `link` 的放行范围只适用于 Emby，避免 Plex 在 `link = none` 时误触发 `plex://` 降级打开 App。
- 增加 HomeViewModel 媒体服务器跳转测试，覆盖 Emby 结构化字段、旧 fragment 回退，以及 Plex 无效 link 不打开三条路径。

## 背景

PR #12 已合并，它引入了新版 MoviePilot 后端的结构化 `item_id` / `server_id` 字段。新版后端可能把 `link` 返回为 `none`，旧入口会在解析 link 前提前退出，导致 Emby 外跳无法使用这些新字段。

Emby 官方社区的 tvOS deep link 讨论里，用户反馈 `emby://items?serverId=...&itemId=...` 过去在 tvOS 只能打开 App 不能进入具体媒体；Emby 团队在 2026-04-08 回复建议在 Emby for Apple TV 2.0.6+ 再试。因此这里把 Emby 的结构化字段直跳补上，同时保留旧版本/旧数据的回退路径。

来源：https://emby.media/community/topic/146297-ios-deeplink-universal-link-support-for-opening-a-movie-via-link-on-tvos/

## 验证

- `xcodebuild test -project "MoviePilot-TV.xcodeproj" -scheme "MoviePilot-TV" -configuration Debug -destination "platform=tvOS Simulator,name=Apple TV,OS=26.5" -only-testing:MoviePilot-TV-Tests/HomeViewModelMediaServerLinkTests -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipPackagePluginValidation`：通过，3 个测试。
- `xcodebuild -resolvePackageDependencies -project "MoviePilot-TV.xcodeproj" -scheme "MoviePilot-TV" -skipPackagePluginValidation`：通过。
- `xcodebuild clean build -project "MoviePilot-TV.xcodeproj" -scheme "MoviePilot-TV" -configuration Debug -destination "platform=tvOS Simulator,name=Apple TV,OS=26.5" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipPackagePluginValidation`：通过。
- `xcodebuild test -project "MoviePilot-TV.xcodeproj" -scheme "MoviePilot-TV" -configuration Debug -destination "platform=tvOS Simulator,name=Apple TV,OS=26.5" -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipPackagePluginValidation`：通过，46 个测试，1 个 skipped，0 failures。
