### PR TITLE
[AI] Add subscription auto-search setting

### DIFF
--- a/MoviePilot-TV-Tests/SubscribeSheetViewModelTests.swift
+++ b/MoviePilot-TV-Tests/SubscribeSheetViewModelTests.swift
@@ -81,6 +81,38 @@ final class SubscribeSheetViewModelTests: XCTestCase {
     XCTAssertEqual(searchRequestCount, 1)
   }
 
+  func testSaveExistingSubscriptionSearchesWhenNewSubscriptionAutoSearchIsDisabled() async throws {
+    XCTAssertTrue(URLProtocol.registerClass(SubscribeSheetURLProtocol.self))
+    defer { URLProtocol.unregisterClass(SubscribeSheetURLProtocol.self) }
+
+    let service = APIService.shared
+    let snapshot = SubscribeSheetServiceSnapshot.capture(service: service)
+    let originalValue = UserDefaults.standard.object(forKey: autoSearchKey)
+    defer {
+      snapshot.restore(to: service)
+      restoreUserDefaultsValue(originalValue, forKey: autoSearchKey)
+    }
+
+    await SubscribeSheetURLProtocol.stub.reset()
+    service.baseURL = "http://subscribe-sheet-tests.local"
+    UserDefaults.standard.set(false, forKey: autoSearchKey)
+
+    let viewModel = SubscribeSheetViewModel(
+      subscribe: Subscribe(id: 779, name: "已有订阅", type: "电影", tmdbid: 123458),
+      isNewSubscription: false
+    )
+
+    let didSave = await viewModel.save()
+
+    XCTAssertTrue(didSave)
+    let statusRequestCount = await SubscribeSheetURLProtocol.stub.requestCount(
+      method: "PUT", path: "/api/v1/subscribe/status/779")
+    let searchRequestCount = await SubscribeSheetURLProtocol.stub.requestCount(
+      method: "GET", path: "/api/v1/subscribe/search/779")
+    XCTAssertEqual(statusRequestCount, 0)
+    XCTAssertEqual(searchRequestCount, 1)
+  }
+
   private func restoreUserDefaultsValue(_ value: Any?, forKey key: String) {
     if let value {
       UserDefaults.standard.set(value, forKey: key)

--- a/MoviePilot-TV-Tests/SubscribeSheetViewModelTests.swift
+++ b/MoviePilot-TV-Tests/SubscribeSheetViewModelTests.swift
@@ -1,0 +1,217 @@
+import XCTest
+
+@testable import MoviePilot_TV
+
+@MainActor
+final class SubscribeSheetViewModelTests: XCTestCase {
+  private let autoSearchKey = "autoSearchNewSubscriptions"
+
+  func testAutoSearchNewSubscriptionsDefaultsToEnabled() {
+    let originalValue = UserDefaults.standard.object(forKey: autoSearchKey)
+    UserDefaults.standard.removeObject(forKey: autoSearchKey)
+    defer { restoreUserDefaultsValue(originalValue, forKey: autoSearchKey) }
+
+    let viewModel = SystemViewModel()
+
+    XCTAssertTrue(viewModel.autoSearchNewSubscriptions)
+    XCTAssertTrue(SystemViewModel.shouldAutoSearchNewSubscriptions)
+  }
+
+  func testSaveNewSubscriptionSkipsSearchWhenAutoSearchSettingIsDisabled() async throws {
+    XCTAssertTrue(URLProtocol.registerClass(SubscribeSheetURLProtocol.self))
+    defer { URLProtocol.unregisterClass(SubscribeSheetURLProtocol.self) }
+
+    let service = APIService.shared
+    let snapshot = SubscribeSheetServiceSnapshot.capture(service: service)
+    let originalValue = UserDefaults.standard.object(forKey: autoSearchKey)
+    defer {
+      snapshot.restore(to: service)
+      restoreUserDefaultsValue(originalValue, forKey: autoSearchKey)
+    }
+
+    await SubscribeSheetURLProtocol.stub.reset()
+    service.baseURL = "http://subscribe-sheet-tests.local"
+    UserDefaults.standard.set(false, forKey: autoSearchKey)
+
+    let viewModel = SubscribeSheetViewModel(
+      subscribe: Subscribe(id: 777, name: "关闭自动搜索", type: "电影", tmdbid: 123456),
+      isNewSubscription: true
+    )
+
+    let didSave = await viewModel.save()
+
+    XCTAssertTrue(didSave)
+    let statusRequestCount = await SubscribeSheetURLProtocol.stub.requestCount(
+      method: "PUT", path: "/api/v1/subscribe/status/777")
+    let searchRequestCount = await SubscribeSheetURLProtocol.stub.requestCount(
+      method: "GET", path: "/api/v1/subscribe/search/777")
+    XCTAssertEqual(statusRequestCount, 1)
+    XCTAssertEqual(searchRequestCount, 0)
+  }
+
+  func testSaveNewSubscriptionSearchesByDefault() async throws {
+    XCTAssertTrue(URLProtocol.registerClass(SubscribeSheetURLProtocol.self))
+    defer { URLProtocol.unregisterClass(SubscribeSheetURLProtocol.self) }
+
+    let service = APIService.shared
+    let snapshot = SubscribeSheetServiceSnapshot.capture(service: service)
+    let originalValue = UserDefaults.standard.object(forKey: autoSearchKey)
+    defer {
+      snapshot.restore(to: service)
+      restoreUserDefaultsValue(originalValue, forKey: autoSearchKey)
+    }
+
+    await SubscribeSheetURLProtocol.stub.reset()
+    service.baseURL = "http://subscribe-sheet-tests.local"
+    UserDefaults.standard.removeObject(forKey: autoSearchKey)
+
+    let viewModel = SubscribeSheetViewModel(
+      subscribe: Subscribe(id: 778, name: "默认自动搜索", type: "电影", tmdbid: 123457),
+      isNewSubscription: true
+    )
+
+    let didSave = await viewModel.save()
+
+    XCTAssertTrue(didSave)
+    let statusRequestCount = await SubscribeSheetURLProtocol.stub.requestCount(
+      method: "PUT", path: "/api/v1/subscribe/status/778")
+    let searchRequestCount = await SubscribeSheetURLProtocol.stub.requestCount(
+      method: "GET", path: "/api/v1/subscribe/search/778")
+    XCTAssertEqual(statusRequestCount, 1)
+    XCTAssertEqual(searchRequestCount, 1)
+  }
+
+  private func restoreUserDefaultsValue(_ value: Any?, forKey key: String) {
+    if let value {
+      UserDefaults.standard.set(value, forKey: key)
+    } else {
+      UserDefaults.standard.removeObject(forKey: key)
+    }
+  }
+}
+
+private struct SubscribeSheetServiceSnapshot {
+  let baseURL: String
+  let serverURLDefaults: String?
+
+  @MainActor
+  static func capture(service: APIService) -> SubscribeSheetServiceSnapshot {
+    SubscribeSheetServiceSnapshot(
+      baseURL: service.baseURL,
+      serverURLDefaults: UserDefaults.standard.string(forKey: "serverURL")
+    )
+  }
+
+  @MainActor
+  func restore(to service: APIService) {
+    service.baseURL = baseURL
+
+    if let serverURLDefaults {
+      UserDefaults.standard.set(serverURLDefaults, forKey: "serverURL")
+    } else {
+      UserDefaults.standard.removeObject(forKey: "serverURL")
+    }
+  }
+}
+
+private actor SubscribeSheetURLProtocolStub {
+  private var requestCounts: [String: Int] = [:]
+
+  func reset() {
+    requestCounts.removeAll()
+  }
+
+  func requestCount(method: String, path: String) -> Int {
+    requestCounts["\(method) \(path)", default: 0]
+  }
+
+  func response(for request: URLRequest) throws -> (HTTPURLResponse, Data) {
+    let method = request.httpMethod ?? "GET"
+    let path = request.url?.path ?? ""
+    requestCounts["\(method) \(path)", default: 0] += 1
+
+    guard path.hasPrefix("/api/v1/subscribe") else {
+      throw URLError(.badServerResponse)
+    }
+
+    let data = #"{"success":true}"#.data(using: .utf8)!
+    let response = HTTPURLResponse(
+      url: request.url!,
+      statusCode: 200,
+      httpVersion: nil,
+      headerFields: ["Content-Type": "application/json"]
+    )!
+    return (response, data)
+  }
+}
+
+private final class SubscribeSheetURLProtocol: URLProtocol {
+  static let stub = SubscribeSheetURLProtocolStub()
+  private var loadingTask: Task<Void, Never>?
+
+  override class func canInit(with request: URLRequest) -> Bool {
+    request.url?.host == "subscribe-sheet-tests.local"
+  }
+
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    request
+  }
+
+  override func startLoading() {
+    let context = SubscribeSheetURLProtocolTaskContext(
+      request: request,
+      clientBox: SubscribeSheetURLProtocolClientBox(protocolInstance: self, client: client)
+    )
+    loadingTask = SubscribeSheetURLProtocol.makeLoadingTask(for: context)
+  }
+
+  private static func makeLoadingTask(for context: SubscribeSheetURLProtocolTaskContext)
+    -> Task<Void, Never>
+  {
+    Task {
+      do {
+        let (response, data) = try await Self.stub.response(for: context.request)
+        guard !Task.isCancelled else { return }
+        context.clientBox.succeed(response: response, data: data)
+      } catch {
+        guard !Task.isCancelled else { return }
+        context.clientBox.fail(error)
+      }
+    }
+  }
+
+  override func stopLoading() {
+    loadingTask?.cancel()
+    loadingTask = nil
+  }
+}
+
+private final class SubscribeSheetURLProtocolTaskContext: @unchecked Sendable {
+  let request: URLRequest
+  let clientBox: SubscribeSheetURLProtocolClientBox
+
+  init(request: URLRequest, clientBox: SubscribeSheetURLProtocolClientBox) {
+    self.request = request
+    self.clientBox = clientBox
+  }
+}
+
+private final class SubscribeSheetURLProtocolClientBox: @unchecked Sendable {
+  private let protocolInstance: URLProtocol
+  private let client: URLProtocolClient?
+
+  init(protocolInstance: URLProtocol, client: URLProtocolClient?) {
+    self.protocolInstance = protocolInstance
+    self.client = client
+  }
+
+  func succeed(response: HTTPURLResponse, data: Data) {
+    client?.urlProtocol(protocolInstance, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(protocolInstance, didLoad: data)
+    client?.urlProtocolDidFinishLoading(protocolInstance)
+  }
+
+  func fail(_ error: Error) {
+    client?.urlProtocol(protocolInstance, didFailWithError: error)
+  }
+}

--- a/MoviePilot-TV/ViewModels/SubscribeSheetViewModel.swift
+++ b/MoviePilot-TV/ViewModels/SubscribeSheetViewModel.swift
@@ -134,8 +134,9 @@ class SubscribeSheetViewModel: ObservableObject {
           if isNewSubscription {
             _ = try await apiService.updateSubscriptionStatus(id: id, state: "R")
           }
-          // 立即触发对该订阅的搜索
-          _ = try await apiService.searchSubscription(id: id)
+          if !isNewSubscription || SystemViewModel.shouldAutoSearchNewSubscriptions {
+            _ = try await apiService.searchSubscription(id: id)
+          }
         }
         self.isSaved = true
         NotificationCenter.default.post(name: .subscriptionDidUpdate, object: nil)

--- a/MoviePilot-TV/ViewModels/SystemViewModel.swift
+++ b/MoviePilot-TV/ViewModels/SystemViewModel.swift
@@ -26,12 +26,22 @@ class SystemViewModel: ObservableObject {
   // MARK: - 详情页设置
 
   private static let waitMediaDetailBackgroundImageKey = "waitMediaDetailBackgroundImage"
+  private static let autoSearchNewSubscriptionsKey = "autoSearchNewSubscriptions"
 
   /// 是否在 MediaDetail 首屏等待背景/海报预加载完成。默认开启。
   var waitMediaDetailBackgroundImage: Bool {
     get { Self.shouldWaitMediaDetailBackgroundImage }
     set {
       UserDefaults.standard.set(newValue, forKey: Self.waitMediaDetailBackgroundImageKey)
+      objectWillChange.send()
+    }
+  }
+
+  /// 新增订阅保存后是否立即触发一次手动搜索。默认开启，保持现有 TV 行为。
+  var autoSearchNewSubscriptions: Bool {
+    get { Self.shouldAutoSearchNewSubscriptions }
+    set {
+      UserDefaults.standard.set(newValue, forKey: Self.autoSearchNewSubscriptionsKey)
       objectWillChange.send()
     }
   }
@@ -305,6 +315,13 @@ class SystemViewModel: ObservableObject {
       return true
     }
     return UserDefaults.standard.bool(forKey: waitMediaDetailBackgroundImageKey)
+  }
+
+  static var shouldAutoSearchNewSubscriptions: Bool {
+    guard UserDefaults.standard.object(forKey: autoSearchNewSubscriptionsKey) != nil else {
+      return true
+    }
+    return UserDefaults.standard.bool(forKey: autoSearchNewSubscriptionsKey)
   }
 
   private func normalizeDefaultSearchSites(_ sites: Set<Int>) -> Set<Int> {

--- a/MoviePilot-TV/Views/Pages/SystemView.swift
+++ b/MoviePilot-TV/Views/Pages/SystemView.swift
@@ -55,6 +55,17 @@ struct SystemView: View {
           .foregroundColor(.primary)
         }
 
+        Section(header: Text("订阅")) {
+          Toggle(
+            isOn: Binding(
+              get: { viewModel.autoSearchNewSubscriptions },
+              set: { viewModel.autoSearchNewSubscriptions = $0 }
+            )
+          ) {
+            Text("新增订阅后立即搜索")
+          }
+        }
+
         Section(header: Text("详情加载页")) {
           Toggle(
             isOn: Binding(


### PR DESCRIPTION
## Summary
- Add a local Settings toggle for whether new subscriptions immediately trigger a manual search.
- Keep the default enabled to preserve the current TV behavior.
- When disabled, new subscriptions are still resumed/enabled after save, but `/subscribe/search/{id}` is skipped.

## Validation
- `git diff --check`
- `xcodebuild test -quiet -project "MoviePilot-TV.xcodeproj" -scheme "MoviePilot-TV" -configuration Debug -destination "platform=tvOS Simulator,name=Apple TV" -only-testing:MoviePilot-TV-Tests/SubscribeSheetViewModelTests -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipPackagePluginValidation`
- Full tvOS XCTest before commit: 148 tests, 1 skipped, 0 failures
