### PR TITLE
[AI] feat/ui-preview: 增加 Debug UI 预览目录

### DIFF
--- a/.github/workflows/release-preview-guard.yml
+++ b/.github/workflows/release-preview-guard.yml
@@ -1,0 +1,64 @@
+name: Release Preview Guard
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-preview-guard:
+    name: Verify Release app excludes preview UI
+    runs-on: macos-26
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve Swift packages
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project "MoviePilot-TV.xcodeproj" \
+            -scheme "MoviePilot-TV" \
+            -skipPackagePluginValidation
+
+      - name: Build Release
+        run: |
+          xcodebuild clean build \
+            -project "MoviePilot-TV.xcodeproj" \
+            -scheme "MoviePilot-TV" \
+            -configuration Release \
+            -destination "generic/platform=tvOS" \
+            -derivedDataPath build/DerivedData \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            -skipPackagePluginValidation
+
+      - name: Scan Release app for preview UI
+        run: |
+          set -euo pipefail
+          APP_PATH="build/DerivedData/Build/Products/Release-appletvos/MoviePilot-TV.app"
+
+          if [ ! -d "$APP_PATH" ]; then
+            echo "App bundle not found: $APP_PATH"
+            find build/DerivedData/Build/Products -maxdepth 3 -type d -name "*.app" -print
+            exit 1
+          fi
+
+          if find "$APP_PATH" -type f -print0 | xargs -0 strings -a | grep -E -- "UIPreview|uiPreview|PreviewCatalog|PreviewSupport|-uiPreviewMode"; then
+            echo "Preview UI symbols found in Release app product"
+            exit 1
+          fi
+
+          echo "No preview UI symbols found in Release app product"

--- a/MoviePilot-TV-Tests/UIPreviewModeTests.swift
+++ b/MoviePilot-TV-Tests/UIPreviewModeTests.swift
@@ -390,6 +390,23 @@ final class UIPreviewModeTests: XCTestCase {
     XCTAssertTrue(persistSource.contains("UserDefaults.standard.set"))
   }
 
+  func testPreviewPermissionsAreInstalledBeforeFirstPreviewFrame() throws {
+    let previewSource = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let initStart = try XCTUnwrap(
+      previewSource.range(of: "init(\n    selectedTab: ContentViewModel.Tab = .home")
+    )
+    let bodyStart = try XCTUnwrap(previewSource.range(of: "\n  var body: some View", range: initStart.upperBound..<previewSource.endIndex))
+    let initSource = String(previewSource[initStart.lowerBound..<bodyStart.lowerBound])
+    let applyRange = try XCTUnwrap(initSource.range(of: "UIPreviewFixtures.applyPermissions("))
+    let firstStateObjectRange = try XCTUnwrap(initSource.range(of: "_homeViewModel = StateObject"))
+
+    XCTAssertLessThan(applyRange.lowerBound, firstStateObjectRange.lowerBound)
+
+    let apiSource = try String(contentsOf: repoFile("MoviePilot-TV/Services/APIService.swift"))
+    XCTAssertTrue(apiSource.contains("return uiPreviewCanRequestSuperUserEndpoints ?? false"))
+    XCTAssertTrue(apiSource.contains("return uiPreviewPermissions?.contains(permission) ?? false"))
+  }
+
   private func repoFile(_ path: String) -> URL {
     URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()

--- a/MoviePilot-TV-Tests/UIPreviewModeTests.swift
+++ b/MoviePilot-TV-Tests/UIPreviewModeTests.swift
@@ -13,12 +13,37 @@ final class UIPreviewModeTests: XCTestCase {
     XCTAssertEqual(UIPreviewMode.launchArgument, "-uiPreviewMode")
   }
 
+  func testPreviewSceneLaunchArgumentSelectsSpecificCatalogScene() {
+    XCTAssertEqual(
+      UIPreviewMode.sceneID(arguments: ["MoviePilot-TV", "-uiPreviewMode", "-uiPreviewScene", "detail-tvWithSeasons"]),
+      "detail-tvWithSeasons"
+    )
+    XCTAssertNil(UIPreviewMode.sceneID(arguments: ["MoviePilot-TV", "-uiPreviewMode"]))
+    XCTAssertNil(UIPreviewMode.sceneID(arguments: ["MoviePilot-TV", "-uiPreviewScene"]))
+  }
+
+  func testInitialPreviewSceneResetsStateBeforeResolvingScene() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let initSource = try sourceSlice(
+      source,
+      from: "init(initialSceneID: String? = nil)",
+      to: "\n\n  var body"
+    )
+
+    XCTAssertTrue(initSource.contains("UIPreviewFixtures.resetPreviewState()"))
+    XCTAssertTrue(initSource.contains("_didResetPreviewState = State(initialValue: true)"))
+
+    let resetRange = try XCTUnwrap(initSource.range(of: "UIPreviewFixtures.resetPreviewState()"))
+    let selectedSceneRange = try XCTUnwrap(initSource.range(of: "_selectedScene = State"))
+    XCTAssertLessThan(resetRange.lowerBound, selectedSceneRange.lowerBound)
+  }
+
   func testContentViewPreviewEntryIsDebugOnly() throws {
     let source = try String(contentsOf: repoFile("MoviePilot-TV/Views/ContentView.swift"))
 
     XCTAssertTrue(source.contains("#if DEBUG"))
     XCTAssertTrue(source.contains("UIPreviewMode.isEnabled()"))
-    XCTAssertTrue(source.contains("PreviewCatalogView()"))
+    XCTAssertTrue(source.contains("PreviewCatalogView(initialSceneID: UIPreviewMode.sceneID())"))
   }
 
   func testPreviewEntryDoesNotInstantiateRealRootStateBeforePreviewBranch() throws {
@@ -63,6 +88,7 @@ final class UIPreviewModeTests: XCTestCase {
       "App 入口 / Tab 页面",
       "详情页",
       "分季页",
+      "页面入口",
       "搜索链路",
       "状态 / 任务",
       "设置",
@@ -76,55 +102,199 @@ final class UIPreviewModeTests: XCTestCase {
 
     let requiredScenes = [
       "启动入口 · 正常已登录",
+      "启动入口 · 启动会话准备中",
+      "启动入口 · 低权限 Tab",
+      "启动入口 · 后端版本告警",
+      "启动入口 · 账号权限告警",
       "启动入口 · 登录页",
+      "启动入口 · 可提交登录",
+      "启动入口 · 登录中",
+      "启动入口 · 登录失败",
       "首页 · 加载中",
       "首页 · 空数据",
       "首页 · 完整数据",
+      "首页 · 最近添加空服务器",
+      "首页 · 仅订阅",
+      "首页 · 无订阅权限",
+      "首页 · 无搜索权限",
+      "首页 · 订阅编辑弹窗",
+      "首页 · 取消订阅确认",
+      "推荐 · 初始化中",
       "推荐 · 加载中",
       "推荐 · 空数据",
       "推荐 · 完整数据",
+      "推荐 · 低权限菜单",
+      "探索 · 初始化中",
+      "探索 · 加载中",
       "探索 · TMDB 筛选",
+      "探索 · 豆瓣筛选",
+      "探索 · Bangumi 筛选",
+      "探索 · 热门订阅",
       "探索 · 订阅分享",
+      "探索 · 订阅分享弹窗",
+      "探索 · 无订阅权限",
+      "探索 · 空结果",
+      "详情页 · 电影，未订阅",
+      "详情页 · 电影，已订阅",
+      "详情页 · 加载中",
+      "详情页 · 详情加载失败",
+      "详情页 · 电视剧，有分季",
+      "详情页 · 有分季且无订阅权限",
+      "详情页 · 电视剧，无分季",
+      "详情页 · 分季加载失败",
+      "详情页 · 无海报 / 无背景图",
+      "详情页 · 第二页内容",
+      "详情页 · 第二页行加载更多",
+      "详情页 · 第二页无操作权限",
+      "详情页 · 分季单剧集组",
+      "详情页 · 多分季 / 多剧集组",
+      "详情页 · TMDB 跳转识别中",
+      "详情页 · 站点选择弹窗",
+      "详情页 · 订阅弹窗",
+      "详情页 · 取消订阅确认",
+      "详情页 · 取消订阅中",
+      "详情页 · 无订阅权限",
+      "详情页 · 无搜索权限",
+      "详情页 · 无分季且无订阅权限",
+      "详情页 · 无分季且无搜索权限",
+      "详情页 · 无搜索且无订阅权限",
+      "分季页 · 加载中",
+      "分季页 · 普通多季",
+      "分季页 · 空数据",
+      "分季页 · 加载失败",
+      "分季页 · 已订阅 / 缺集混合",
+      "分季页 · 无订阅权限",
+      "分季页 · 分季详情弹窗",
+      "分季页 · 新增订阅弹窗",
+      "分季页 · 取消订阅确认",
+      "搜索 · 未搜索",
+      "搜索 · 聚合加载中",
       "搜索 · 聚合结果",
+      "搜索 · 聚合行加载更多",
+      "搜索 · 订阅分享弹窗",
+      "搜索 · 聚合结果无订阅权限",
       "搜索 · 聚合空结果",
+      "搜索 · 站点选择弹窗",
       "搜索 · 资源加载中",
       "搜索 · 资源结果",
       "搜索 · 资源空结果",
       "合集详情 · 加载中",
+      "合集详情 · 空数据",
       "合集详情 · 完整数据",
+      "合集详情 · 加载更多中",
       "人物详情 · 加载中",
+      "人物详情 · 无简介",
+      "人物详情 · 简介弹窗",
       "人物详情 · 完整数据",
+      "人物详情 · 加载更多中",
       "资源结果页 · 加载中",
+      "资源结果页 · 空数据",
       "资源结果页 · 完整数据",
+      "资源结果页 · 筛选弹窗",
       "状态页 · 空权限 / 空数据",
       "状态页 · 完整数据",
       "下载任务 · 空数据",
       "下载任务 · 多状态任务",
+      "下载任务 · 收起",
+      "下载任务 · 删除确认",
       "整理历史 · 加载中",
+      "整理历史 · 加载更多中",
       "整理历史 · 空数据",
       "整理历史 · 多选 / AI 整理中",
       "整理历史 · 详情弹窗",
+      "整理历史 · 单项删除确认",
+      "整理历史 · 批量删除确认",
+      "整理历史 · 批量重整弹窗",
       "设置 · 全权限",
       "设置 · 无订阅权限",
       "设置 · 无搜索权限",
+      "设置 · 无超级用户权限",
+      "设置 · 低权限",
+      "设置 · 连接页",
+      "设置 · 刷新登录凭据中",
+      "设置 · 站点选择页",
+      "设置 · 站点空列表",
+      "设置 · 硬过滤页",
+      "设置 · 硬过滤加载中",
+      "设置 · 硬过滤空列表",
+      "设置 · 软过滤页",
+      "设置 · 软过滤加载中",
+      "设置 · 软过滤空列表",
+      "设置 · 站点加载中",
+      "设置 · 过滤规则加载中",
+      "设置 · 过滤规则空列表",
       "设置 · APP 信息",
       "设置 · 退出登录确认",
+      "订阅弹窗 · 加载中",
       "订阅弹窗 · 新增",
+      "订阅弹窗 · 电影新增",
+      "订阅弹窗 · 高级配置",
+      "订阅弹窗 · 站点选择",
+      "订阅弹窗 · 过滤组选择",
+      "订阅弹窗 · 保存中",
       "订阅分享弹窗 · 复用",
+      "下载弹窗 · 加载中",
       "下载弹窗 · 添加下载",
+      "下载弹窗 · 高级配置",
+      "下载弹窗 · 提交中",
+      "下载弹窗 · 无搜索权限",
+      "下载弹窗 · 错误通知",
+      "整理弹窗 · 加载中",
       "整理弹窗 · 单项重整",
       "整理弹窗 · 批量重整",
+      "整理弹窗 · 豆瓣识别源",
+      "整理弹窗 · 高级配置",
+      "整理弹窗 · 提交中",
+      "整理弹窗 · 错误通知",
       "分季详情弹窗",
       "多选弹窗 · 站点选择",
       "组件 · 媒体卡片",
+      "组件 · 媒体卡片完整菜单",
+      "组件 · 媒体卡片低权限菜单",
       "组件 · 种子卡片",
+      "组件 · 种子卡片无搜索权限",
+      "组件 · 种子卡片下载弹窗",
+      "组件 · 单选弹窗",
+      "组件 · 订阅结果提示",
       "组件 · 选择器 / 输入框",
+      "组件 · TMDB 识别中",
+      "组件 · TMDB 未识别提示",
       "组件 · 通知",
     ]
 
     for scene in requiredScenes {
       XCTAssertTrue(source.contains("title: \"\(scene)\""), "Missing preview scene: \(scene)")
     }
+  }
+
+  func testLoginPreviewsCoverEmptyReadyLoadingAndFailedStates() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let loginSource = try sourceSlice(source, from: "static func loginViewModel", to: "\n  @discardableResult")
+
+    let requiredSnippets = [
+      "case .login:",
+      "viewModel.serverURL = \"\"",
+      "viewModel.username = \"\"",
+      "viewModel.password = \"\"",
+      "let filledServerURL = \"http://moviepilot.local:3000\"",
+      "case .loginReady:",
+      "viewModel.serverURL = filledServerURL",
+      "case .loginLoading:",
+      "viewModel.isLoading = true",
+      "case .loginFailed:",
+      "viewModel.errorMessage = \"登录失败: 用户名或密码错误\"",
+    ]
+
+    for snippet in requiredSnippets {
+      XCTAssertTrue(loginSource.contains(snippet), "Missing login preview fixture state: \(snippet)")
+    }
+
+    let emptyCaseRange = try XCTUnwrap(loginSource.range(of: "case .login:"))
+    let readyCaseRange = try XCTUnwrap(loginSource.range(of: "case .loginReady:"))
+    XCTAssertLessThan(emptyCaseRange.lowerBound, readyCaseRange.lowerBound)
+    XCTAssertNil(
+      loginSource.range(of: "viewModel.serverURL = filledServerURL", range: emptyCaseRange.upperBound..<readyCaseRange.lowerBound)
+    )
   }
 
   func testPreviewCatalogReferencesPrimaryPageSheetAndComponentViews() throws {
@@ -158,12 +328,15 @@ final class UIPreviewModeTests: XCTestCase {
       "MultiSelectionSheet(",
       "SeasonDetailSheet(",
       "MediaGridView(",
+      "MediaContextMenuItems(",
       "TorrentCard(",
       "CategoryPickerView(",
       "ShelfPicker(",
       "SheetPicker(",
       "SheetTextField(",
       "NotificationView(",
+      "MediaActionHandler()",
+      ".mediaActionAlerts()",
     ]
 
     for viewEntry in requiredViewEntries {
@@ -266,10 +439,15 @@ final class UIPreviewModeTests: XCTestCase {
     }
 
     let requiredPreviewRoutes = [
-      "UIPreviewLoggedInRootView(selectedTab: .home, homeMode: previewCase.homeMode)",
-      "UIPreviewLoggedInRootView(selectedTab: .recommend, recommendMode: previewCase.recommendMode)",
-      "UIPreviewLoggedInRootView(selectedTab: .explore, exploreMode: previewCase.exploreMode)",
-      "UIPreviewLoggedInRootView(selectedTab: .search, searchCase: searchCase)",
+      "selectedTab: .home",
+      "homeMode: previewCase.homeMode",
+      "homePreviewDestinations: HomeViewUIPreviewDestinations(homePresentation: previewCase.homePresentation)",
+      "selectedTab: .recommend",
+      "recommendMode: previewCase.recommendMode",
+      "exploreMode: previewCase.exploreMode",
+      "permissions: previewCase.permissions",
+      "selectedTab: .search",
+      "searchCase: searchCase",
       "selectedTab: .status",
       "selectedTab: .system",
     ]
@@ -304,11 +482,398 @@ final class UIPreviewModeTests: XCTestCase {
 
     XCTAssertTrue(searchSource.contains("SearchViewUIPreviewDestinations"))
     XCTAssertTrue(searchSource.contains("CollectionDetailView("))
-    XCTAssertTrue(searchSource.contains("PersonDetailView(previewViewModel: previewViewModel"))
+    XCTAssertTrue(searchSource.contains("PersonDetailView("))
+    XCTAssertTrue(searchSource.contains("previewViewModel: previewViewModel"))
     XCTAssertTrue(searchSource.contains("ResourceResultView("))
-    XCTAssertTrue(searchSource.contains("SubscribeSeasonView(previewViewModel: previewViewModel)"))
+    XCTAssertTrue(searchSource.contains("SubscribeSeasonView("))
+    XCTAssertTrue(searchSource.contains("uiPreviewPresentation: uiPreviewDestinations?.seasonPresentation"))
     XCTAssertFalse(source.contains("NavigationStack {\n      SubscribeSeasonView(previewViewModel: viewModel)"))
     XCTAssertFalse(source.contains("ResourceResultView(\n      title: mode"))
+  }
+
+  func testSettingsPreviewCoversPermissionLoadingAndEmptyCombinations() throws {
+    let catalogSource = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let systemSource = try String(contentsOf: repoFile("MoviePilot-TV/Views/Pages/SystemView.swift"))
+
+    let requiredSettingsIDs = [
+      "settings-noSuperUser",
+      "settings-siteEmpty",
+      "settings-hardFilterLoading",
+      "settings-hardFilterEmpty",
+      "settings-softFilterLoading",
+      "settings-softFilterEmpty",
+      "settings-rulesLoading",
+      "settings-rulesEmpty",
+    ]
+
+    for id in requiredSettingsIDs {
+      XCTAssertTrue(catalogSource.contains("id: \"\(id)\""), "Missing settings preview id: \(id)")
+    }
+
+    XCTAssertTrue(catalogSource.contains("case .noSuperUser:"))
+    XCTAssertTrue(catalogSource.contains("case .siteEmpty:"))
+    XCTAssertTrue(catalogSource.contains(".hardFilterLoading"))
+    XCTAssertTrue(catalogSource.contains(".hardFilterEmpty"))
+    XCTAssertTrue(catalogSource.contains(".softFilterLoading"))
+    XCTAssertTrue(catalogSource.contains(".softFilterEmpty"))
+    XCTAssertTrue(catalogSource.contains("var hasEmptySites: Bool"))
+    XCTAssertTrue(catalogSource.contains("var hasEmptyFilterRules: Bool"))
+    XCTAssertTrue(catalogSource.contains("var isLoadingFilterRules: Bool"))
+    XCTAssertTrue(systemSource.contains("if viewModel.isLoadingRules {"))
+    XCTAssertTrue(systemSource.contains("row(\"规则状态\", value: \"正在加载\")"))
+    XCTAssertTrue(systemSource.contains("row(\"规则状态\", value: \"暂无自定义过滤规则\")"))
+  }
+
+  func testDownloadTaskPreviewCoversEveryTaskStateBadge() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+
+    let requiredStates = [
+      "downloading",
+      "paused",
+      "error",
+      "checking",
+      "stalledDL",
+      "uploading",
+      "missingFiles",
+      "queuedDL",
+    ]
+
+    for state in requiredStates {
+      XCTAssertTrue(source.contains("state: \"\(state)\""), "Missing download preview state: \(state)")
+    }
+  }
+
+  func testTransferHistoryPreviewCoversLoadingMoreBranch() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+
+    let requiredSnippets = [
+      "case transferLoadingMore",
+      "id: \"status-transferLoadingMore\"",
+      "title: \"整理历史 · 加载更多中\"",
+      "case .transferLoadingMore: return .loadingMore",
+      "case .loadingMore:",
+      "isLoadingMore: true",
+    ]
+
+    for snippet in requiredSnippets {
+      XCTAssertTrue(source.contains(snippet), "Missing transfer-history loading-more preview coverage: \(snippet)")
+    }
+  }
+
+  func testTransferHistoryBatchReorganizePreviewDoesNotStayLoading() throws {
+    let transferSource = try String(contentsOf: repoFile("MoviePilot-TV/Views/Pages/TransferHistoryView.swift"))
+    let reorganizeViewModelSource = try String(contentsOf: repoFile("MoviePilot-TV/ViewModels/ReorganizeViewModel.swift"))
+
+    XCTAssertTrue(transferSource.contains("case .batchReorganize:"))
+    XCTAssertTrue(transferSource.contains("showBatchRedoSheet = true"))
+    XCTAssertTrue(transferSource.contains("ReorganizeSheet(logIds: Array(viewModel.selectedIds), fileItem: nil)"))
+    XCTAssertTrue(reorganizeViewModelSource.contains("if UIPreviewMode.isEnabled() {"))
+    XCTAssertTrue(reorganizeViewModelSource.contains("isLoading = false"))
+  }
+
+  func testDeepMediaGridPreviewsCoverLoadingMoreBranches() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+
+    let requiredSnippets = [
+      "case collectionLoadingMore",
+      "id: \"page-collectionLoadingMore\"",
+      "title: \"合集详情 · 加载更多中\"",
+      "case .collectionLoadingMore: return .loadingMore",
+      "case .loadingMore:",
+      "return CollectionDetailViewModel(previewPaginator: .uiPreview(items: previewMediaGrid, isLoadingMore: true))",
+      "case personLoadingMore",
+      "id: \"page-personLoadingMore\"",
+      "title: \"人物详情 · 加载更多中\"",
+      "case .personLoadingMore: return .loadingMore",
+      "previewPaginator: .uiPreview(items: previewMediaGrid, isLoadingMore: true)",
+    ]
+
+    for snippet in requiredSnippets {
+      XCTAssertTrue(source.contains(snippet), "Missing deep media-grid loading-more preview coverage: \(snippet)")
+    }
+  }
+
+  func testExplorePreviewCoversForkSubscribeSheetBranch() throws {
+    let catalogSource = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let exploreSource = try String(contentsOf: repoFile("MoviePilot-TV/Views/Pages/ExploreView.swift"))
+
+    let requiredCatalogSnippets = [
+      "case exploreShareSheet",
+      "id: \"page-exploreShareSheet\"",
+      "title: \"探索 · 订阅分享弹窗\"",
+      "case .exploreShareSheet: return \"探索 · 订阅分享弹窗\"",
+      "case .exploreShareSheet: return \"探索页订阅分享卡片点击后，通过真实 ExploreView sheet 展示 ForkSubscribeSheet。\"",
+      "explorePreviewForkShare: previewCase.explorePreviewForkShare",
+      "case .exploreShareSheet: return .share",
+      "case .exploreShareSheet:",
+      "return UIPreviewFixtures.previewSubscribeShare",
+    ]
+
+    for snippet in requiredCatalogSnippets {
+      XCTAssertTrue(catalogSource.contains(snippet), "Missing explore fork-sheet preview coverage: \(snippet)")
+    }
+
+    XCTAssertTrue(exploreSource.contains("uiPreviewForkShare: SubscribeShare? = nil"))
+    XCTAssertTrue(exploreSource.contains("private let uiPreviewForkShare: SubscribeShare?"))
+    XCTAssertTrue(exploreSource.contains("guard let uiPreviewForkShare else { return }"))
+    XCTAssertTrue(exploreSource.contains("subscriptionHandler.forkSheetRequest = uiPreviewForkShare"))
+  }
+
+  func testUnifiedSearchPreviewCoversRowLoadingMoreBranches() throws {
+    let catalogSource = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let searchViewModelSource = try String(contentsOf: repoFile("MoviePilot-TV/ViewModels/SearchViewModel.swift"))
+    let searchViewSource = try String(contentsOf: repoFile("MoviePilot-TV/Views/Pages/SearchView.swift"))
+
+    let requiredCatalogSnippets = [
+      "case unifiedLoadingMore",
+      "id: \"search-unifiedLoadingMore\"",
+      "title: \"搜索 · 聚合行加载更多\"",
+      "case .unifiedLoadingMore: return \"搜索 · 聚合行加载更多\"",
+      "case .unifiedLoadingMore: return \"聚合搜索已有结果时，各横向结果行底部显示加载更多进度。\"",
+      "isLoadingMore: true",
+    ]
+
+    for snippet in requiredCatalogSnippets {
+      XCTAssertTrue(catalogSource.contains(snippet), "Missing unified-search loading-more preview coverage: \(snippet)")
+    }
+
+    XCTAssertTrue(searchViewModelSource.contains("isLoadingMore: Bool = false"))
+    XCTAssertTrue(searchViewModelSource.contains("moviePaginator = .uiPreview(items: movies, isLoadingMore: isLoadingMore)"))
+    XCTAssertTrue(searchViewModelSource.contains("tvPaginator = .uiPreview(items: tvShows, isLoadingMore: isLoadingMore)"))
+    XCTAssertTrue(searchViewModelSource.contains("collectionPaginator = .uiPreview(items: collections, isLoadingMore: isLoadingMore)"))
+    XCTAssertTrue(searchViewModelSource.contains("personPaginator = .uiPreview(items: persons, isLoadingMore: isLoadingMore)"))
+    XCTAssertTrue(searchViewModelSource.contains("subscriptionSharePaginator = .uiPreview(items: shares, isLoadingMore: isLoadingMore)"))
+
+    XCTAssertTrue(searchViewSource.contains("isLoadingMore: paginator?.isLoadingMore ?? false"))
+    XCTAssertTrue(searchViewSource.contains("isLoadingMore: viewModel.personPaginator?.isLoadingMore ?? false"))
+  }
+
+  func testUnifiedSearchPreviewCoversForkSubscribeSheetBranch() throws {
+    let catalogSource = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let searchViewSource = try String(contentsOf: repoFile("MoviePilot-TV/Views/Pages/SearchView.swift"))
+
+    let requiredCatalogSnippets = [
+      "case unifiedShareSheet",
+      "id: \"search-unifiedShareSheet\"",
+      "title: \"搜索 · 订阅分享弹窗\"",
+      "case .unifiedShareSheet: return \"搜索 · 订阅分享弹窗\"",
+      "case .unifiedShareSheet: return \"聚合搜索订阅分享点击后，通过真实 SearchView sheet 展示 ForkSubscribeSheet。\"",
+      "searchPreviewDestinations: SearchViewUIPreviewDestinations(forkShare: searchCase.searchPreviewForkShare)",
+      "case .unifiedShareSheet:",
+      "return UIPreviewFixtures.previewSubscribeShare",
+    ]
+
+    for snippet in requiredCatalogSnippets {
+      XCTAssertTrue(catalogSource.contains(snippet), "Missing unified-search fork-sheet preview coverage: \(snippet)")
+    }
+
+    XCTAssertTrue(searchViewSource.contains("var forkShare: SubscribeShare? = nil"))
+    XCTAssertTrue(searchViewSource.contains("guard let forkShare = uiPreviewDestinations?.forkShare else { return }"))
+    XCTAssertTrue(searchViewSource.contains("subscriptionHandler.forkSheetRequest = forkShare"))
+  }
+
+  func testSheetPreviewsCoverMovieSubscriptionAndDoubanRecognitionBranches() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let subscribeSource = try String(contentsOf: repoFile("MoviePilot-TV/Views/Sheets/SubscribeSheet.swift"))
+    let reorganizeSource = try String(contentsOf: repoFile("MoviePilot-TV/Views/Sheets/ReorganizeSheet.swift"))
+
+    let requiredCatalogSnippets = [
+      "case subscribeMovie",
+      "id: \"sheet-subscribeMovie\"",
+      "title: \"订阅弹窗 · 电影新增\"",
+      "UIPreviewFixtures.subscribeSheetViewModel(type: \"电影\")",
+      "case reorganizeDouban",
+      "id: \"sheet-reorganizeDouban\"",
+      "title: \"整理弹窗 · 豆瓣识别源\"",
+      "case .reorganizeDouban:",
+      "return .doubanRecognition",
+    ]
+
+    for snippet in requiredCatalogSnippets {
+      XCTAssertTrue(source.contains(snippet), "Missing sheet branch preview coverage: \(snippet)")
+    }
+
+    XCTAssertTrue(subscribeSource.contains("if viewModel.subscribe.type == \"电视剧\""))
+    XCTAssertTrue(reorganizeSource.contains("recognizeSource == \"themoviedb\""))
+    XCTAssertTrue(reorganizeSource.contains("title: \"豆瓣 ID\""))
+  }
+
+  func testMediaCardPreviewCoversSubscribedAndExternalSourceContextMenuBranches() throws {
+    let catalogSource = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let contextMenuSource = try String(contentsOf: repoFile("MoviePilot-TV/Views/Components/MediaContextMenu.swift"))
+
+    let requiredCatalogSnippets = [
+      "case mediaCardsContextMenu",
+      "id: \"component-mediaCardsContextMenu\"",
+      "title: \"组件 · 媒体卡片完整菜单\"",
+      "case .mediaCardsContextMenu: return \"组件 · 媒体卡片完整菜单\"",
+      "case .mediaCardsContextMenu: return \"全权限媒体卡片菜单，覆盖 TMDB 跳转、已订阅、分季订阅、搜索资源和订阅分享复用入口。\"",
+      "showsContextMenu: componentCase != .mediaCards",
+      "externalSourceMedia(id: 98_005",
+      "title: \"外部来源：边境信号\"",
+      "installSubscribedContextMenuPreviewTask(for: items)",
+      "let subscribedItem = items[0]",
+      "task.isSubscribed = true",
+      "MediaPreloader.shared.installPreviewTask(task, for: subscribedItem)",
+    ]
+
+    for snippet in requiredCatalogSnippets {
+      XCTAssertTrue(catalogSource.contains(snippet), "Missing media-card context-menu preview fixture: \(snippet)")
+    }
+
+    XCTAssertTrue(contextMenuSource.contains("if item.collection_id == nil"))
+    XCTAssertTrue(contextMenuSource.contains("if item.douban_id != nil || item.bangumi_id != nil"))
+    XCTAssertTrue(contextMenuSource.contains("Label(\"TMDB详情页\", systemImage: \"link\")"))
+    XCTAssertTrue(contextMenuSource.contains("Label(\"已订阅\", systemImage: \"checkmark.circle.fill\")"))
+  }
+
+  func testPreviewCatalogCoversPermissionSensitiveCardMenus() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+
+    let requiredSnippets = [
+      "case homeNoSearchPermission",
+      "id: \"page-homeNoSearchPermission\"",
+      "title: \"首页 · 无搜索权限\"",
+      "case recommendLimitedPermissions",
+      "id: \"page-recommendLimitedPermissions\"",
+      "title: \"推荐 · 低权限菜单\"",
+      "case tvWithSeasonsNoSubscribePermission",
+      "id: \"detail-tvWithSeasonsNoSubscribePermission\"",
+      "title: \"详情页 · 有分季且无订阅权限\"",
+      ".tvWithSeasonsNoSubscribePermission, .noArtwork",
+      "case mediaCardsLimitedPermissions",
+      "id: \"component-mediaCardsLimitedPermissions\"",
+      "title: \"组件 · 媒体卡片低权限菜单\"",
+      "case limitedPermissions",
+      "id: \"settings-limitedPermissions\"",
+      "title: \"设置 · 低权限\"",
+      "case torrentCardsNoSearchPermission",
+      "id: \"component-torrentCardsNoSearchPermission\"",
+      "title: \"组件 · 种子卡片无搜索权限\"",
+      "componentCase.permissions",
+      "MediaContextMenuItems(",
+    ]
+
+    for snippet in requiredSnippets {
+      XCTAssertTrue(source.contains(snippet), "Missing permission-sensitive preview coverage: \(snippet)")
+    }
+  }
+
+  func testDetailPreviewsCoverContentRowsPermissionsAndSeasonShelfBranches() throws {
+    let catalogSource = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let detailViewSource = try String(contentsOf: repoFile("MoviePilot-TV/Views/Pages/MediaDetailView.swift"))
+    let detailViewModelSource = try String(contentsOf: repoFile("MoviePilot-TV/ViewModels/MediaDetailViewModel.swift"))
+    let paginatorSource = try String(contentsOf: repoFile("MoviePilot-TV/Services/Paginator.swift"))
+    let seasonViewSource = try String(contentsOf: repoFile("MoviePilot-TV/Views/Pages/SubscribeSeasonView.swift"))
+
+    let requiredSceneSnippets = [
+      "case contentPageNoSearchAndNoSubscribePermission",
+      "id: \"detail-contentPageNoSearchAndNoSubscribePermission\"",
+      "title: \"详情页 · 第二页无操作权限\"",
+      "case contentPageSingleEpisodeGroup",
+      "id: \"detail-contentPageSingleEpisodeGroup\"",
+      "title: \"详情页 · 分季单剧集组\"",
+      "case contentPageManySeasons",
+      "id: \"detail-contentPageManySeasons\"",
+      "title: \"详情页 · 多分季 / 多剧集组\"",
+    ]
+
+    for snippet in requiredSceneSnippets {
+      XCTAssertTrue(catalogSource.contains(snippet), "Missing detail preview branch: \(snippet)")
+    }
+
+    XCTAssertTrue(detailViewSource.contains("struct MediaDetailUIPreviewRows"))
+    XCTAssertTrue(detailViewSource.contains("uiPreviewRows: MediaDetailUIPreviewRows?"))
+    XCTAssertTrue(detailViewSource.contains("scrollToUIPreviewContentPage"))
+    XCTAssertTrue(detailViewSource.contains("proxy.scrollTo(\"contentTop\", anchor: .top)"))
+    XCTAssertTrue(detailViewModelSource.contains("func installUIPreviewRows("))
+    XCTAssertTrue(paginatorSource.contains("func installUIPreviewItems("))
+
+    XCTAssertTrue(catalogSource.contains("previewDetailRows"))
+    XCTAssertTrue(catalogSource.contains("previewManySeasons"))
+    XCTAssertTrue(catalogSource.contains("seasons: previewManySeasons"))
+    XCTAssertTrue(catalogSource.contains("episodeGroups: []"))
+    XCTAssertTrue(catalogSource.contains("episodeGroups: previewEpisodeGroups"))
+    XCTAssertTrue(catalogSource.contains("viewModel.seasonInfos = seasonInfos"))
+    XCTAssertTrue(catalogSource.contains("viewModel.episodeGroups = groups"))
+
+    XCTAssertTrue(seasonViewSource.contains("if viewModel.seasonInfos.count > 10"))
+    XCTAssertTrue(seasonViewSource.contains("titleText: \"查看全部\""))
+  }
+
+  func testDetailContentPagePreviewCoversRowsLoadingMoreBranch() throws {
+    let catalogSource = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let detailViewSource = try String(contentsOf: repoFile("MoviePilot-TV/Views/Pages/MediaDetailView.swift"))
+    let detailViewModelSource = try String(contentsOf: repoFile("MoviePilot-TV/ViewModels/MediaDetailViewModel.swift"))
+
+    let requiredSnippets = [
+      "case contentPageRowsLoadingMore",
+      "id: \"detail-contentPageRowsLoadingMore\"",
+      "title: \"详情页 · 第二页行加载更多\"",
+      "case .contentPageRowsLoadingMore: return \"详情页 · 第二页行加载更多\"",
+      "case .contentPageRowsLoadingMore:",
+      "return \"详情页第二页演员、推荐、类似行显示加载更多进度。\"",
+      "previewDetailRowsLoadingMore",
+      "isLoadingMore: true",
+    ]
+
+    for snippet in requiredSnippets {
+      XCTAssertTrue(catalogSource.contains(snippet), "Missing detail row loading-more preview coverage: \(snippet)")
+    }
+
+    XCTAssertTrue(detailViewSource.contains("if viewModel.actorsPaginator.isLoadingMore"))
+    XCTAssertTrue(detailViewSource.contains("if viewModel.recommendPaginator.isLoadingMore"))
+    XCTAssertTrue(detailViewSource.contains("if viewModel.similarPaginator.isLoadingMore"))
+    XCTAssertTrue(detailViewModelSource.contains("isLoadingMore: Bool = false"))
+    XCTAssertTrue(detailViewModelSource.contains("actorsPaginator.installUIPreviewItems(actors, isLoadingMore: isLoadingMore)"))
+    XCTAssertTrue(detailViewModelSource.contains("recommendPaginator.installUIPreviewItems(recommendations, isLoadingMore: isLoadingMore)"))
+    XCTAssertTrue(detailViewModelSource.contains("similarPaginator.installUIPreviewItems(similar, isLoadingMore: isLoadingMore)"))
+  }
+
+  func testDetailPreviewCoversUnsubscribingButtonLoadingState() throws {
+    let catalogSource = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let detailViewSource = try String(contentsOf: repoFile("MoviePilot-TV/Views/Pages/MediaDetailView.swift"))
+    let detailViewModelSource = try String(contentsOf: repoFile("MoviePilot-TV/ViewModels/MediaDetailViewModel.swift"))
+
+    let requiredCatalogSnippets = [
+      "case unsubscribing",
+      "id: \"detail-unsubscribing\"",
+      "title: \"详情页 · 取消订阅中\"",
+      "case .unsubscribing: return \"详情页 · 取消订阅中\"",
+      "case .unsubscribing: return \"已订阅电影 Header 中，订阅按钮显示取消订阅进行中的 ProgressView。\"",
+      "self == .movieSubscribed || self == .unsubscribeConfirmation || self == .unsubscribing",
+      "case .unsubscribing:",
+      "return .unsubscribing",
+    ]
+
+    for snippet in requiredCatalogSnippets {
+      XCTAssertTrue(catalogSource.contains(snippet), "Missing detail unsubscribing preview coverage: \(snippet)")
+    }
+
+    XCTAssertTrue(detailViewSource.contains("case unsubscribing"))
+    XCTAssertTrue(detailViewSource.contains("vm.isUnsubscribing = uiPreviewPresentation == .unsubscribing"))
+    XCTAssertTrue(detailViewSource.contains("if viewModel.isUnsubscribing"))
+    XCTAssertTrue(detailViewModelSource.contains("@Published var isUnsubscribing = false"))
+  }
+
+  func testDetailPreviewCoversFullDetailLoadFailureBranch() throws {
+    let catalogSource = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let containerSource = try String(contentsOf: repoFile("MoviePilot-TV/Views/Pages/MediaDetailContainerView.swift"))
+
+    let requiredCatalogSnippets = [
+      "case detailLoadFailed",
+      "id: \"detail-detailLoadFailed\"",
+      "title: \"详情页 · 详情加载失败\"",
+      "case .detailLoadFailed: return \"详情页 · 详情加载失败\"",
+      "case .detailLoadFailed: return \"完整详情接口失败时，容器退掉 Loading 并显示 partial detail fallback。\"",
+      "task.isDetailFailed = true",
+    ]
+
+    for snippet in requiredCatalogSnippets {
+      XCTAssertTrue(catalogSource.contains(snippet), "Missing detail load-failed preview coverage: \(snippet)")
+    }
+
+    XCTAssertTrue(containerSource.contains("|| preloadTask.isDetailFailed"))
   }
 
   func testPreviewRootDoesNotAddPreviewNavigationChrome() throws {
@@ -329,8 +894,9 @@ final class UIPreviewModeTests: XCTestCase {
       to: "\n@MainActor\nprivate struct UIPreviewMultiSelectionSheet"
     )
 
-    XCTAssertTrue(sheetSource.contains("@State private var isSheetPresented = true"))
+    XCTAssertTrue(sheetSource.contains("@State private var isSheetPresented = false"))
     XCTAssertTrue(sheetSource.contains(".sheet(isPresented: $isSheetPresented)"))
+    XCTAssertTrue(sheetSource.contains("isSheetPresented = true"))
     XCTAssertTrue(sheetSource.contains("private var sheetContent: some View"))
     XCTAssertTrue(sheetSource.contains("Button(\"打开弹窗\")"))
   }
@@ -341,8 +907,9 @@ final class UIPreviewModeTests: XCTestCase {
 
     XCTAssertTrue(source.contains("homeInitialPath: initialPath"))
     XCTAssertTrue(source.contains("path.append(media)"))
-    XCTAssertTrue(source.contains("HomeView(viewModel: homeViewModel, loadsDataOnAppear: false, initialPath: homeInitialPath)"))
+    XCTAssertTrue(source.contains("uiPreviewDestinations: homePreviewDestinations"))
     XCTAssertTrue(homeSource.contains("MediaDetailContainerView(media: mediaInfo, navigationPath: $path)"))
+    XCTAssertTrue(homeSource.contains("uiPreviewPresentation: presentation"))
     XCTAssertFalse(source.contains(".navigationDestination(for: String.self)"))
     XCTAssertFalse(source.contains("path.append(\"detail\")"))
     XCTAssertFalse(source.contains(".navigationTitle(detailCase.title)"))
@@ -515,8 +1082,10 @@ final class UIPreviewModeTests: XCTestCase {
       from: "init(uiPreviewPresentation: SystemViewUIPreviewPresentation",
       to: "#endif"
     )
-    XCTAssertTrue(previewInitSource.contains("if uiPreviewPresentation == .logoutConfirmation"))
-    XCTAssertTrue(previewInitSource.contains("State(initialValue: [.connection])"))
+    XCTAssertTrue(previewInitSource.contains("let route = uiPreviewPresentation.initialRoute"))
+    XCTAssertTrue(previewInitSource.contains("_route = State(initialValue: route)"))
+    XCTAssertTrue(systemViewSource.contains("case .connection, .logoutConfirmation:"))
+    XCTAssertTrue(systemViewSource.contains("return [.connection]"))
   }
 
   func testDetailPreviewDoesNotRefreshBackendOrDeleteSubscription() throws {

--- a/MoviePilot-TV-Tests/UIPreviewModeTests.swift
+++ b/MoviePilot-TV-Tests/UIPreviewModeTests.swift
@@ -405,6 +405,21 @@ final class UIPreviewModeTests: XCTestCase {
     let apiSource = try String(contentsOf: repoFile("MoviePilot-TV/Services/APIService.swift"))
     XCTAssertTrue(apiSource.contains("return uiPreviewCanRequestSuperUserEndpoints ?? false"))
     XCTAssertTrue(apiSource.contains("return uiPreviewPermissions?.contains(permission) ?? false"))
+
+    let sheetStart = try XCTUnwrap(previewSource.range(of: "private struct UIPreviewSheetSceneView: View"))
+    let sheetEnd = try XCTUnwrap(
+      previewSource.range(of: "\n@MainActor\nprivate struct UIPreviewMultiSelectionSheet", range: sheetStart.upperBound..<previewSource.endIndex)
+    )
+    let sheetSource = String(previewSource[sheetStart.lowerBound..<sheetEnd.lowerBound])
+    let sheetInitRange = try XCTUnwrap(sheetSource.range(of: "init(sheetCase: UIPreviewSheetCase)"))
+    let sheetBodyRange = try XCTUnwrap(sheetSource.range(of: "\n  var body: some View"))
+    let sheetApplyRange = try XCTUnwrap(
+      sheetSource.range(of: "UIPreviewFixtures.applyPermissions(", range: sheetInitRange.lowerBound..<sheetBodyRange.lowerBound)
+    )
+    let addDownloadRange = try XCTUnwrap(sheetSource.range(of: "AddDownloadSheet("))
+
+    XCTAssertLessThan(sheetApplyRange.lowerBound, addDownloadRange.lowerBound)
+    XCTAssertFalse(sheetSource.contains(".onAppear { UIPreviewFixtures.applyPermissions("))
   }
 
   private func repoFile(_ path: String) -> URL {

--- a/MoviePilot-TV-Tests/UIPreviewModeTests.swift
+++ b/MoviePilot-TV-Tests/UIPreviewModeTests.swift
@@ -317,6 +317,11 @@ final class UIPreviewModeTests: XCTestCase {
 
   func testPreviewModeShortCircuitsBackendActions() throws {
     let requiredSnippetsByFile = [
+      "MoviePilot-TV/ViewModels/ContentViewModel.swift": [
+        "if UIPreviewMode.isEnabled() { return }",
+        "apiService.$token",
+        "UIApplication.willEnterForegroundNotification",
+      ],
       "MoviePilot-TV/ViewModels/MediaPreloader.swift": [
         "return uiPreviewTask(for: media)",
       ],
@@ -325,6 +330,7 @@ final class UIPreviewModeTests: XCTestCase {
         "tmdbIdToUse = 900_000",
       ],
       "MoviePilot-TV/ViewModels/HomeViewModel.swift": [
+        "private func persistSelectedLatestMediaServer()",
         "func toggleSubscribeStatus(subscribe: Subscribe) async -> Bool",
         "func resetSubscribe(subscribe: Subscribe) async -> Bool",
         "func searchSubscribe(subscribe: Subscribe) async -> Bool",
@@ -367,6 +373,21 @@ final class UIPreviewModeTests: XCTestCase {
         XCTAssertTrue(source.contains(snippet), "\(file) missing preview action guard near \(snippet)")
       }
     }
+  }
+
+  func testPreviewModeSkipsStartupSettingsAndHomePersistence() throws {
+    let contentSource = try String(contentsOf: repoFile("MoviePilot-TV/ViewModels/ContentViewModel.swift"))
+    let previewGuardRange = try XCTUnwrap(contentSource.range(of: "if UIPreviewMode.isEnabled() { return }"))
+    let tokenSinkRange = try XCTUnwrap(contentSource.range(of: "apiService.$token"))
+    let foregroundRange = try XCTUnwrap(contentSource.range(of: "UIApplication.willEnterForegroundNotification"))
+    XCTAssertLessThan(previewGuardRange.lowerBound, tokenSinkRange.lowerBound)
+    XCTAssertLessThan(previewGuardRange.lowerBound, foregroundRange.lowerBound)
+
+    let homeSource = try String(contentsOf: repoFile("MoviePilot-TV/ViewModels/HomeViewModel.swift"))
+    let persistRange = try XCTUnwrap(homeSource.range(of: "private func persistSelectedLatestMediaServer()"))
+    let persistSource = String(homeSource[persistRange.lowerBound...]).prefix(220)
+    XCTAssertTrue(persistSource.contains("if UIPreviewMode.isEnabled() { return }"))
+    XCTAssertTrue(persistSource.contains("UserDefaults.standard.set"))
   }
 
   private func repoFile(_ path: String) -> URL {

--- a/MoviePilot-TV-Tests/UIPreviewModeTests.swift
+++ b/MoviePilot-TV-Tests/UIPreviewModeTests.swift
@@ -21,6 +21,24 @@ final class UIPreviewModeTests: XCTestCase {
     XCTAssertTrue(source.contains("PreviewCatalogView()"))
   }
 
+  func testPreviewEntryDoesNotInstantiateRealRootStateBeforePreviewBranch() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/Views/ContentView.swift"))
+
+    XCTAssertTrue(source.contains("private struct RealAppContentView: View"))
+
+    let contentViewSource = try sourceSlice(
+      source,
+      from: "struct ContentView: View",
+      to: "private struct RealAppContentView: View"
+    )
+    XCTAssertFalse(contentViewSource.contains("@StateObject private var viewModel = ContentViewModel()"))
+    XCTAssertFalse(contentViewSource.contains("@StateObject private var mediaActionHandler = MediaActionHandler()"))
+
+    let realRootSource = try sourceSlice(source, from: "private struct RealAppContentView: View")
+    XCTAssertTrue(realRootSource.contains("@StateObject private var viewModel = ContentViewModel()"))
+    XCTAssertTrue(realRootSource.contains("@StateObject private var mediaActionHandler = MediaActionHandler()"))
+  }
+
   func testPreviewSupportFilesAreDebugWrapped() throws {
     let fileManager = FileManager.default
     let directory = repoFile("MoviePilot-TV/PreviewSupport")
@@ -327,7 +345,7 @@ final class UIPreviewModeTests: XCTestCase {
       ],
       "MoviePilot-TV/ViewModels/MediaActionHandler.swift": [
         "return searchResourcesTarget(for: item)",
-        "tmdbIdToUse = 900_000",
+        "tmdbIdToUse = deterministicUIPreviewTMDBId(for: item.id)",
       ],
       "MoviePilot-TV/ViewModels/HomeViewModel.swift": [
         "private func persistSelectedLatestMediaServer()",
@@ -386,8 +404,136 @@ final class UIPreviewModeTests: XCTestCase {
     let homeSource = try String(contentsOf: repoFile("MoviePilot-TV/ViewModels/HomeViewModel.swift"))
     let persistRange = try XCTUnwrap(homeSource.range(of: "private func persistSelectedLatestMediaServer()"))
     let persistSource = String(homeSource[persistRange.lowerBound...]).prefix(220)
-    XCTAssertTrue(persistSource.contains("if UIPreviewMode.isEnabled() { return }"))
-    XCTAssertTrue(persistSource.contains("UserDefaults.standard.set"))
+    let homeGuardRange = try XCTUnwrap(persistSource.range(of: "if UIPreviewMode.isEnabled() { return }"))
+    let homeWriteRange = try XCTUnwrap(persistSource.range(of: "UserDefaults.standard.set"))
+    XCTAssertLessThan(homeGuardRange.lowerBound, homeWriteRange.lowerBound)
+  }
+
+  func testSystemPreviewActionsAndPreferencesAreSandboxed() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/ViewModels/SystemViewModel.swift"))
+
+    try assertPreviewGuard(
+      in: source,
+      function: "func relogin() async",
+      before: "APIService.shared.login"
+    )
+    try assertPreviewGuard(
+      in: source,
+      function: "func logout()",
+      before: "APIService.shared.logout"
+    )
+
+    try assertPreviewGuard(
+      in: source,
+      function: "@Published var waitMediaDetailBackgroundImage",
+      before: "UserDefaults.standard.set(waitMediaDetailBackgroundImage"
+    )
+    try assertPreviewGuard(
+      in: source,
+      function: "@Published var autoSearchNewSubscriptions",
+      before: "UserDefaults.standard.set(autoSearchNewSubscriptions"
+    )
+
+    XCTAssertTrue(source.contains("private var uiPreviewDefaultSearchSites: Set<Int> = []"))
+    XCTAssertTrue(source.contains("private var uiPreviewHardFilterRuleId: String?"))
+    XCTAssertTrue(source.contains("private var uiPreviewSoftFilterRuleId: String?"))
+    XCTAssertTrue(source.contains("if Self.isUIPreviewMode { return uiPreviewDefaultSearchSites }"))
+    XCTAssertTrue(source.contains("if Self.isUIPreviewMode { return uiPreviewHardFilterRuleId }"))
+    XCTAssertTrue(source.contains("if Self.isUIPreviewMode { return uiPreviewSoftFilterRuleId }"))
+
+    let systemViewSource = try String(contentsOf: repoFile("MoviePilot-TV/Views/Pages/SystemView.swift"))
+    let previewInitSource = try sourceSlice(
+      systemViewSource,
+      from: "init(uiPreviewPresentation: SystemViewUIPreviewPresentation",
+      to: "#endif"
+    )
+    XCTAssertTrue(previewInitSource.contains("if uiPreviewPresentation == .logoutConfirmation"))
+    XCTAssertTrue(previewInitSource.contains("State(initialValue: [.connection])"))
+  }
+
+  func testDetailPreviewDoesNotRefreshBackendOrDeleteSubscription() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/ViewModels/MediaDetailViewModel.swift"))
+
+    try assertPreviewGuard(
+      in: source,
+      function: "func applyFullDetail(_ fullDetail: MediaInfo)",
+      before: "Task {"
+    )
+    try assertPreviewGuard(
+      in: source,
+      function: "func refreshSubscriptionStatus(forceRefresh: Bool = true) async -> Bool",
+      before: "withTaskGroup"
+    )
+    try assertPreviewGuard(
+      in: source,
+      function: "func cancelSubscription() async",
+      before: "deleteResolvedSubscription()"
+    )
+    try assertPreviewGuard(
+      in: source,
+      function: "private func deleteResolvedSubscription() async -> Bool",
+      before: "fetchSubscriptionLookup"
+    )
+  }
+
+  func testSearchPreviewDoesNotEscapeToProductionResourceSearch() throws {
+    let viewModelSource = try String(contentsOf: repoFile("MoviePilot-TV/ViewModels/SearchViewModel.swift"))
+    try assertPreviewGuard(
+      in: viewModelSource,
+      function: "func autoSearch() async",
+      before: "searchGeneration += 1"
+    )
+
+    let searchViewSource = try String(contentsOf: repoFile("MoviePilot-TV/Views/Pages/SearchView.swift"))
+    let resourceDestinationSource = try sourceSlice(
+      searchViewSource,
+      from: "private func resourceDestination(for request: ResourceSearchRequest) -> some View",
+      to: "private func seasonDestination"
+    )
+    XCTAssertTrue(resourceDestinationSource.contains("} else if UIPreviewMode.isEnabled() {"))
+
+    let previewSource = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let previewDestinationsSource = try sourceSlice(
+      previewSource,
+      from: "func uiPreviewNavigationDestinations(path: Binding<NavigationPath>) -> some View",
+      to: "func previewNavigationPath() -> NavigationPath"
+    )
+    XCTAssertFalse(previewDestinationsSource.contains("ResourceResultView(request: request)"))
+
+    let resourceResultSource = try String(contentsOf: repoFile("MoviePilot-TV/Views/Pages/ResourceResultView.swift"))
+    let onDisappearSource = try sourceSlice(resourceResultSource, from: ".onDisappear {")
+    let guardRange = try XCTUnwrap(onDisappearSource.range(of: "guard searchesOnAppear else { return }"))
+    let cancelRange = try XCTUnwrap(onDisappearSource.range(of: "viewModel.cancelInFlightSearch()"))
+    XCTAssertLessThan(guardRange.lowerBound, cancelRange.lowerBound)
+  }
+
+  func testComponentPreviewsInstallPermissionsBeforeBodyAndPreviewStateIsStable() throws {
+    let previewSource = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let componentSource = try sourceSlice(
+      previewSource,
+      from: "private struct UIPreviewComponentSceneView: View",
+      to: "private struct UIPreviewMediaCards: View"
+    )
+    let initRange = try XCTUnwrap(componentSource.range(of: "init(componentCase: UIPreviewComponentCase"))
+    let applyRange = try XCTUnwrap(componentSource.range(of: "UIPreviewFixtures.applyPermissions("))
+    let bodyRange = try XCTUnwrap(componentSource.range(of: "var body: some View"))
+    XCTAssertLessThan(initRange.lowerBound, bodyRange.lowerBound)
+    XCTAssertLessThan(applyRange.lowerBound, bodyRange.lowerBound)
+    XCTAssertFalse(componentSource.contains(".onAppear { UIPreviewFixtures.applyPermissions("))
+
+    let preloaderSource = try String(contentsOf: repoFile("MoviePilot-TV/ViewModels/MediaPreloader.swift"))
+    let previewTaskSource = try sourceSlice(preloaderSource, from: "private func uiPreviewTask(for media: MediaInfo)")
+    XCTAssertTrue(previewTaskSource.contains("task.isSeasonDataLoaded = media.type == \"电视剧\""))
+
+    let actionSource = try String(contentsOf: repoFile("MoviePilot-TV/ViewModels/MediaActionHandler.swift"))
+    XCTAssertFalse(actionSource.contains(".hashValue"))
+    XCTAssertTrue(actionSource.contains("deterministicUIPreviewTMDBId(for: item.id)"))
+
+    let transferSource = try String(contentsOf: repoFile("MoviePilot-TV/ViewModels/TransferHistoryViewModel.swift"))
+    let installSource = try sourceSlice(transferSource, from: "func installUIPreviewData(")
+    XCTAssertTrue(installSource.contains("paginatorItems = items"))
+    XCTAssertTrue(installSource.contains("prependedItems.removeAll()"))
+    XCTAssertTrue(installSource.contains("deletedIds.removeAll()"))
   }
 
   func testPreviewPermissionsAreInstalledBeforeFirstPreviewFrame() throws {
@@ -419,7 +565,39 @@ final class UIPreviewModeTests: XCTestCase {
     let addDownloadRange = try XCTUnwrap(sheetSource.range(of: "AddDownloadSheet("))
 
     XCTAssertLessThan(sheetApplyRange.lowerBound, addDownloadRange.lowerBound)
-    XCTAssertFalse(sheetSource.contains(".onAppear { UIPreviewFixtures.applyPermissions("))
+    XCTAssertNil(
+      sheetSource.range(
+        of: #"\\.onAppear\\s*\\{[^}]*UIPreviewFixtures\\.applyPermissions"#,
+        options: .regularExpression
+      )
+    )
+  }
+
+  private func assertPreviewGuard(
+    in source: String,
+    function: String,
+    before guardedMarker: String
+  ) throws {
+    let functionSource = try sourceSlice(source, from: function)
+    let guardRange = try XCTUnwrap(
+      functionSource.range(of: "UIPreviewMode.isEnabled()")
+        ?? functionSource.range(of: "Self.isUIPreviewMode")
+    )
+    let markerRange = try XCTUnwrap(functionSource.range(of: guardedMarker))
+    XCTAssertLessThan(guardRange.lowerBound, markerRange.lowerBound)
+  }
+
+  private func sourceSlice(
+    _ source: String,
+    from startMarker: String,
+    to endMarker: String? = nil
+  ) throws -> Substring {
+    let start = try XCTUnwrap(source.range(of: startMarker))
+    if let endMarker {
+      let end = try XCTUnwrap(source.range(of: endMarker, range: start.upperBound..<source.endIndex))
+      return source[start.lowerBound..<end.lowerBound]
+    }
+    return source[start.lowerBound...]
   }
 
   private func repoFile(_ path: String) -> URL {

--- a/MoviePilot-TV-Tests/UIPreviewModeTests.swift
+++ b/MoviePilot-TV-Tests/UIPreviewModeTests.swift
@@ -176,14 +176,24 @@ final class UIPreviewModeTests: XCTestCase {
 
   func testPreviewCatalogPresentsScenesAsRootViews() throws {
     let source = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let rootSource = try sourceSlice(source, from: "struct PreviewCatalogView: View", to: "private struct UIPreviewCatalogHomeView")
 
     XCTAssertTrue(source.contains("@State private var selectedScene: UIPreviewScene?"))
+    XCTAssertTrue(source.contains("ZStack {"))
     XCTAssertTrue(source.contains("if let selectedScene"))
-    XCTAssertTrue(source.contains("UIPreviewCatalogHomeView { scene in"))
+    XCTAssertTrue(source.contains("UIPreviewCatalogHomeView(isActive: selectedScene == nil) { scene in"))
     XCTAssertTrue(source.contains("selectedScene = scene"))
     XCTAssertTrue(source.contains("UIPreviewSceneDestination(scene: selectedScene)"))
-    XCTAssertTrue(source.contains(".onExitCommand"))
+    XCTAssertTrue(rootSource.contains(".onExitCommand"))
+    XCTAssertTrue(rootSource.contains("selectedScene = nil"))
+    XCTAssertFalse(rootSource.contains("UIPreviewBackObserver"))
+    XCTAssertFalse(source.contains("import UIKit"))
+    XCTAssertFalse(source.contains("UIPress.PressType.menu.rawValue"))
+    XCTAssertFalse(source.contains("recognizer.cancelsTouchesInView"))
+    XCTAssertFalse(source.contains("shouldRecognizeSimultaneouslyWith otherGestureRecognizer"))
     XCTAssertTrue(source.contains(".navigationTitle(\"UI 预览\")"))
+    XCTAssertTrue(rootSource.contains(".opacity(selectedScene == nil ? 1 : 0)"))
+    XCTAssertTrue(rootSource.contains(".disabled(selectedScene != nil)"))
     XCTAssertEqual(source.components(separatedBy: ".navigationTitle(").count - 1, 1)
     XCTAssertTrue(source.contains("ScrollView {"))
     XCTAssertTrue(source.contains("Button {"))
@@ -193,6 +203,50 @@ final class UIPreviewModeTests: XCTestCase {
     XCTAssertFalse(source.contains("path.append(scene)"))
     XCTAssertFalse(source.contains("ToolbarItem(placement: .navigationBarLeading)"))
     XCTAssertFalse(source.contains("返回目录"))
+  }
+
+  func testPreviewCatalogKeepsFocusAndSectionsCollapsedByDefault() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let rootSource = try sourceSlice(source, from: "struct PreviewCatalogView: View", to: "private struct UIPreviewCatalogHomeView")
+    let homeSource = try sourceSlice(source, from: "private struct UIPreviewCatalogHomeView", to: "private enum UIPreviewCatalog")
+
+    XCTAssertTrue(rootSource.contains("ZStack {"))
+    XCTAssertFalse(rootSource.contains("focusedCatalogItemID"))
+    XCTAssertTrue(homeSource.contains("let isActive: Bool"))
+    XCTAssertTrue(homeSource.contains("@State private var lastFocusedControlID: String?"))
+    XCTAssertTrue(homeSource.contains("@State private var expandedSectionIDs: Set<String> = []"))
+    XCTAssertFalse(homeSource.contains("@Binding var focusedItemID"))
+    XCTAssertTrue(homeSource.contains("focusedControlID = focusedControlID ?? UIPreviewCatalog.firstSectionID"))
+    XCTAssertFalse(homeSource.contains(".defaultFocus("))
+    XCTAssertFalse(source.contains("focusedItemID = newValue"))
+    XCTAssertTrue(homeSource.contains("lastFocusedControlID = newValue ?? lastFocusedControlID"))
+    XCTAssertTrue(homeSource.contains(".onChange(of: isActive)"))
+    XCTAssertTrue(homeSource.contains("focusedControlID = lastFocusedControlID ?? focusedControlID ?? UIPreviewCatalog.firstSectionID"))
+    XCTAssertTrue(homeSource.contains(".frame(width: 760, alignment: .leading)"))
+    XCTAssertTrue(homeSource.contains(".frame(maxWidth: .infinity, alignment: .center)"))
+    XCTAssertGreaterThanOrEqual(homeSource.components(separatedBy: ".frame(maxWidth: .infinity, alignment: .leading)").count - 1, 2)
+    XCTAssertTrue(homeSource.contains("if expandedSectionIDs.contains(section.id)"))
+    XCTAssertTrue(homeSource.contains("expandedSectionIDs.remove(sectionID)"))
+    XCTAssertTrue(homeSource.contains("expandedSectionIDs.insert(sectionID)"))
+    XCTAssertFalse(homeSource.contains(".buttonStyle("))
+    XCTAssertFalse(homeSource.contains("UIPreviewCatalogButtonStyle"))
+  }
+
+  func testNotificationPreviewHasLocalFocusAnchorForExitCommand() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let notificationSource = try sourceSlice(
+      source,
+      from: "private struct UIPreviewNotificationComponents",
+      to: "private struct UIPreviewPushedMediaDetailView"
+    )
+
+    XCTAssertTrue(notificationSource.contains("@FocusState private var isReturnAnchorFocused: Bool"))
+    XCTAssertTrue(notificationSource.contains(".focusable()"))
+    XCTAssertTrue(notificationSource.contains(".focused($isReturnAnchorFocused)"))
+    XCTAssertTrue(notificationSource.contains("isReturnAnchorFocused = true"))
+    XCTAssertTrue(notificationSource.contains(".accessibilityHidden(true)"))
+    XCTAssertFalse(notificationSource.contains("UIPreviewBackObserver"))
+    XCTAssertFalse(notificationSource.contains("返回目录"))
   }
 
   func testTopLevelPreviewScenesPreserveRealTabRoot() throws {
@@ -265,6 +319,20 @@ final class UIPreviewModeTests: XCTestCase {
 
     XCTAssertFalse(functionSource.contains("NavigationStack"))
     XCTAssertFalse(functionSource.contains(".navigationTitle(title)"))
+  }
+
+  func testSheetPreviewsUseNativeSheetPresentation() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let sheetSource = try sourceSlice(
+      source,
+      from: "private struct UIPreviewSheetSceneView: View",
+      to: "\n@MainActor\nprivate struct UIPreviewMultiSelectionSheet"
+    )
+
+    XCTAssertTrue(sheetSource.contains("@State private var isSheetPresented = true"))
+    XCTAssertTrue(sheetSource.contains(".sheet(isPresented: $isSheetPresented)"))
+    XCTAssertTrue(sheetSource.contains("private var sheetContent: some View"))
+    XCTAssertTrue(sheetSource.contains("Button(\"打开弹窗\")"))
   }
 
   func testDetailPreviewStartsAsNativeNavigationDestination() throws {

--- a/MoviePilot-TV-Tests/UIPreviewModeTests.swift
+++ b/MoviePilot-TV-Tests/UIPreviewModeTests.swift
@@ -1,0 +1,378 @@
+import XCTest
+
+@testable import MoviePilot_TV
+
+final class UIPreviewModeTests: XCTestCase {
+  func testPreviewModeRequiresExplicitLaunchArgument() {
+    XCTAssertTrue(UIPreviewMode.isEnabled(arguments: ["MoviePilot-TV", "-uiPreviewMode"]))
+    XCTAssertFalse(UIPreviewMode.isEnabled(arguments: ["MoviePilot-TV"]))
+    XCTAssertFalse(UIPreviewMode.isEnabled(arguments: ["MoviePilot-TV", "uiPreviewMode"]))
+  }
+
+  func testLaunchArgumentMatchesDocumentedEntryPoint() {
+    XCTAssertEqual(UIPreviewMode.launchArgument, "-uiPreviewMode")
+  }
+
+  func testContentViewPreviewEntryIsDebugOnly() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/Views/ContentView.swift"))
+
+    XCTAssertTrue(source.contains("#if DEBUG"))
+    XCTAssertTrue(source.contains("UIPreviewMode.isEnabled()"))
+    XCTAssertTrue(source.contains("PreviewCatalogView()"))
+  }
+
+  func testPreviewSupportFilesAreDebugWrapped() throws {
+    let fileManager = FileManager.default
+    let directory = repoFile("MoviePilot-TV/PreviewSupport")
+    let files = try fileManager.contentsOfDirectory(atPath: directory.path)
+      .filter { $0.hasSuffix(".swift") }
+
+    XCTAssertFalse(files.isEmpty)
+
+    for file in files {
+      let source = try String(contentsOf: directory.appendingPathComponent(file))
+      XCTAssertTrue(
+        source.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("#if DEBUG"),
+        "\(file) must be compiled only in DEBUG."
+      )
+    }
+  }
+
+  func testPreviewCatalogCoversAllManualReviewAreas() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+
+    let requiredSections = [
+      "App 入口 / Tab 页面",
+      "详情页",
+      "分季页",
+      "搜索链路",
+      "状态 / 任务",
+      "设置",
+      "弹窗",
+      "核心组件",
+    ]
+
+    for section in requiredSections {
+      XCTAssertTrue(source.contains("title: \"\(section)\""), "Missing preview section: \(section)")
+    }
+
+    let requiredScenes = [
+      "启动入口 · 正常已登录",
+      "启动入口 · 登录页",
+      "首页 · 加载中",
+      "首页 · 空数据",
+      "首页 · 完整数据",
+      "推荐 · 加载中",
+      "推荐 · 空数据",
+      "推荐 · 完整数据",
+      "探索 · TMDB 筛选",
+      "探索 · 订阅分享",
+      "搜索 · 聚合结果",
+      "搜索 · 聚合空结果",
+      "搜索 · 资源加载中",
+      "搜索 · 资源结果",
+      "搜索 · 资源空结果",
+      "合集详情 · 加载中",
+      "合集详情 · 完整数据",
+      "人物详情 · 加载中",
+      "人物详情 · 完整数据",
+      "资源结果页 · 加载中",
+      "资源结果页 · 完整数据",
+      "状态页 · 空权限 / 空数据",
+      "状态页 · 完整数据",
+      "下载任务 · 空数据",
+      "下载任务 · 多状态任务",
+      "整理历史 · 加载中",
+      "整理历史 · 空数据",
+      "整理历史 · 多选 / AI 整理中",
+      "整理历史 · 详情弹窗",
+      "设置 · 全权限",
+      "设置 · 无订阅权限",
+      "设置 · 无搜索权限",
+      "设置 · APP 信息",
+      "设置 · 退出登录确认",
+      "订阅弹窗 · 新增",
+      "订阅分享弹窗 · 复用",
+      "下载弹窗 · 添加下载",
+      "整理弹窗 · 单项重整",
+      "整理弹窗 · 批量重整",
+      "分季详情弹窗",
+      "多选弹窗 · 站点选择",
+      "组件 · 媒体卡片",
+      "组件 · 种子卡片",
+      "组件 · 选择器 / 输入框",
+      "组件 · 通知",
+    ]
+
+    for scene in requiredScenes {
+      XCTAssertTrue(source.contains("title: \"\(scene)\""), "Missing preview scene: \(scene)")
+    }
+  }
+
+  func testPreviewCatalogReferencesPrimaryPageSheetAndComponentViews() throws {
+    let source = try [
+      "MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift",
+      "MoviePilot-TV/Views/Pages/SearchView.swift",
+      "MoviePilot-TV/Views/Pages/StatusView.swift",
+    ]
+    .map { try String(contentsOf: repoFile($0)) }
+    .joined(separator: "\n")
+
+    let requiredViewEntries = [
+      "LoginView(",
+      "HomeView(",
+      "RecommendView(",
+      "ExploreView(",
+      "SearchView(",
+      "StatusView(",
+      "SystemView(",
+      "CollectionDetailView(",
+      "PersonDetailView(",
+      "MediaDetailContainerView(",
+      "SubscribeSeasonView(",
+      "ResourceResultView(",
+      "DownloadTaskView(",
+      "TransferHistoryView(",
+      "SubscribeSheet(",
+      "ForkSubscribeSheet(",
+      "AddDownloadSheet(",
+      "ReorganizeSheet(",
+      "MultiSelectionSheet(",
+      "SeasonDetailSheet(",
+      "MediaGridView(",
+      "TorrentCard(",
+      "CategoryPickerView(",
+      "ShelfPicker(",
+      "SheetPicker(",
+      "SheetTextField(",
+      "NotificationView(",
+    ]
+
+    for viewEntry in requiredViewEntries {
+      XCTAssertTrue(
+        source.contains(viewEntry),
+        "Preview catalog must route through primary UI entry: \(viewEntry)"
+      )
+    }
+  }
+
+  func testPreviewCatalogPresentsScenesAsRootViews() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+
+    XCTAssertTrue(source.contains("@State private var selectedScene: UIPreviewScene?"))
+    XCTAssertTrue(source.contains("if let selectedScene"))
+    XCTAssertTrue(source.contains("UIPreviewCatalogHomeView { scene in"))
+    XCTAssertTrue(source.contains("selectedScene = scene"))
+    XCTAssertTrue(source.contains("UIPreviewSceneDestination(scene: selectedScene)"))
+    XCTAssertTrue(source.contains(".onExitCommand"))
+    XCTAssertTrue(source.contains(".navigationTitle(\"UI 预览\")"))
+    XCTAssertEqual(source.components(separatedBy: ".navigationTitle(").count - 1, 1)
+    XCTAssertTrue(source.contains("ScrollView {"))
+    XCTAssertTrue(source.contains("Button {"))
+    XCTAssertFalse(source.contains("List {"))
+    XCTAssertFalse(source.contains("NavigationLink(value: scene)"))
+    XCTAssertFalse(source.contains(".navigationDestination(for: UIPreviewScene.self)"))
+    XCTAssertFalse(source.contains("path.append(scene)"))
+    XCTAssertFalse(source.contains("ToolbarItem(placement: .navigationBarLeading)"))
+    XCTAssertFalse(source.contains("返回目录"))
+  }
+
+  func testTopLevelPreviewScenesPreserveRealTabRoot() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+
+    let requiredTabLabels = [
+      "Label(\"媒体库\", systemImage: \"play.tv\")",
+      "Label(\"推荐\", systemImage: \"sparkles.tv\")",
+      "Label(\"探索\", systemImage: \"safari\")",
+      "Label(\"搜索\", systemImage: \"magnifyingglass\")",
+      "Label(\"状态\", systemImage: \"slider.horizontal.3\")",
+      "Label(\"设置\", systemImage: \"gear\")",
+    ]
+
+    for tabLabel in requiredTabLabels {
+      XCTAssertTrue(source.contains(tabLabel), "Missing real TabView entry: \(tabLabel)")
+    }
+
+    let requiredPreviewRoutes = [
+      "UIPreviewLoggedInRootView(selectedTab: .home, homeMode: previewCase.homeMode)",
+      "UIPreviewLoggedInRootView(selectedTab: .recommend, recommendMode: previewCase.recommendMode)",
+      "UIPreviewLoggedInRootView(selectedTab: .explore, exploreMode: previewCase.exploreMode)",
+      "UIPreviewLoggedInRootView(selectedTab: .search, searchCase: searchCase)",
+      "selectedTab: .status",
+      "selectedTab: .system",
+    ]
+
+    for route in requiredPreviewRoutes {
+      XCTAssertTrue(source.contains(route), "Preview scene must keep the real TabView root: \(route)")
+    }
+
+    XCTAssertFalse(source.contains("HomeView(viewModel: UIPreviewFixtures.homeViewModel"))
+    XCTAssertFalse(source.contains("RecommendView(viewModel: UIPreviewFixtures.recommendViewModel"))
+    XCTAssertFalse(source.contains("SearchView(viewModel: UIPreviewFixtures.searchViewModel"))
+  }
+
+  func testDeepPreviewScenesPreserveRealTabRoot() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let searchSource = try String(contentsOf: repoFile("MoviePilot-TV/Views/Pages/SearchView.swift"))
+
+    let requiredRoutes = [
+      "searchPreviewDestinations: SearchViewUIPreviewDestinations(",
+      "collectionViewModel: UIPreviewFixtures.collectionViewModel(mode)",
+      "personViewModel: viewModel",
+      "seasonViewModel: viewModel",
+      "resourceResultViewModel: UIPreviewFixtures.resourceResultViewModel(mode)",
+      "searchInitialPath: media.previewNavigationPath()",
+      "searchInitialPath: viewModel.person.previewNavigationPath()",
+      "searchInitialPath: request.previewNavigationPath()",
+    ]
+
+    for route in requiredRoutes {
+      XCTAssertTrue(source.contains(route), "Deep preview scene must keep the real TabView root: \(route)")
+    }
+
+    XCTAssertTrue(searchSource.contains("SearchViewUIPreviewDestinations"))
+    XCTAssertTrue(searchSource.contains("CollectionDetailView("))
+    XCTAssertTrue(searchSource.contains("PersonDetailView(previewViewModel: previewViewModel"))
+    XCTAssertTrue(searchSource.contains("ResourceResultView("))
+    XCTAssertTrue(searchSource.contains("SubscribeSeasonView(previewViewModel: previewViewModel)"))
+    XCTAssertFalse(source.contains("NavigationStack {\n      SubscribeSeasonView(previewViewModel: viewModel)"))
+    XCTAssertFalse(source.contains("ResourceResultView(\n      title: mode"))
+  }
+
+  func testPreviewRootDoesNotAddPreviewNavigationChrome() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let functionRange = try XCTUnwrap(source.range(of: "func previewRoot(_ title: String) -> some View"))
+    let functionSource = String(source[functionRange.lowerBound...])
+      .prefix(200)
+
+    XCTAssertFalse(functionSource.contains("NavigationStack"))
+    XCTAssertFalse(functionSource.contains(".navigationTitle(title)"))
+  }
+
+  func testDetailPreviewStartsAsNativeNavigationDestination() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+    let homeSource = try String(contentsOf: repoFile("MoviePilot-TV/Views/Pages/HomeView.swift"))
+
+    XCTAssertTrue(source.contains("homeInitialPath: initialPath"))
+    XCTAssertTrue(source.contains("path.append(media)"))
+    XCTAssertTrue(source.contains("HomeView(viewModel: homeViewModel, loadsDataOnAppear: false, initialPath: homeInitialPath)"))
+    XCTAssertTrue(homeSource.contains("MediaDetailContainerView(media: mediaInfo, navigationPath: $path)"))
+    XCTAssertFalse(source.contains(".navigationDestination(for: String.self)"))
+    XCTAssertFalse(source.contains("path.append(\"detail\")"))
+    XCTAssertFalse(source.contains(".navigationTitle(detailCase.title)"))
+  }
+
+  func testPreviewCatalogDoesNotContainSyntheticComponentPlayground() throws {
+    let source = try String(contentsOf: repoFile("MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift"))
+
+    XCTAssertFalse(source.contains("组件 · 空态 / 操作行"))
+    XCTAssertFalse(source.contains("UIPreviewEmptyAndActionRows"))
+    XCTAssertFalse(source.contains("Color.green"))
+  }
+
+  func testReleaseVisiblePreviewControlSignaturesAreNotExposed() throws {
+    let forbiddenSignaturesByFile = [
+      "MoviePilot-TV/Views/Pages/HomeView.swift": [
+        "init(viewModel: HomeViewModel? = nil, loadsDataOnAppear: Bool = true)"
+      ],
+      "MoviePilot-TV/Views/Pages/DownloadTaskView.swift": [
+        "init(viewModel: DownloadTaskViewModel? = nil, refreshesOnAppear: Bool = true)"
+      ],
+      "MoviePilot-TV/Views/Pages/SearchView.swift": [
+        "init(viewModel: SearchViewModel? = nil, loadsSitesOnAppear: Bool = true)"
+      ],
+      "MoviePilot-TV/Views/Pages/StatusView.swift": [
+        "viewModel: StatusViewModel? = nil",
+        "downloadTaskViewModel: DownloadTaskViewModel? = nil",
+        "transferHistoryViewModel: TransferHistoryViewModel? = nil",
+        "refreshesOnAppear: Bool = true",
+      ],
+      "MoviePilot-TV/Views/Pages/SystemView.swift": [
+        "init(isSelected: Bool = true, viewModel: SystemViewModel? = nil, loadsDataOnAppear: Bool = true)"
+      ],
+      "MoviePilot-TV/Views/Pages/TransferHistoryView.swift": [
+        "init(viewModel: TransferHistoryViewModel, refreshesOnAppear: Bool = true)"
+      ],
+      "MoviePilot-TV/ViewModels/ExploreViewModel.swift": [
+        "init(loadsAutomatically: Bool = true)"
+      ],
+      "MoviePilot-TV/ViewModels/RecommendViewModel.swift": [
+        "init(loadsAutomatically: Bool = true)"
+      ],
+      "MoviePilot-TV/Views/Pages/RecommendView.swift": [
+        "init(viewModel: RecommendViewModel? = nil)"
+      ],
+      "MoviePilot-TV/Views/Pages/ExploreView.swift": [
+        "init(viewModel: ExploreViewModel? = nil)"
+      ],
+    ]
+
+    for (file, signatures) in forbiddenSignaturesByFile {
+      let source = try String(contentsOf: repoFile(file))
+      for signature in signatures {
+        XCTAssertFalse(source.contains(signature), "\(file) exposes preview-only control: \(signature)")
+      }
+    }
+  }
+
+  func testPreviewModeShortCircuitsBackendActions() throws {
+    let requiredSnippetsByFile = [
+      "MoviePilot-TV/ViewModels/MediaPreloader.swift": [
+        "return uiPreviewTask(for: media)",
+      ],
+      "MoviePilot-TV/ViewModels/MediaActionHandler.swift": [
+        "return searchResourcesTarget(for: item)",
+        "tmdbIdToUse = 900_000",
+      ],
+      "MoviePilot-TV/ViewModels/HomeViewModel.swift": [
+        "func toggleSubscribeStatus(subscribe: Subscribe) async -> Bool",
+        "func resetSubscribe(subscribe: Subscribe) async -> Bool",
+        "func searchSubscribe(subscribe: Subscribe) async -> Bool",
+        "func deleteSubscribe(subscribe: Subscribe) async -> Bool",
+      ],
+      "MoviePilot-TV/ViewModels/SubscribeSeasonViewModel.swift": [
+        "func checkSubscriptionStatus(forceRefresh: Bool = false) async -> Bool",
+        "func unsubscribeSeason(_ seasonNumber: Int) async",
+      ],
+      "MoviePilot-TV/ViewModels/SubscribeSheetViewModel.swift": [
+        "func save() async -> Bool",
+        "func cancel() async",
+      ],
+      "MoviePilot-TV/ViewModels/SubscriptionHandler.swift": [
+        "func handleSubscribe(_ item: MediaInfo)",
+        "func fork(share: SubscribeShare) async -> Int?",
+      ],
+      "MoviePilot-TV/ViewModels/AddDownloadViewModel.swift": [
+        "func addDownload() async",
+      ],
+      "MoviePilot-TV/ViewModels/ReorganizeViewModel.swift": [
+        "func submit(background: Bool) async -> Bool",
+      ],
+      "MoviePilot-TV/ViewModels/DownloadTaskViewModel.swift": [
+        "func stopDownload(hash: String) async -> Bool",
+        "func startDownload(hash: String) async -> Bool",
+        "func deleteDownload(hash: String) async",
+      ],
+      "MoviePilot-TV/ViewModels/TransferHistoryViewModel.swift": [
+        "func deleteHistory(item: TransferHistory, deleteSource: Bool, deleteDest: Bool) async",
+        "func deleteSelected(deleteSource: Bool, deleteDest: Bool) async",
+        "func triggerAiRedo(for ids: [Int]) async",
+      ],
+    ]
+
+    for (file, snippets) in requiredSnippetsByFile {
+      let source = try String(contentsOf: repoFile(file))
+      XCTAssertTrue(source.contains("UIPreviewMode.isEnabled()"), "\(file) must guard UI preview backend actions.")
+      for snippet in snippets {
+        XCTAssertTrue(source.contains(snippet), "\(file) missing preview action guard near \(snippet)")
+      }
+    }
+  }
+
+  private func repoFile(_ path: String) -> URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent(path)
+  }
+}

--- a/MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift
+++ b/MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift
@@ -1,0 +1,2204 @@
+#if DEBUG
+import SwiftUI
+
+struct PreviewCatalogView: View {
+  @StateObject private var mediaActionHandler = MediaActionHandler()
+  @State private var selectedScene: UIPreviewScene?
+  @State private var didResetPreviewState = false
+
+  var body: some View {
+    Group {
+      if let selectedScene {
+        UIPreviewSceneDestination(scene: selectedScene)
+          .id(selectedScene.id)
+          .onExitCommand {
+            self.selectedScene = nil
+          }
+      } else {
+        NavigationStack {
+          UIPreviewCatalogHomeView { scene in
+            selectedScene = scene
+          }
+          .navigationTitle("UI 预览")
+        }
+      }
+    }
+    .mediaActionAlerts()
+    .environmentObject(mediaActionHandler)
+    .withNotification()
+    .onAppear {
+      guard !didResetPreviewState else { return }
+      didResetPreviewState = true
+      UIPreviewFixtures.resetPreviewState()
+    }
+  }
+}
+
+private struct UIPreviewCatalogHomeView: View {
+  let selectScene: (UIPreviewScene) -> Void
+  @FocusState private var focusedSceneID: String?
+
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 34) {
+        ForEach(UIPreviewCatalog.sections) { section in
+          VStack(alignment: .leading, spacing: 14) {
+            Text(section.title)
+              .font(.title3.bold())
+              .foregroundStyle(.secondary)
+
+            VStack(spacing: 10) {
+              ForEach(section.scenes) { scene in
+                let isFocused = focusedSceneID == scene.id
+
+                Button {
+                  selectScene(scene)
+                } label: {
+                  VStack(alignment: .leading, spacing: 8) {
+                    Text(scene.title)
+                      .font(.headline)
+                      .foregroundStyle(isFocused ? .black : .primary)
+                    Text(scene.note)
+                      .font(.caption)
+                      .foregroundStyle(isFocused ? .black.opacity(0.65) : .secondary)
+                  }
+                  .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .buttonStyle(UIPreviewCatalogButtonStyle())
+                .focused($focusedSceneID, equals: scene.id)
+              }
+            }
+          }
+        }
+      }
+      .padding(.horizontal, 96)
+      .padding(.vertical, 60)
+    }
+    .onAppear {
+      focusedSceneID = focusedSceneID ?? UIPreviewCatalog.firstSceneID
+    }
+  }
+}
+
+private struct UIPreviewCatalogButtonStyle: ButtonStyle {
+  @Environment(\.isFocused) private var isFocused
+
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .padding(.horizontal, 26)
+      .padding(.vertical, 18)
+      .background {
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+          .fill(backgroundColor(isPressed: configuration.isPressed))
+      }
+      .scaleEffect(isFocused && !configuration.isPressed ? 1.02 : 1.0)
+      .animation(.easeOut(duration: 0.18), value: isFocused)
+      .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+  }
+
+  private func backgroundColor(isPressed: Bool) -> Color {
+    if isFocused {
+      return .white
+    }
+    return .white.opacity(isPressed ? 0.12 : 0.04)
+  }
+}
+
+private struct UIPreviewSceneDestination: View {
+  let scene: UIPreviewScene
+  @State private var navigationPath = NavigationPath()
+
+  var body: some View {
+    switch scene.kind {
+    case .app(let previewCase):
+      UIPreviewAppSceneView(previewCase: previewCase)
+    case .page(let previewCase):
+      UIPreviewPageSceneView(previewCase: previewCase)
+    case .detail(let detailCase):
+      UIPreviewDetailSceneView(detailCase: detailCase)
+    case .season(let seasonCase):
+      UIPreviewSeasonSceneView(seasonCase: seasonCase)
+    case .search(let searchCase):
+      UIPreviewSearchSceneView(searchCase: searchCase)
+    case .status(let statusCase):
+      UIPreviewStatusSceneView(statusCase: statusCase)
+    case .settings(let settingsCase):
+      UIPreviewSettingsSceneView(settingsCase: settingsCase)
+    case .sheet(let sheetCase):
+      UIPreviewSheetSceneView(sheetCase: sheetCase)
+    case .component(let componentCase):
+      UIPreviewComponentSceneView(componentCase: componentCase, navigationPath: $navigationPath)
+    }
+  }
+}
+
+@MainActor
+private struct UIPreviewAppSceneView: View {
+  let previewCase: UIPreviewAppCase
+
+  var body: some View {
+    Group {
+      switch previewCase {
+      case .loggedIn:
+        UIPreviewLoggedInRootView()
+      case .login:
+        LoginView()
+      }
+    }
+    .onAppear {
+      switch previewCase {
+      case .loggedIn:
+        UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true)
+      case .login:
+        UIPreviewFixtures.applyPermissions([], canRequestSuperUserEndpoints: false)
+      }
+    }
+  }
+}
+
+@MainActor
+private struct UIPreviewLoggedInRootView: View {
+  @StateObject private var homeViewModel: HomeViewModel
+  @StateObject private var recommendViewModel: RecommendViewModel
+  @StateObject private var exploreViewModel: ExploreViewModel
+  @StateObject private var searchViewModel: SearchViewModel
+  @StateObject private var statusViewModel: StatusViewModel
+  @StateObject private var downloadViewModel: DownloadTaskViewModel
+  @StateObject private var transferViewModel: TransferHistoryViewModel
+  @StateObject private var systemViewModel: SystemViewModel
+  @State private var selectedTab: ContentViewModel.Tab
+
+  private let permissions: Set<UserPermissionKey>
+  private let canRequestSuperUserEndpoints: Bool
+  private let systemPresentation: SystemViewUIPreviewPresentation?
+  private let transferPresentation: TransferHistoryUIPreviewPresentation?
+  private let homeInitialPath: NavigationPath
+  private let searchInitialPath: NavigationPath
+  private let searchPreviewDestinations: SearchViewUIPreviewDestinations?
+
+  init(
+    selectedTab: ContentViewModel.Tab = .home,
+    homeMode: UIPreviewHomeMode = .full,
+    recommendMode: UIPreviewRecommendMode = .full,
+    exploreMode: UIPreviewExploreMode = .tmdb,
+    searchCase: UIPreviewSearchCase = .unifiedResults,
+    statusMode: UIPreviewStatusMode = .full,
+    downloadMode: UIPreviewDownloadMode = .multiState,
+    transferMode: UIPreviewTransferMode = .aiRedoing,
+    settingsCase: UIPreviewSettingsCase = .fullAccess,
+    permissions: Set<UserPermissionKey> = .allPreviewPermissions,
+    canRequestSuperUserEndpoints: Bool = true,
+    systemPresentation: SystemViewUIPreviewPresentation? = nil,
+    transferPresentation: TransferHistoryUIPreviewPresentation? = nil,
+    homeInitialPath: NavigationPath = NavigationPath(),
+    searchInitialPath: NavigationPath = NavigationPath(),
+    searchPreviewDestinations: SearchViewUIPreviewDestinations? = nil
+  ) {
+    _homeViewModel = StateObject(wrappedValue: UIPreviewFixtures.homeViewModel(homeMode))
+    _recommendViewModel = StateObject(wrappedValue: UIPreviewFixtures.recommendViewModel(recommendMode))
+    _exploreViewModel = StateObject(wrappedValue: UIPreviewFixtures.exploreViewModel(exploreMode))
+    _searchViewModel = StateObject(wrappedValue: UIPreviewFixtures.searchViewModel(searchCase))
+    _statusViewModel = StateObject(wrappedValue: UIPreviewFixtures.statusViewModel(statusMode))
+    _downloadViewModel = StateObject(wrappedValue: UIPreviewFixtures.downloadViewModel(downloadMode))
+    _transferViewModel = StateObject(wrappedValue: UIPreviewFixtures.transferHistoryViewModel(transferMode))
+    _systemViewModel = StateObject(wrappedValue: UIPreviewFixtures.systemViewModel(settingsCase))
+    _selectedTab = State(initialValue: Self.resolvedSelectedTab(selectedTab, permissions: permissions))
+    self.permissions = permissions
+    self.canRequestSuperUserEndpoints = canRequestSuperUserEndpoints
+    self.systemPresentation = systemPresentation
+    self.transferPresentation = transferPresentation
+    self.homeInitialPath = homeInitialPath
+    self.searchInitialPath = searchInitialPath
+    self.searchPreviewDestinations = searchPreviewDestinations
+  }
+
+  var body: some View {
+    TabView(selection: $selectedTab) {
+      HomeView(viewModel: homeViewModel, loadsDataOnAppear: false, initialPath: homeInitialPath)
+        .tabItem { Label("媒体库", systemImage: "play.tv") }
+        .tag(ContentViewModel.Tab.home)
+
+      if visibleTabs.contains(.recommend) {
+        RecommendView(viewModel: recommendViewModel)
+          .tabItem { Label("推荐", systemImage: "sparkles.tv") }
+          .tag(ContentViewModel.Tab.recommend)
+      }
+
+      if visibleTabs.contains(.explore) {
+        ExploreView(viewModel: exploreViewModel)
+          .tabItem { Label("探索", systemImage: "safari") }
+          .tag(ContentViewModel.Tab.explore)
+      }
+
+      if visibleTabs.contains(.search) {
+        SearchView(
+          viewModel: searchViewModel,
+          loadsSitesOnAppear: false,
+          initialPath: searchInitialPath,
+          uiPreviewDestinations: searchPreviewDestinations
+        )
+        .tabItem { Label("搜索", systemImage: "magnifyingglass") }
+        .tag(ContentViewModel.Tab.search)
+      }
+
+      if visibleTabs.contains(.status) {
+        StatusView(
+          viewModel: statusViewModel,
+          downloadTaskViewModel: downloadViewModel,
+          transferHistoryViewModel: transferViewModel,
+          refreshesOnAppear: false,
+          transferPresentation: transferPresentation
+        )
+        .tabItem { Label("状态", systemImage: "slider.horizontal.3") }
+        .tag(ContentViewModel.Tab.status)
+      }
+
+      systemTab
+        .tabItem { Label("设置", systemImage: "gear") }
+        .tag(ContentViewModel.Tab.system)
+    }
+    .foregroundColor(.primary)
+    .onAppear {
+      UIPreviewFixtures.applyPermissions(
+        permissions,
+        canRequestSuperUserEndpoints: canRequestSuperUserEndpoints
+      )
+      selectedTab = Self.resolvedSelectedTab(selectedTab, permissions: permissions)
+    }
+  }
+
+  @ViewBuilder
+  private var systemTab: some View {
+    if let systemPresentation {
+      SystemView(uiPreviewPresentation: systemPresentation, viewModel: systemViewModel)
+    } else {
+      SystemView(isSelected: selectedTab == .system, viewModel: systemViewModel, loadsDataOnAppear: false)
+    }
+  }
+
+  private var visibleTabs: Set<ContentViewModel.Tab> {
+    Self.visibleTabs(for: permissions)
+  }
+
+  private static func resolvedSelectedTab(
+    _ selectedTab: ContentViewModel.Tab,
+    permissions: Set<UserPermissionKey>
+  ) -> ContentViewModel.Tab {
+    let visibleTabs = visibleTabs(for: permissions)
+    return visibleTabs.contains(selectedTab) ? selectedTab : .home
+  }
+
+  private static func visibleTabs(for permissions: Set<UserPermissionKey>) -> Set<ContentViewModel.Tab> {
+    var tabs: Set<ContentViewModel.Tab> = [.home, .system]
+    if permissions.contains(.discovery) {
+      tabs.insert(.recommend)
+      tabs.insert(.explore)
+    }
+    if permissions.contains(.search) {
+      tabs.insert(.search)
+    }
+    if permissions.contains(.manage) {
+      tabs.insert(.status)
+    }
+    return tabs
+  }
+}
+
+@MainActor
+private struct UIPreviewPageSceneView: View {
+  let previewCase: UIPreviewPageCase
+
+  var body: some View {
+    switch previewCase {
+    case .homeLoading, .homeEmpty, .homeFull:
+      UIPreviewLoggedInRootView(selectedTab: .home, homeMode: previewCase.homeMode)
+    case .recommendLoading, .recommendEmpty, .recommendFull:
+      UIPreviewLoggedInRootView(selectedTab: .recommend, recommendMode: previewCase.recommendMode)
+    case .exploreTmdb, .exploreShare:
+      UIPreviewLoggedInRootView(selectedTab: .explore, exploreMode: previewCase.exploreMode)
+    case .collectionLoading, .collectionFull:
+      UIPreviewCollectionScene(mode: previewCase.collectionMode)
+    case .personLoading, .personFull:
+      UIPreviewPersonScene(mode: previewCase.personMode)
+    }
+  }
+}
+
+@MainActor
+private struct UIPreviewCollectionScene: View {
+  let mode: UIPreviewCollectionMode
+
+  var body: some View {
+    let media = UIPreviewFixtures.collectionMedia(id: 991, title: "边境信号系列")
+
+    UIPreviewLoggedInRootView(
+      selectedTab: .search,
+      searchInitialPath: media.previewNavigationPath(),
+      searchPreviewDestinations: SearchViewUIPreviewDestinations(
+        collectionViewModel: UIPreviewFixtures.collectionViewModel(mode)
+      )
+    )
+  }
+}
+
+@MainActor
+private struct UIPreviewPersonScene: View {
+  let mode: UIPreviewPersonMode
+
+  var body: some View {
+    let viewModel = UIPreviewFixtures.personViewModel(mode)
+
+    UIPreviewLoggedInRootView(
+      selectedTab: .search,
+      searchInitialPath: viewModel.person.previewNavigationPath(),
+      searchPreviewDestinations: SearchViewUIPreviewDestinations(personViewModel: viewModel)
+    )
+  }
+}
+
+@MainActor
+private struct UIPreviewDetailSceneView: View {
+  let detailCase: UIPreviewDetailCase
+  @State private var media: MediaInfo
+
+  init(detailCase: UIPreviewDetailCase) {
+    self.detailCase = detailCase
+    _media = State(initialValue: UIPreviewFixtures.installDetail(detailCase))
+  }
+
+  var body: some View {
+    UIPreviewLoggedInRootView(
+      selectedTab: .home,
+      permissions: detailCase.permissions,
+      canRequestSuperUserEndpoints: detailCase.permissions.contains(.manage),
+      homeInitialPath: initialPath
+    )
+  }
+
+  private var initialPath: NavigationPath {
+    var path = NavigationPath()
+    path.append(media)
+    return path
+  }
+}
+
+@MainActor
+private struct UIPreviewSeasonSceneView: View {
+  let seasonCase: UIPreviewSeasonCase
+  @StateObject private var viewModel: SubscribeSeasonViewModel
+
+  init(seasonCase: UIPreviewSeasonCase) {
+    self.seasonCase = seasonCase
+    _viewModel = StateObject(wrappedValue: UIPreviewFixtures.seasonViewModel(seasonCase))
+  }
+
+  var body: some View {
+    UIPreviewLoggedInRootView(
+      selectedTab: .search,
+      searchInitialPath: SubscribeSeasonRequest(
+        mediaInfo: viewModel.mediaInfo,
+        initialSeason: nil
+      ).previewNavigationPath(),
+      searchPreviewDestinations: SearchViewUIPreviewDestinations(seasonViewModel: viewModel)
+    )
+    .onAppear {
+      UIPreviewFixtures.applyPermissions(seasonCase.permissions)
+    }
+  }
+}
+
+@MainActor
+private struct UIPreviewSearchSceneView: View {
+  let searchCase: UIPreviewSearchCase
+
+  var body: some View {
+    switch searchCase {
+    case .unifiedResults, .unifiedEmpty, .resourceLoading, .resourceResults, .resourceEmpty:
+      UIPreviewLoggedInRootView(selectedTab: .search, searchCase: searchCase)
+    case .resourcePageLoading, .resourcePageResults:
+      UIPreviewResourceResultScene(mode: searchCase.resourcePageMode)
+    }
+  }
+}
+
+@MainActor
+private struct UIPreviewResourceResultScene: View {
+  let mode: UIPreviewResourcePageMode
+
+  var body: some View {
+    let media = UIPreviewFixtures.baseTVMedia(id: 97_101, title: "边境信号")
+    let title = mode == .loading ? "边境信号 · 搜索中" : "边境信号 · 资源结果"
+    let request = ResourceSearchRequest(
+      keyword: "边境信号",
+      type: media.type,
+      area: nil,
+      title: title,
+      year: media.year,
+      season: nil,
+      mediaInfo: media,
+      sites: nil
+    )
+
+    UIPreviewLoggedInRootView(
+      selectedTab: .search,
+      searchInitialPath: request.previewNavigationPath(),
+      searchPreviewDestinations: SearchViewUIPreviewDestinations(
+        resourceResultViewModel: UIPreviewFixtures.resourceResultViewModel(mode)
+      )
+    )
+  }
+}
+
+@MainActor
+private struct UIPreviewStatusSceneView: View {
+  let statusCase: UIPreviewStatusCase
+
+  var body: some View {
+    switch statusCase {
+    case .statusEmpty, .statusFull:
+      UIPreviewLoggedInRootView(
+        selectedTab: .status,
+        statusMode: statusCase.statusMode,
+        downloadMode: statusCase == .statusEmpty ? .empty : .multiState,
+        transferMode: statusCase == .statusEmpty ? .empty : .aiRedoing
+      )
+    case .downloadEmpty, .downloadMultiState:
+      UIPreviewLoggedInRootView(
+        selectedTab: .status,
+        downloadMode: statusCase.downloadMode
+      )
+    case .transferLoading, .transferEmpty, .transferAiRedoing:
+      UIPreviewLoggedInRootView(
+        selectedTab: .status,
+        transferMode: statusCase.transferMode
+      )
+    case .transferDetail:
+      UIPreviewLoggedInRootView(
+        selectedTab: .status,
+        transferMode: .aiRedoing,
+        transferPresentation: .detail
+      )
+    }
+  }
+}
+
+@MainActor
+private struct UIPreviewSettingsSceneView: View {
+  let settingsCase: UIPreviewSettingsCase
+
+  var body: some View {
+    UIPreviewLoggedInRootView(
+      selectedTab: .system,
+      settingsCase: settingsCase,
+      permissions: settingsCase.permissions,
+      canRequestSuperUserEndpoints: settingsCase.canRequestSuperUserEndpoints,
+      systemPresentation: settingsCase.presentation
+    )
+  }
+}
+
+@MainActor
+private struct UIPreviewSheetSceneView: View {
+  let sheetCase: UIPreviewSheetCase
+
+  var body: some View {
+    switch sheetCase {
+    case .subscribe:
+      SubscribeSheet(previewViewModel: UIPreviewFixtures.subscribeSheetViewModel())
+        .previewRoot(sheetCase.title)
+        .onAppear { UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true) }
+    case .addDownload:
+      AddDownloadSheet(previewViewModel: UIPreviewFixtures.addDownloadViewModel())
+        .environmentObject(NotificationManager())
+        .previewRoot(sheetCase.title)
+        .onAppear { UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true) }
+    case .reorganize:
+      ReorganizeSheet(previewViewModel: UIPreviewFixtures.reorganizeViewModel()) {}
+        .environmentObject(NotificationManager())
+        .previewRoot(sheetCase.title)
+        .onAppear { UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true) }
+    case .reorganizeBatch:
+      ReorganizeSheet(previewViewModel: UIPreviewFixtures.reorganizeBatchViewModel()) {}
+        .environmentObject(NotificationManager())
+        .previewRoot(sheetCase.title)
+        .onAppear { UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true) }
+    case .forkSubscribe:
+      ForkSubscribeSheet(
+        share: UIPreviewFixtures.previewSubscribeShare,
+        onFork: { _ in },
+        subscriptionHandler: SubscriptionHandler()
+      )
+      .previewRoot(sheetCase.title)
+      .onAppear { UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true) }
+    case .seasonDetail:
+      SeasonDetailSheet(
+        season: UIPreviewFixtures.previewSeasonDetail,
+        mediaInfo: UIPreviewFixtures.baseTVMedia(id: 45_301, title: "边境信号")
+      )
+      .previewRoot(sheetCase.title)
+      .onAppear { UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true) }
+    case .multiSelection:
+      UIPreviewMultiSelectionSheet()
+        .previewRoot(sheetCase.title)
+        .onAppear { UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true) }
+    }
+  }
+}
+
+@MainActor
+private struct UIPreviewMultiSelectionSheet: View {
+  @State private var selected: Set<Int> = [1, 3]
+
+  var body: some View {
+    MultiSelectionSheet(
+      options: UIPreviewFixtures.sites,
+      id: \.id,
+      selected: $selected,
+      label: { $0.name },
+      disabledOptions: [5],
+      disabledOptionsTitle: "预览：当前搜索源不可用"
+    )
+  }
+}
+
+@MainActor
+private struct UIPreviewComponentSceneView: View {
+  let componentCase: UIPreviewComponentCase
+  @Binding var navigationPath: NavigationPath
+
+  var body: some View {
+    switch componentCase {
+    case .mediaCards:
+      NavigationStack(path: $navigationPath) {
+        UIPreviewMediaCards(navigationPath: $navigationPath)
+          .uiPreviewNavigationDestinations(path: $navigationPath)
+      }
+    case .torrentCards:
+      UIPreviewTorrentCards()
+        .previewRoot(componentCase.title)
+        .onAppear { UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true) }
+    case .pickers:
+      UIPreviewPickerComponents()
+        .previewRoot(componentCase.title)
+    case .notification:
+      UIPreviewNotificationComponents()
+        .previewRoot(componentCase.title)
+    }
+  }
+}
+
+private struct UIPreviewMediaCards: View {
+  @Binding var navigationPath: NavigationPath
+
+  var body: some View {
+    MediaGridView(
+      items: [
+        UIPreviewFixtures.movieMedia(id: 98_001, title: "长标题电影：跨越三行也不能挤坏焦点卡片"),
+        UIPreviewFixtures.baseTVMedia(id: 98_002, title: "无海报剧集", hasArtwork: false),
+        UIPreviewFixtures.collectionMedia(id: 98_003, title: "边境信号系列"),
+        UIPreviewFixtures.shareMedia(id: 98_004, title: "订阅分享卡片"),
+      ],
+      isLoading: false,
+      isLoadingMore: true,
+      onLoadMore: { _ in },
+      navigationPath: $navigationPath,
+      header: {
+        Text("媒体卡片 / 网格 / 加载更多")
+          .font(.largeTitle.bold())
+          .foregroundStyle(.secondary)
+      }
+    )
+  }
+}
+
+private struct UIPreviewTorrentCards: View {
+  var body: some View {
+    ScrollView {
+      LazyVGrid(columns: [GridItem(.adaptive(minimum: 500, maximum: 620), spacing: 36)], spacing: 36) {
+        ForEach(UIPreviewFixtures.contexts) { context in
+          TorrentCard(context: context, overrideMediaInfo: UIPreviewFixtures.baseTVMedia(id: 98_011, title: "边境信号"))
+        }
+      }
+      .padding(60)
+    }
+    .focusSection()
+  }
+}
+
+private struct UIPreviewPickerComponents: View {
+  @State private var selectedCategory: RecommendCategory = .movie
+  @State private var selectedShelf: RecommendShelf? = RecommendViewModel.allShelves.first
+  @State private var pickerSelection = "1080p"
+  @State private var text = "边境信号 S01E01"
+
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 40) {
+        CategoryPickerView(selectedCategory: $selectedCategory)
+
+        ShelfPicker(
+          shelves: RecommendViewModel.allShelves,
+          selectedShelf: $selectedShelf
+        )
+
+        VStack(spacing: 16) {
+          SheetPicker(
+            title: "分辨率",
+            selection: $pickerSelection,
+            options: [
+              PickerOption(title: "全部", value: ""),
+              PickerOption(title: "1080P", value: "1080p"),
+              PickerOption(title: "4K", value: "4k"),
+            ]
+          )
+          SheetTextField(title: "搜索词", placeholder: "输入关键字", text: $text)
+        }
+        .frame(width: 980)
+        .applySheetStyles()
+      }
+      .padding(80)
+    }
+    .focusSection()
+  }
+}
+
+private struct UIPreviewNotificationComponents: View {
+  @StateObject private var manager = NotificationManager()
+
+  var body: some View {
+    ZStack(alignment: .topTrailing) {
+      VStack(spacing: 24) {
+        NotificationView(message: "信息提示：正在使用 UI 预览目录", type: .info)
+        NotificationView(message: "成功提示：订阅已保存", type: .success)
+        NotificationView(message: "警告提示：站点响应较慢", type: .warning)
+        NotificationView(message: "错误提示：搜索任务失败", type: .error)
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+      Color.clear
+        .withNotification()
+        .environmentObject(manager)
+    }
+    .onAppear {
+      manager.show(message: "悬浮通知预览", type: .success, duration: 20)
+    }
+  }
+}
+
+@MainActor
+private struct UIPreviewPushedMediaDetailView: View {
+  let media: MediaInfo
+  @Binding var path: NavigationPath
+
+  init(media: MediaInfo, path: Binding<NavigationPath>) {
+    self.media = media
+    _path = path
+    UIPreviewFixtures.installReadyDetail(media)
+  }
+
+  var body: some View {
+    MediaDetailContainerView(media: media, navigationPath: $path)
+  }
+}
+
+private extension View {
+  func previewRoot(_ title: String) -> some View {
+    _ = title
+    return self
+  }
+
+  func uiPreviewNavigationDestinations(path: Binding<NavigationPath>) -> some View {
+    self
+      .navigationDestination(for: MediaInfo.self) { media in
+        UIPreviewPushedMediaDetailView(media: media, path: path)
+      }
+      .navigationDestination(for: Person.self) { person in
+        PersonDetailView(person: person, navigationPath: path)
+      }
+      .navigationDestination(for: ResourceSearchRequest.self) { request in
+        ResourceResultView(request: request)
+      }
+      .navigationDestination(for: SubscribeSeasonRequest.self) { request in
+        SubscribeSeasonView(
+          previewViewModel: UIPreviewFixtures.seasonViewModel(
+            mediaInfo: request.mediaInfo,
+            initialSeason: request.initialSeason
+          )
+        )
+      }
+  }
+}
+
+private extension Hashable {
+  func previewNavigationPath() -> NavigationPath {
+    var path = NavigationPath()
+    path.append(self)
+    return path
+  }
+}
+
+private struct UIPreviewSection: Identifiable {
+  let id: String
+  let title: String
+  let scenes: [UIPreviewScene]
+}
+
+private struct UIPreviewScene: Identifiable, Hashable {
+  let id: String
+  let title: String
+  let note: String
+  let kind: UIPreviewSceneKind
+}
+
+private enum UIPreviewSceneKind: Hashable {
+  case app(UIPreviewAppCase)
+  case page(UIPreviewPageCase)
+  case detail(UIPreviewDetailCase)
+  case season(UIPreviewSeasonCase)
+  case search(UIPreviewSearchCase)
+  case status(UIPreviewStatusCase)
+  case settings(UIPreviewSettingsCase)
+  case sheet(UIPreviewSheetCase)
+  case component(UIPreviewComponentCase)
+}
+
+private extension UIPreviewSceneKind {
+  var note: String {
+    switch self {
+    case .app(let previewCase):
+      return previewCase.note
+    case .page(let previewCase):
+      return previewCase.note
+    case .detail(let detailCase):
+      return detailCase.note
+    case .season(let seasonCase):
+      return seasonCase.note
+    case .search(let searchCase):
+      return searchCase.note
+    case .status(let statusCase):
+      return statusCase.note
+    case .settings(let settingsCase):
+      return settingsCase.note
+    case .sheet(let sheetCase):
+      return sheetCase.note
+    case .component(let componentCase):
+      return componentCase.note
+    }
+  }
+}
+
+private enum UIPreviewCatalog {
+  static var firstSceneID: String? {
+    sections.first?.scenes.first?.id
+  }
+
+  static let sections: [UIPreviewSection] = [
+    UIPreviewSection(
+      id: "app",
+      title: "App 入口 / Tab 页面",
+      scenes: [
+        scene(.app(.loggedIn), id: "app-loggedIn", title: "启动入口 · 正常已登录"),
+        scene(.app(.login), id: "app-login", title: "启动入口 · 登录页"),
+      ]
+    ),
+    UIPreviewSection(
+      id: "detail",
+      title: "详情页",
+      scenes: [
+        scene(.detail(.loading), id: "detail-loading", title: "详情页 · 加载中"),
+        scene(.detail(.tvWithSeasons), id: "detail-tvWithSeasons", title: "详情页 · 电视剧，有分季"),
+        scene(.detail(.tvWithoutSeasons), id: "detail-tvWithoutSeasons", title: "详情页 · 电视剧，无分季"),
+        scene(.detail(.seasonLoadFailed), id: "detail-seasonLoadFailed", title: "详情页 · 分季加载失败"),
+        scene(.detail(.noArtwork), id: "detail-noArtwork", title: "详情页 · 无海报 / 无背景图"),
+        scene(.detail(.noSubscribePermission), id: "detail-noSubscribePermission", title: "详情页 · 无订阅权限"),
+        scene(.detail(.noSearchPermission), id: "detail-noSearchPermission", title: "详情页 · 无搜索权限"),
+      ]
+    ),
+    UIPreviewSection(
+      id: "season",
+      title: "分季页",
+      scenes: [
+        scene(.season(.loading), id: "season-loading", title: "分季页 · 加载中"),
+        scene(.season(.seasons), id: "season-seasons", title: "分季页 · 普通多季"),
+        scene(.season(.empty), id: "season-empty", title: "分季页 · 空数据"),
+        scene(.season(.failed), id: "season-failed", title: "分季页 · 加载失败"),
+        scene(.season(.mixedSubscription), id: "season-mixedSubscription", title: "分季页 · 已订阅 / 缺集混合"),
+      ]
+    ),
+    UIPreviewSection(
+      id: "page",
+      title: "页面入口",
+      scenes: [
+        scene(.page(.homeLoading), id: "page-homeLoading", title: "首页 · 加载中"),
+        scene(.page(.homeEmpty), id: "page-homeEmpty", title: "首页 · 空数据"),
+        scene(.page(.homeFull), id: "page-homeFull", title: "首页 · 完整数据"),
+        scene(.page(.recommendLoading), id: "page-recommendLoading", title: "推荐 · 加载中"),
+        scene(.page(.recommendEmpty), id: "page-recommendEmpty", title: "推荐 · 空数据"),
+        scene(.page(.recommendFull), id: "page-recommendFull", title: "推荐 · 完整数据"),
+        scene(.page(.exploreTmdb), id: "page-exploreTmdb", title: "探索 · TMDB 筛选"),
+        scene(.page(.exploreShare), id: "page-exploreShare", title: "探索 · 订阅分享"),
+        scene(.page(.collectionLoading), id: "page-collectionLoading", title: "合集详情 · 加载中"),
+        scene(.page(.collectionFull), id: "page-collectionFull", title: "合集详情 · 完整数据"),
+        scene(.page(.personLoading), id: "page-personLoading", title: "人物详情 · 加载中"),
+        scene(.page(.personFull), id: "page-personFull", title: "人物详情 · 完整数据"),
+      ]
+    ),
+    UIPreviewSection(
+      id: "search",
+      title: "搜索链路",
+      scenes: [
+        scene(.search(.unifiedResults), id: "search-unifiedResults", title: "搜索 · 聚合结果"),
+        scene(.search(.unifiedEmpty), id: "search-unifiedEmpty", title: "搜索 · 聚合空结果"),
+        scene(.search(.resourceLoading), id: "search-resourceLoading", title: "搜索 · 资源加载中"),
+        scene(.search(.resourceResults), id: "search-resourceResults", title: "搜索 · 资源结果"),
+        scene(.search(.resourceEmpty), id: "search-resourceEmpty", title: "搜索 · 资源空结果"),
+        scene(.search(.resourcePageLoading), id: "search-resourcePageLoading", title: "资源结果页 · 加载中"),
+        scene(.search(.resourcePageResults), id: "search-resourcePageResults", title: "资源结果页 · 完整数据"),
+      ]
+    ),
+    UIPreviewSection(
+      id: "status",
+      title: "状态 / 任务",
+      scenes: [
+        scene(.status(.statusEmpty), id: "status-statusEmpty", title: "状态页 · 空权限 / 空数据"),
+        scene(.status(.statusFull), id: "status-statusFull", title: "状态页 · 完整数据"),
+        scene(.status(.downloadEmpty), id: "status-downloadEmpty", title: "下载任务 · 空数据"),
+        scene(.status(.downloadMultiState), id: "status-downloadMultiState", title: "下载任务 · 多状态任务"),
+        scene(.status(.transferLoading), id: "status-transferLoading", title: "整理历史 · 加载中"),
+        scene(.status(.transferEmpty), id: "status-transferEmpty", title: "整理历史 · 空数据"),
+        scene(.status(.transferAiRedoing), id: "status-transferAiRedoing", title: "整理历史 · 多选 / AI 整理中"),
+        scene(.status(.transferDetail), id: "status-transferDetail", title: "整理历史 · 详情弹窗"),
+      ]
+    ),
+    UIPreviewSection(
+      id: "settings",
+      title: "设置",
+      scenes: [
+        scene(.settings(.fullAccess), id: "settings-fullAccess", title: "设置 · 全权限"),
+        scene(.settings(.noSubscribe), id: "settings-noSubscribe", title: "设置 · 无订阅权限"),
+        scene(.settings(.noSearch), id: "settings-noSearch", title: "设置 · 无搜索权限"),
+        scene(.settings(.appInfo), id: "settings-appInfo", title: "设置 · APP 信息"),
+        scene(.settings(.logoutConfirmation), id: "settings-logoutConfirmation", title: "设置 · 退出登录确认"),
+      ]
+    ),
+    UIPreviewSection(
+      id: "sheet",
+      title: "弹窗",
+      scenes: [
+        scene(.sheet(.subscribe), id: "sheet-subscribe", title: "订阅弹窗 · 新增"),
+        scene(.sheet(.forkSubscribe), id: "sheet-forkSubscribe", title: "订阅分享弹窗 · 复用"),
+        scene(.sheet(.addDownload), id: "sheet-addDownload", title: "下载弹窗 · 添加下载"),
+        scene(.sheet(.reorganize), id: "sheet-reorganize", title: "整理弹窗 · 单项重整"),
+        scene(.sheet(.reorganizeBatch), id: "sheet-reorganizeBatch", title: "整理弹窗 · 批量重整"),
+        scene(.sheet(.seasonDetail), id: "sheet-seasonDetail", title: "分季详情弹窗"),
+        scene(.sheet(.multiSelection), id: "sheet-multiSelection", title: "多选弹窗 · 站点选择"),
+      ]
+    ),
+    UIPreviewSection(
+      id: "component",
+      title: "核心组件",
+      scenes: [
+        scene(.component(.mediaCards), id: "component-mediaCards", title: "组件 · 媒体卡片"),
+        scene(.component(.torrentCards), id: "component-torrentCards", title: "组件 · 种子卡片"),
+        scene(.component(.pickers), id: "component-pickers", title: "组件 · 选择器 / 输入框"),
+        scene(.component(.notification), id: "component-notification", title: "组件 · 通知"),
+      ]
+    ),
+  ]
+
+  private static func scene(
+    _ kind: UIPreviewSceneKind,
+    id: String,
+    title: String
+  ) -> UIPreviewScene {
+    UIPreviewScene(
+      id: id,
+      title: title,
+      note: kind.note,
+      kind: kind
+    )
+  }
+}
+
+private protocol UIPreviewCase: CaseIterable, Hashable, RawRepresentable where RawValue == String {
+  var title: String { get }
+  var note: String { get }
+}
+
+private enum UIPreviewAppCase: String, UIPreviewCase {
+  case loggedIn
+  case login
+
+  var title: String {
+    switch self {
+    case .loggedIn: return "启动入口 · 正常已登录"
+    case .login: return "启动入口 · 登录页"
+    }
+  }
+
+  var note: String {
+    switch self {
+    case .loggedIn: return "TabView 根入口，覆盖首页/推荐/探索/搜索/状态/设置焦点切换。"
+    case .login: return "未登录根入口，检查服务器地址、用户名、密码和登录按钮焦点。"
+    }
+  }
+}
+
+private enum UIPreviewHomeMode { case loading, empty, full }
+private enum UIPreviewRecommendMode { case loading, empty, full }
+private enum UIPreviewExploreMode { case tmdb, share }
+private enum UIPreviewCollectionMode { case loading, full }
+private enum UIPreviewPersonMode { case loading, full }
+
+private enum UIPreviewPageCase: String, UIPreviewCase {
+  case homeLoading
+  case homeEmpty
+  case homeFull
+  case recommendLoading
+  case recommendEmpty
+  case recommendFull
+  case exploreTmdb
+  case exploreShare
+  case collectionLoading
+  case collectionFull
+  case personLoading
+  case personFull
+
+  var title: String {
+    switch self {
+    case .homeLoading: return "首页 · 加载中"
+    case .homeEmpty: return "首页 · 空数据"
+    case .homeFull: return "首页 · 完整数据"
+    case .recommendLoading: return "推荐 · 加载中"
+    case .recommendEmpty: return "推荐 · 空数据"
+    case .recommendFull: return "推荐 · 完整数据"
+    case .exploreTmdb: return "探索 · TMDB 筛选"
+    case .exploreShare: return "探索 · 订阅分享"
+    case .collectionLoading: return "合集详情 · 加载中"
+    case .collectionFull: return "合集详情 · 完整数据"
+    case .personLoading: return "人物详情 · 加载中"
+    case .personFull: return "人物详情 · 完整数据"
+    }
+  }
+
+  var note: String {
+    switch self {
+    case .homeLoading: return "首页全屏 Loading，检查 Tab 切入后的焦点落点。"
+    case .homeEmpty: return "无最近添加、无电影订阅、无电视剧订阅。"
+    case .homeFull: return "最近添加服务器 Picker + 电影/电视剧订阅行 + 行操作菜单。"
+    case .recommendLoading: return "推荐页 Paginator 首次加载。"
+    case .recommendEmpty: return "推荐页分类/货架存在但网格为空。"
+    case .recommendFull: return "推荐页分类、货架和媒体网格完整组合。"
+    case .exploreTmdb: return "探索页 TheMovieDb 多 Picker 过滤器。"
+    case .exploreShare: return "探索页订阅分享源，卡片触发 Fork 入口。"
+    case .collectionLoading: return "合集详情真实根路径加载中。"
+    case .collectionFull: return "合集详情网格 + 详情导航。"
+    case .personLoading: return "人物详情简介加载占位 + 作品加载。"
+    case .personFull: return "人物详情头像/简介/作品网格。"
+    }
+  }
+
+  var homeMode: UIPreviewHomeMode {
+    switch self {
+    case .homeLoading: return .loading
+    case .homeEmpty: return .empty
+    default: return .full
+    }
+  }
+
+  var recommendMode: UIPreviewRecommendMode {
+    switch self {
+    case .recommendLoading: return .loading
+    case .recommendEmpty: return .empty
+    default: return .full
+    }
+  }
+
+  var exploreMode: UIPreviewExploreMode {
+    self == .exploreShare ? .share : .tmdb
+  }
+
+  var collectionMode: UIPreviewCollectionMode {
+    self == .collectionLoading ? .loading : .full
+  }
+
+  var personMode: UIPreviewPersonMode {
+    self == .personLoading ? .loading : .full
+  }
+}
+
+private enum UIPreviewDetailCase: String, UIPreviewCase {
+  case loading
+  case tvWithSeasons
+  case tvWithoutSeasons
+  case seasonLoadFailed
+  case noArtwork
+  case noSubscribePermission
+  case noSearchPermission
+
+  var title: String {
+    switch self {
+    case .loading: return "详情页 · 加载中"
+    case .tvWithSeasons: return "详情页 · 电视剧，有分季"
+    case .tvWithoutSeasons: return "详情页 · 电视剧，无分季"
+    case .seasonLoadFailed: return "详情页 · 分季加载失败"
+    case .noArtwork: return "详情页 · 无海报 / 无背景图"
+    case .noSubscribePermission: return "详情页 · 无订阅权限"
+    case .noSearchPermission: return "详情页 · 无搜索权限"
+    }
+  }
+
+  var note: String {
+    switch self {
+    case .loading: return "保持 Loading 遮罩，验证焦点不会落到下层详情。"
+    case .tvWithSeasons: return "Header 分季订阅 + 第二页分季横向 Shelf。"
+    case .tvWithoutSeasons: return "分季加载完成但为空，Header 显示不可用状态。"
+    case .seasonLoadFailed: return "分季区域保留错误 Banner，可关闭错误提示。"
+    case .noArtwork: return "背景和海报都为空，验证占位背景与文字可读性。"
+    case .noSubscribePermission: return "隐藏订阅入口，只保留搜索和 TMDB 跳转。"
+    case .noSearchPermission: return "隐藏搜索和站点筛选，只保留分季订阅。"
+    }
+  }
+
+  var permissions: Set<UserPermissionKey> {
+    switch self {
+    case .noSubscribePermission:
+      return [.discovery, .search, .manage]
+    case .noSearchPermission:
+      return [.discovery, .subscribe, .manage]
+    default:
+      return .allPreviewPermissions
+    }
+  }
+}
+
+private enum UIPreviewSeasonCase: String, UIPreviewCase {
+  case loading
+  case seasons
+  case empty
+  case failed
+  case mixedSubscription
+
+  var title: String {
+    switch self {
+    case .loading: return "分季页 · 加载中"
+    case .seasons: return "分季页 · 普通多季"
+    case .empty: return "分季页 · 空数据"
+    case .failed: return "分季页 · 加载失败"
+    case .mixedSubscription: return "分季页 · 已订阅 / 缺集混合"
+    }
+  }
+
+  var note: String {
+    switch self {
+    case .loading: return "Grid 根路径中的加载态。"
+    case .seasons: return "多季卡片、剧集组 Picker 和焦点重定向。"
+    case .empty: return "无季集信息空态。"
+    case .failed: return "错误 Banner + 空态组合。"
+    case .mixedSubscription: return "已订阅、完整入库、部分缺失、整季缺失组合。"
+    }
+  }
+
+  var permissions: Set<UserPermissionKey> {
+    .allPreviewPermissions
+  }
+}
+
+private enum UIPreviewResourcePageMode { case loading, results }
+
+private enum UIPreviewSearchCase: String, UIPreviewCase {
+  case unifiedResults
+  case unifiedEmpty
+  case resourceLoading
+  case resourceResults
+  case resourceEmpty
+  case resourcePageLoading
+  case resourcePageResults
+
+  var title: String {
+    switch self {
+    case .unifiedResults: return "搜索 · 聚合结果"
+    case .unifiedEmpty: return "搜索 · 聚合空结果"
+    case .resourceLoading: return "搜索 · 资源加载中"
+    case .resourceResults: return "搜索 · 资源结果"
+    case .resourceEmpty: return "搜索 · 资源空结果"
+    case .resourcePageLoading: return "资源结果页 · 加载中"
+    case .resourcePageResults: return "资源结果页 · 完整数据"
+    }
+  }
+
+  var note: String {
+    switch self {
+    case .unifiedResults: return "最佳结果、电影、电视剧、合集、人物、订阅分享多行组合。"
+    case .unifiedEmpty: return "搜索完成但没有任何聚合结果。"
+    case .resourceLoading: return "资源模式流式进度文案和进度条。"
+    case .resourceResults: return "资源模式结果筛选栏 + 种子卡片。"
+    case .resourceEmpty: return "资源模式搜索完成但无资源。"
+    case .resourcePageLoading: return "从详情/菜单进入的资源结果页加载中。"
+    case .resourcePageResults: return "资源结果页背景图 + 筛选栏 + 种子卡片。"
+    }
+  }
+
+  var resourcePageMode: UIPreviewResourcePageMode {
+    self == .resourcePageLoading ? .loading : .results
+  }
+}
+
+private enum UIPreviewStatusMode { case empty, full }
+private enum UIPreviewDownloadMode { case empty, multiState }
+private enum UIPreviewTransferMode { case loading, empty, aiRedoing }
+
+private enum UIPreviewStatusCase: String, UIPreviewCase {
+  case statusEmpty
+  case statusFull
+  case downloadEmpty
+  case downloadMultiState
+  case transferLoading
+  case transferEmpty
+  case transferAiRedoing
+  case transferDetail
+
+  var title: String {
+    switch self {
+    case .statusEmpty: return "状态页 · 空权限 / 空数据"
+    case .statusFull: return "状态页 · 完整数据"
+    case .downloadEmpty: return "下载任务 · 空数据"
+    case .downloadMultiState: return "下载任务 · 多状态任务"
+    case .transferLoading: return "整理历史 · 加载中"
+    case .transferEmpty: return "整理历史 · 空数据"
+    case .transferAiRedoing: return "整理历史 · 多选 / AI 整理中"
+    case .transferDetail: return "整理历史 · 详情弹窗"
+    }
+  }
+
+  var note: String {
+    switch self {
+    case .statusEmpty: return "统计、存储、下载器为空，任务列表为空。"
+    case .statusFull: return "统计卡、存储、下载器、下载任务、整理历史组合。"
+    case .downloadEmpty: return "下载任务标题区、下载器 Picker 和空态。"
+    case .downloadMultiState: return "下载中、暂停、错误、校验等状态徽标和 ActionRow。"
+    case .transferLoading: return "整理历史首次加载中。"
+    case .transferEmpty: return "整理历史空态。"
+    case .transferAiRedoing: return "多选、AI 整理中遮罩和行操作按钮。"
+    case .transferDetail: return "整理历史长按详情弹窗，检查路径、存储名和状态信息。"
+    }
+  }
+
+  var statusMode: UIPreviewStatusMode {
+    self == .statusEmpty ? .empty : .full
+  }
+
+  var downloadMode: UIPreviewDownloadMode {
+    self == .downloadEmpty ? .empty : .multiState
+  }
+
+  var transferMode: UIPreviewTransferMode {
+    switch self {
+    case .transferLoading: return .loading
+    case .transferEmpty: return .empty
+    default: return .aiRedoing
+    }
+  }
+}
+
+private enum UIPreviewSettingsCase: String, UIPreviewCase {
+  case fullAccess
+  case noSubscribe
+  case noSearch
+  case appInfo
+  case logoutConfirmation
+
+  var title: String {
+    switch self {
+    case .fullAccess: return "设置 · 全权限"
+    case .noSubscribe: return "设置 · 无订阅权限"
+    case .noSearch: return "设置 · 无搜索权限"
+    case .appInfo: return "设置 · APP 信息"
+    case .logoutConfirmation: return "设置 · 退出登录确认"
+    }
+  }
+
+  var note: String {
+    switch self {
+    case .fullAccess: return "订阅、详情页、搜索站点、自定义过滤、连接信息全部可见。"
+    case .noSubscribe: return "隐藏订阅设置，保留详情页和搜索设置。"
+    case .noSearch: return "隐藏资源搜索设置，保留订阅和详情页设置。"
+    case .appInfo: return "设置页 App 信息 Sheet，检查版本、兼容版本和链接行。"
+    case .logoutConfirmation: return "退出登录系统 Alert，检查取消/确认焦点。"
+    }
+  }
+
+  var permissions: Set<UserPermissionKey> {
+    switch self {
+    case .fullAccess, .appInfo, .logoutConfirmation: return .allPreviewPermissions
+    case .noSubscribe: return [.discovery, .search, .manage]
+    case .noSearch: return [.discovery, .subscribe, .manage]
+    }
+  }
+
+  var canRequestSuperUserEndpoints: Bool {
+    switch self {
+    case .fullAccess, .appInfo, .logoutConfirmation:
+      return true
+    case .noSubscribe, .noSearch:
+      return false
+    }
+  }
+
+  var presentation: SystemViewUIPreviewPresentation? {
+    switch self {
+    case .appInfo:
+      return .appInfo
+    case .logoutConfirmation:
+      return .logoutConfirmation
+    case .fullAccess, .noSubscribe, .noSearch:
+      return nil
+    }
+  }
+}
+
+private enum UIPreviewSheetCase: String, UIPreviewCase {
+  case subscribe
+  case forkSubscribe
+  case addDownload
+  case reorganize
+  case reorganizeBatch
+  case seasonDetail
+  case multiSelection
+
+  var title: String {
+    switch self {
+    case .subscribe: return "订阅弹窗 · 新增"
+    case .forkSubscribe: return "订阅分享弹窗 · 复用"
+    case .addDownload: return "下载弹窗 · 添加下载"
+    case .reorganize: return "整理弹窗 · 单项重整"
+    case .reorganizeBatch: return "整理弹窗 · 批量重整"
+    case .seasonDetail: return "分季详情弹窗"
+    case .multiSelection: return "多选弹窗 · 站点选择"
+    }
+  }
+
+  var note: String {
+    switch self {
+    case .subscribe: return "新增订阅表单、站点/下载器/保存路径/高级配置入口。"
+    case .forkSubscribe: return "订阅分享复用入口，检查海报、分享人和复用按钮焦点。"
+    case .addDownload: return "添加下载表单、种子信息、下载器、保存路径和 TMDB ID。"
+    case .reorganize: return "重新整理表单、目的存储、整理方式、剧集定位和高级配置。"
+    case .reorganizeBatch: return "整理历史批量重整表单，检查无单文件时的字段状态。"
+    case .seasonDetail: return "分季详情弹窗，检查海报、播出日期、评分和简介。"
+    case .multiSelection: return "多选 Sheet、禁用项说明和确认按钮焦点。"
+    }
+  }
+}
+
+private enum UIPreviewComponentCase: String, UIPreviewCase {
+  case mediaCards
+  case torrentCards
+  case pickers
+  case notification
+
+  var title: String {
+    switch self {
+    case .mediaCards: return "组件 · 媒体卡片"
+    case .torrentCards: return "组件 · 种子卡片"
+    case .pickers: return "组件 · 选择器 / 输入框"
+    case .notification: return "组件 · 通知"
+    }
+  }
+
+  var note: String {
+    switch self {
+    case .mediaCards: return "普通媒体、无图、合集、订阅分享、加载更多组合。"
+    case .torrentCards: return "免费、促销、软过滤、低做种等种子卡片组合。"
+    case .pickers: return "Segmented Picker、ShelfPicker、SheetPicker、SheetTextField。"
+    case .notification: return "信息/成功/警告/错误四类通知和悬浮提示。"
+    }
+  }
+}
+
+private extension Set where Element == UserPermissionKey {
+  static let allPreviewPermissions: Set<UserPermissionKey> = [.discovery, .search, .subscribe, .manage]
+}
+
+@MainActor
+private enum UIPreviewFixtures {
+  static func resetPreviewState() {
+    APIService.shared.uiPreviewPermissions = nil
+    APIService.shared.uiPreviewCanRequestSuperUserEndpoints = nil
+    MediaPreloader.shared.clearAll()
+  }
+
+  static func applyPermissions(
+    _ permissions: Set<UserPermissionKey>,
+    canRequestSuperUserEndpoints: Bool = true
+  ) {
+    APIService.shared.uiPreviewPermissions = permissions
+    APIService.shared.uiPreviewCanRequestSuperUserEndpoints = canRequestSuperUserEndpoints
+  }
+
+  @discardableResult
+  static func installDetail(_ detailCase: UIPreviewDetailCase) -> MediaInfo {
+    applyPermissions(
+      detailCase.permissions,
+      canRequestSuperUserEndpoints: detailCase.permissions.contains(.manage)
+    )
+    MediaPreloader.shared.clearAll()
+
+    let media = detailMedia(detailCase)
+    let task = MediaPreloadTask(partialMedia: media)
+
+    if detailCase != .loading {
+      task.fullDetail = media
+      task.isDetailReady = true
+      task.tmdbId = media.tmdb_id
+      task.isSubscribed = false
+    }
+
+    switch detailCase {
+    case .tvWithSeasons, .noArtwork, .noSearchPermission:
+      task.seasonViewModel = seasonViewModel(mediaInfo: media, initialSeason: nil, mode: .mixedSubscription)
+      task.isSeasonDataLoaded = true
+    case .tvWithoutSeasons:
+      task.seasonViewModel = seasonViewModel(mediaInfo: media, initialSeason: nil, mode: .empty)
+      task.isSeasonDataLoaded = true
+    case .seasonLoadFailed:
+      task.seasonViewModel = seasonViewModel(mediaInfo: media, initialSeason: nil, mode: .failed)
+      task.isSeasonDataLoaded = true
+    case .loading, .noSubscribePermission:
+      break
+    }
+
+    MediaPreloader.shared.installPreviewTask(task, for: media)
+    return media
+  }
+
+  static func installReadyDetail(_ media: MediaInfo) {
+    let task = MediaPreloadTask(partialMedia: media)
+    task.fullDetail = media
+    task.isDetailReady = true
+    task.tmdbId = media.tmdb_id
+    task.isSubscribed = false
+    MediaPreloader.shared.installPreviewTask(task, for: media)
+  }
+
+  static func homeViewModel(_ mode: UIPreviewHomeMode) -> HomeViewModel {
+    let viewModel = HomeViewModel()
+    switch mode {
+    case .loading:
+      viewModel.installUIPreviewData(
+        latestMediaByServer: [:],
+        selectedServer: "",
+        movieSubscriptions: [],
+        tvSubscriptions: [],
+        isLoading: true
+      )
+    case .empty:
+      viewModel.installUIPreviewData(
+        latestMediaByServer: [:],
+        selectedServer: "",
+        movieSubscriptions: [],
+        tvSubscriptions: [],
+        isLoading: false
+      )
+    case .full:
+      viewModel.installUIPreviewData(
+        latestMediaByServer: [
+          "Emby": mediaServerItems(prefix: "emby"),
+          "Plex": mediaServerItems(prefix: "plex"),
+        ],
+        selectedServer: "Emby",
+        movieSubscriptions: [
+          subscribe(id: 31_001, name: "沙丘：预言", type: "电影", state: "R", lack: nil),
+          subscribe(id: 31_002, name: "荒原长路", type: "电影", state: "S", lack: nil),
+        ],
+        tvSubscriptions: [
+          subscribe(id: 31_101, name: "边境信号", type: "电视剧", state: "R", lack: 3),
+          subscribe(id: 31_102, name: "海岸档案", type: "电视剧", state: "N", lack: 12),
+        ],
+        isLoading: false
+      )
+    }
+    return viewModel
+  }
+
+  static func recommendViewModel(_ mode: UIPreviewRecommendMode) -> RecommendViewModel {
+    let viewModel = RecommendViewModel(loadsAutomatically: false)
+    viewModel.selectedCategory = .movie
+    viewModel.selectedShelf = RecommendViewModel.allShelves.first { $0.category == .movie }
+    switch mode {
+    case .loading:
+      viewModel.installUIPreviewPaginator(.uiPreview(isFirstLoading: true))
+    case .empty:
+      viewModel.installUIPreviewPaginator(.uiPreview(items: []))
+    case .full:
+      viewModel.installUIPreviewPaginator(.uiPreview(items: previewMediaGrid, isLoadingMore: true))
+    }
+    return viewModel
+  }
+
+  static func exploreViewModel(_ mode: UIPreviewExploreMode) -> ExploreViewModel {
+    let viewModel = ExploreViewModel(loadsAutomatically: false)
+    switch mode {
+    case .tmdb:
+      viewModel.selectedSource = .themoviedb
+      viewModel.selectedType = .movies
+      viewModel.tmdbGenre = "878"
+      viewModel.tmdbLanguage = "ja"
+      viewModel.installUIPreviewPaginator(.uiPreview(items: previewMediaGrid, isLoadingMore: true))
+    case .share:
+      viewModel.selectedSource = .subscriptionShare
+      viewModel.selectedType = .tvs
+      viewModel.shareGenre = "10765"
+      viewModel.installUIPreviewPaginator(.uiPreview(items: [
+        shareMedia(id: 33_001, title: "高质量订阅分享 · 边境信号"),
+        shareMedia(id: 33_002, title: "整季打包分享 · 海岸档案"),
+      ]))
+    }
+    return viewModel
+  }
+
+  static func searchViewModel(_ searchCase: UIPreviewSearchCase) -> SearchViewModel {
+    let viewModel = SearchViewModel()
+    viewModel.siteFilter.availableSites = sites
+    viewModel.siteFilter.selectedSites = [1, 3]
+    switch searchCase {
+    case .unifiedResults:
+      let movies = [movieMedia(id: 34_001, title: "边境信号：序章")]
+      let tvShows = [baseTVMedia(id: 34_101, title: "边境信号")]
+      let collections = [collectionMedia(id: 34_201, title: "边境信号系列")]
+      let people = [person(id: 34_301, name: "林原真", character: "导演")]
+      let shares = [shareMedia(id: 34_401, title: "边境信号 订阅分享")]
+      viewModel.installUIPreviewUnifiedResults(
+        query: "边境信号",
+        movies: movies,
+        tvShows: tvShows,
+        collections: collections,
+        persons: people,
+        shares: shares,
+        bestResults: [.media(tvShows[0]), .person(people[0]), .media(shares[0])]
+      )
+    case .unifiedEmpty:
+      viewModel.installUIPreviewUnifiedEmpty(query: "没有结果的关键词")
+    case .resourceLoading:
+      viewModel.installUIPreviewResourceResults(
+        query: "边境信号",
+        results: [],
+        isLoading: true,
+        progressText: "正在搜索 3 个站点...",
+        progress: 45
+      )
+    case .resourceResults:
+      viewModel.installUIPreviewResourceResults(query: "边境信号", results: contexts)
+    case .resourceEmpty:
+      viewModel.installUIPreviewResourceResults(query: "没有资源的关键词", results: [])
+    case .resourcePageLoading, .resourcePageResults:
+      break
+    }
+    return viewModel
+  }
+
+  static func collectionViewModel(_ mode: UIPreviewCollectionMode) -> CollectionDetailViewModel {
+    switch mode {
+    case .loading:
+      return CollectionDetailViewModel(previewPaginator: .uiPreview(isFirstLoading: true))
+    case .full:
+      return CollectionDetailViewModel(previewPaginator: .uiPreview(items: previewMediaGrid))
+    }
+  }
+
+  static func personViewModel(_ mode: UIPreviewPersonMode) -> PersonDetailViewModel {
+    let previewPerson = person(
+      id: 35_001,
+      name: "林原真",
+      character: nil,
+      biography: mode == .loading ? nil : "长期活跃于科幻与悬疑题材的导演，作品以冷静的工业质感和细密的人物关系见长。这段长简介用于检查可聚焦简介卡片、Sheet 展开和多行文本。"
+    )
+    switch mode {
+    case .loading:
+      return PersonDetailViewModel(
+        person: previewPerson,
+        previewPaginator: .uiPreview(isFirstLoading: true),
+        isLoadingDetails: true
+      )
+    case .full:
+      return PersonDetailViewModel(
+        person: previewPerson,
+        previewPaginator: .uiPreview(items: previewMediaGrid),
+        isLoadingDetails: false
+      )
+    }
+  }
+
+  static func resourceResultViewModel(_ mode: UIPreviewResourcePageMode) -> ResourceResultViewModel {
+    ResourceResultViewModel(
+      previewTitle: "边境信号",
+      mediaInfo: baseTVMedia(id: 36_001, title: "边境信号"),
+      results: mode == .loading ? [] : contexts,
+      isLoading: mode == .loading,
+      progressText: "正在搜索默认站点...",
+      progress: 60
+    )
+  }
+
+  static func statusViewModel(_ mode: UIPreviewStatusMode) -> StatusViewModel {
+    let viewModel = StatusViewModel()
+    switch mode {
+    case .empty:
+      viewModel.installUIPreviewData(statistic: nil, storage: nil, downloader: nil)
+    case .full:
+      viewModel.installUIPreviewData(
+        statistic: Statistic(movie_count: 326, tv_count: 74, episode_count: 4821),
+        storage: Storage(total_storage: 16_000_000_000_000, used_storage: 11_200_000_000_000),
+        downloader: DownloaderInfo(
+          download_speed: 18_400_000,
+          upload_speed: 2_300_000,
+          download_size: 9_400_000_000,
+          upload_size: 18_800_000_000,
+          free_space: 2_500_000_000_000
+        )
+      )
+    }
+    return viewModel
+  }
+
+  static func downloadViewModel(_ mode: UIPreviewDownloadMode) -> DownloadTaskViewModel {
+    let viewModel = DownloadTaskViewModel()
+    viewModel.installUIPreviewData(
+      clients: downloaders,
+      selectedClient: "qb-main",
+      downloads: mode == .empty ? [] : downloads
+    )
+    return viewModel
+  }
+
+  static func transferHistoryViewModel(_ mode: UIPreviewTransferMode) -> TransferHistoryViewModel {
+    let viewModel = TransferHistoryViewModel()
+    switch mode {
+    case .loading:
+      viewModel.installUIPreviewData(items: [], isFirstLoading: true)
+    case .empty:
+      viewModel.installUIPreviewData(items: [], storageDict: ["local": "本地存储"])
+    case .aiRedoing:
+      viewModel.installUIPreviewData(
+        items: transferHistory,
+        storageDict: ["local": "本地存储", "nas": "NAS"],
+        selectedIds: [44_001, 44_002],
+        isAiRedoing: true,
+        aiRedoingIds: [44_001],
+        aiRedoProgressText: "正在重新整理 1 / 2"
+      )
+    }
+    return viewModel
+  }
+
+  static func systemViewModel(_ settingsCase: UIPreviewSettingsCase) -> SystemViewModel {
+    let viewModel = SystemViewModel()
+    viewModel.installUIPreviewData(
+      storageDescription: "已登录 (安全存储)",
+      serverURL: "http://moviepilot.local:3000",
+      username: "preview-user",
+      backendVersion: "v2.14.1",
+      availableSites: settingsCase == .noSearch ? [] : sites,
+      customFilterRules: settingsCase == .fullAccess ? customRules : [],
+      isRefreshing: false,
+      refreshMessage: "上次刷新成功"
+    )
+    return viewModel
+  }
+
+  static func subscribeSheetViewModel() -> SubscribeSheetViewModel {
+    let viewModel = SubscribeSheetViewModel(
+      subscribe: subscribe(id: 45_001, name: "边境信号", type: "电视剧", state: "S", lack: 6),
+      isNewSubscription: true
+    )
+    viewModel.installUIPreviewOptions(
+      sites: sites,
+      downloaders: downloaders,
+      directories: directories,
+      filterGroups: [FilterRuleGroup(name: "官组优先"), FilterRuleGroup(name: "体积过滤")],
+      episodeGroups: [
+        episodeGroup(id: "preview-main", name: "官方顺序"),
+        episodeGroup(id: "preview-alt", name: "播出顺序"),
+      ]
+    )
+    return viewModel
+  }
+
+  static func addDownloadViewModel() -> AddDownloadViewModel {
+    let viewModel = AddDownloadViewModel(
+      torrent: contexts[0].torrent_info!,
+      media: baseTVMedia(id: 45_101, title: "边境信号")
+    )
+    viewModel.installUIPreviewOptions(
+      downloaders: downloaders,
+      directories: directories,
+      selectedDownloader: "qb-main",
+      selectedDirectory: "/downloads/tv",
+      tmdbId: "90101"
+    )
+    return viewModel
+  }
+
+  static func reorganizeViewModel() -> ReorganizeViewModel {
+    let viewModel = ReorganizeViewModel(
+      logIds: [44_001],
+      fileItem: fileItem(name: "Frontier.Signal.S01E01.mkv", path: "/downloads/Frontier.Signal.S01E01.mkv"),
+      targetStorage: "local"
+    )
+    viewModel.form.type_name = "电视剧"
+    viewModel.form.tmdbid = 90_101
+    viewModel.form.season = 1
+    viewModel.form.episode_detail = "1"
+    viewModel.installUIPreviewConfig(
+      directories: directories,
+      storages: storages,
+      targetDirectoryOptions: [
+        PickerOption(title: "自动", value: ""),
+        PickerOption(title: "/media/TV", value: "/media/TV"),
+        PickerOption(title: "/media/Movies", value: "/media/Movies"),
+      ]
+    )
+    return viewModel
+  }
+
+  static func reorganizeBatchViewModel() -> ReorganizeViewModel {
+    let viewModel = ReorganizeViewModel(logIds: [44_001, 44_002], fileItem: nil)
+    viewModel.form.type_name = "电视剧"
+    viewModel.form.tmdbid = 90_101
+    viewModel.form.season = 1
+    viewModel.installUIPreviewConfig(
+      directories: directories,
+      storages: storages,
+      targetDirectoryOptions: [
+        PickerOption(title: "自动", value: ""),
+        PickerOption(title: "/media/TV", value: "/media/TV"),
+        PickerOption(title: "/media/Movies", value: "/media/Movies"),
+      ]
+    )
+    return viewModel
+  }
+
+  static func seasonViewModel(_ seasonCase: UIPreviewSeasonCase) -> SubscribeSeasonViewModel {
+    applyPermissions(seasonCase.permissions)
+    return seasonViewModel(mediaInfo: baseTVMedia(id: 91_100, title: "分季预览剧集"), initialSeason: nil, mode: seasonCase)
+  }
+
+  static func seasonViewModel(
+    mediaInfo: MediaInfo,
+    initialSeason: Int?
+  ) -> SubscribeSeasonViewModel {
+    seasonViewModel(mediaInfo: mediaInfo, initialSeason: initialSeason, mode: .mixedSubscription)
+  }
+
+  private static func seasonViewModel(
+    mediaInfo: MediaInfo,
+    initialSeason: Int?,
+    mode: UIPreviewSeasonCase
+  ) -> SubscribeSeasonViewModel {
+    let viewModel = SubscribeSeasonViewModel(mediaInfo: mediaInfo, initialSeason: initialSeason)
+
+    switch mode {
+    case .loading:
+      viewModel.isLoading = true
+    case .seasons:
+      viewModel.episodeGroups = [episodeGroup(id: "preview-main", name: "官方顺序")]
+      viewModel.seasonInfos = previewSeasons
+      viewModel.seasonsNotExisted = [:]
+      viewModel.isSeasonAvailabilityLoaded = true
+    case .empty:
+      viewModel.seasonInfos = []
+      viewModel.isSeasonAvailabilityLoaded = true
+    case .failed:
+      viewModel.hasSeasonLoadError = true
+      viewModel.errorMessage = "预览：分季接口加载失败"
+      viewModel.isSeasonAvailabilityLoaded = true
+    case .mixedSubscription:
+      viewModel.episodeGroups = [
+        episodeGroup(id: "preview-main", name: "官方顺序"),
+        episodeGroup(id: "preview-alt", name: "播出顺序"),
+      ]
+      viewModel.seasonInfos = previewSeasons
+      viewModel.seasonsNotExisted = [1: 0, 2: 1, 3: 2]
+      viewModel.isSeasonAvailabilityLoaded = true
+      viewModel.seasonSubscriptions = [
+        1: SeasonSubscriptionSummary(id: 90_001, season: 1, episodeGroup: nil)
+      ]
+      viewModel.subscribedSeasons = [1]
+    }
+
+    return viewModel
+  }
+
+  private static func detailMedia(_ detailCase: UIPreviewDetailCase) -> MediaInfo {
+    switch detailCase {
+    case .loading:
+      return baseTVMedia(id: 90_001, title: "边境信号 · 加载中")
+    case .tvWithSeasons:
+      return baseTVMedia(id: 90_002, title: "边境信号")
+    case .tvWithoutSeasons:
+      return baseTVMedia(id: 90_003, title: "边境信号 · 无分季")
+    case .seasonLoadFailed:
+      return baseTVMedia(id: 90_004, title: "边境信号 · 分季失败")
+    case .noArtwork:
+      return baseTVMedia(id: 90_005, title: "边境信号 · 无图", hasArtwork: false)
+    case .noSubscribePermission:
+      return baseTVMedia(id: 90_006, title: "边境信号 · 无订阅权限")
+    case .noSearchPermission:
+      return baseTVMedia(id: 90_007, title: "边境信号 · 无搜索权限")
+    }
+  }
+
+  static func baseTVMedia(
+    id: Int,
+    title: String,
+    hasArtwork: Bool = true
+  ) -> MediaInfo {
+    MediaInfo(
+      tmdb_id: id,
+      source: "themoviedb",
+      title: title,
+      original_title: "Frontier Signal",
+      names: ["Frontier Signal", "边境信号"],
+      type: "电视剧",
+      year: "2026",
+      poster_path: hasArtwork ? "https://image.tmdb.org/t/p/w500/8cdWjvZQUExUUTzyp4t6EDMubfO.jpg" : nil,
+      backdrop_path: hasArtwork ? "https://image.tmdb.org/t/p/original/3V4kLQg0kSqPLctI5ziYWabAZYF.jpg" : nil,
+      overview: "一支深空维护小队在边境航道收到异常信号，必须在有限补给和分裂意见中决定是否继续追踪。",
+      vote_average: 8.4,
+      popularity: 125,
+      directors: [person(id: 70_001, name: "林原真")],
+      actors: [
+        person(id: 70_002, name: "高桥遥", character: "领航员"),
+        person(id: 70_003, name: "陈述", character: "工程师"),
+      ],
+      release_date: "2026-01-12",
+      original_language: "ja",
+      production_countries: [country("日本")],
+      genres: [genre("科幻"), genre("冒险")],
+      category: "剧集"
+    )
+  }
+
+  static func movieMedia(id: Int, title: String, hasArtwork: Bool = true) -> MediaInfo {
+    MediaInfo(
+      tmdb_id: id,
+      source: "themoviedb",
+      title: title,
+      original_title: "Long Road",
+      type: "电影",
+      year: "2025",
+      poster_path: hasArtwork ? "https://image.tmdb.org/t/p/w500/8cdWjvZQUExUUTzyp4t6EDMubfO.jpg" : nil,
+      backdrop_path: hasArtwork ? "https://image.tmdb.org/t/p/original/3V4kLQg0kSqPLctI5ziYWabAZYF.jpg" : nil,
+      overview: "用于预览电影卡片、详情跳转和订阅操作。",
+      vote_average: 7.7,
+      popularity: 88,
+      genres: [genre("剧情")]
+    )
+  }
+
+  static func collectionMedia(id: Int, title: String) -> MediaInfo {
+    MediaInfo(
+      tmdb_id: id,
+      source: "themoviedb",
+      title: title,
+      type: "合集",
+      year: "2026",
+      poster_path: "https://image.tmdb.org/t/p/w500/8cdWjvZQUExUUTzyp4t6EDMubfO.jpg",
+      backdrop_path: "https://image.tmdb.org/t/p/original/3V4kLQg0kSqPLctI5ziYWabAZYF.jpg",
+      overview: "合集预览",
+      vote_average: 8.2,
+      popularity: 55,
+      collection_id: id
+    )
+  }
+
+  static func shareMedia(id: Int, title: String) -> MediaInfo {
+    MediaInfo(
+      tmdb_id: id,
+      source: "themoviedb",
+      title: title,
+      type: "电视剧",
+      year: "2026",
+      poster_path: "https://image.tmdb.org/t/p/w500/8cdWjvZQUExUUTzyp4t6EDMubfO.jpg",
+      overview: "来自 preview-user 的订阅分享，复用 128 次。",
+      vote_average: 8.8,
+      popularity: 128,
+      subscribeShare: subscribeShare(id: id, title: title)
+    )
+  }
+
+  private static var previewMediaGrid: [MediaInfo] {
+    [
+      movieMedia(id: 80_001, title: "荒原长路"),
+      baseTVMedia(id: 80_002, title: "边境信号"),
+      movieMedia(id: 80_003, title: "无海报电影", hasArtwork: false),
+      collectionMedia(id: 80_004, title: "边境信号系列"),
+      shareMedia(id: 80_005, title: "订阅分享：边境信号"),
+      baseTVMedia(id: 80_006, title: "标题很长很长的剧集名称用于检查卡片文字截断和焦点缩放"),
+    ]
+  }
+
+  private static func mediaServerItems(prefix: String) -> [MediaServerPlayItem] {
+    [
+      MediaServerPlayItem(
+        id: "\(prefix)-1",
+        title: "边境信号",
+        subtitle: "2026",
+        type: "电视剧",
+        image: "https://image.tmdb.org/t/p/w500/8cdWjvZQUExUUTzyp4t6EDMubfO.jpg",
+        link: "emby://items/1",
+        server_type: .emby
+      ),
+      MediaServerPlayItem(
+        id: "\(prefix)-2",
+        title: "荒原长路",
+        subtitle: "2025",
+        type: "电影",
+        image: nil,
+        link: "emby://items/2",
+        server_type: .emby
+      ),
+    ]
+  }
+
+  private static var previewSeasons: [TmdbSeason] {
+    [
+      season(number: 1, name: "第 1 季", episodes: 12, vote: 8.5),
+      season(number: 2, name: "第 2 季", episodes: 10, vote: 8.1),
+      season(number: 3, name: "特别篇", episodes: 0, vote: 0),
+    ]
+  }
+
+  static var previewSeasonDetail: TmdbSeason {
+    season(number: 1, name: "第 1 季", episodes: 12, vote: 8.5)
+  }
+
+  static var sites: [Site] {
+    [
+      Site(id: 1, name: "AlphaPT", domain: "alpha", url: "https://alpha.example", downloader: "qb-main", is_active: FlexibleBool(true)),
+      Site(id: 3, name: "BetaHD", domain: "beta", url: "https://beta.example", downloader: "tr-main", is_active: FlexibleBool(true)),
+      Site(id: 5, name: "维护中站点", domain: "offline", url: "https://offline.example", downloader: nil, is_active: FlexibleBool(false)),
+    ]
+  }
+
+  private static var downloaders: [DownloaderConf] {
+    [
+      DownloaderConf(name: "qb-main", type: "qbittorrent", enabled: FlexibleBool(true)),
+      DownloaderConf(name: "tr-main", type: "transmission", enabled: FlexibleBool(true)),
+    ]
+  }
+
+  private static var directories: [TransferDirectoryConf] {
+    [
+      TransferDirectoryConf(
+        name: "电视剧",
+        storage: "local",
+        download_path: "/downloads/tv",
+        library_path: "/media/TV",
+        library_storage: "local",
+        transfer_type: "link",
+        scraping: FlexibleBool(true),
+        library_category_folder: FlexibleBool(true),
+        library_type_folder: FlexibleBool(true)
+      ),
+      TransferDirectoryConf(
+        name: "电影",
+        storage: "nas",
+        download_path: "/downloads/movie",
+        library_path: "/media/Movies",
+        library_storage: "nas",
+        transfer_type: "copy",
+        scraping: FlexibleBool(true),
+        library_category_folder: FlexibleBool(false),
+        library_type_folder: FlexibleBool(true)
+      ),
+    ]
+  }
+
+  private static var storages: [StorageConf] {
+    [
+      StorageConf(name: "本地存储", type: "local"),
+      StorageConf(name: "NAS", type: "nas"),
+    ]
+  }
+
+  private static var customRules: [CustomRule] {
+    [
+      CustomRule(id: "rule-hard", name: "硬过滤：排除低清", include: "1080p|2160p", exclude: "CAM|TS", size_range: "1024-51200", seeders: "5", publish_time: nil),
+      CustomRule(id: "rule-soft", name: "软过滤：官组优先", include: "Alpha|Beta", exclude: nil, size_range: nil, seeders: nil, publish_time: "10080"),
+    ]
+  }
+
+  static var contexts: [Context] {
+    [
+      context(index: 1, title: "Frontier.Signal.S01E01.2160p.WEB-DL.DV.HDR.HEVC-Alpha", site: "AlphaPT", size: 8_600_000_000, seeders: 42, filtered: false),
+      context(index: 2, title: "Frontier.Signal.S01E02.1080p.WEB-DL.H264-Beta", site: "BetaHD", size: 3_200_000_000, seeders: 7, filtered: false),
+      context(index: 3, title: "Frontier.Signal.S01E03.720p.HDTV-LowSeeds", site: "Gamma", size: 1_400_000_000, seeders: 1, filtered: true),
+    ]
+  }
+
+  static var previewSubscribeShare: SubscribeShare {
+    subscribeShare(id: 46_001, title: "边境信号 · 高质量订阅分享")
+  }
+
+  private static var downloads: [DownloadingInfo] {
+    [
+      downloading(hash: "hash-1", title: "Frontier.Signal.S01E01.2160p", state: "downloading", progress: 72, dlspeed: "18.4 MB", left: "12 分钟"),
+      downloading(hash: "hash-2", title: "Long.Road.2025.1080p", state: "paused", progress: 35, dlspeed: "0 B", left: "暂停"),
+      downloading(hash: "hash-3", title: "Coast.Archive.S02E04.1080p", state: "error", progress: 91, dlspeed: "0 B", left: "错误"),
+      downloading(hash: "hash-4", title: "Checking.File.S01E02", state: "checking", progress: 8, dlspeed: "0 B", left: "校验中"),
+    ]
+  }
+
+  private static var transferHistory: [TransferHistory] {
+    [
+      transfer(id: 44_001, title: "边境信号", status: true, mode: "link"),
+      transfer(id: 44_002, title: "荒原长路", status: false, mode: "copy"),
+      transfer(id: 44_003, title: "海岸档案", status: true, mode: "softlink"),
+    ]
+  }
+
+  private static func subscribe(
+    id: Int,
+    name: String,
+    type: String,
+    state: String,
+    lack: Int?
+  ) -> Subscribe {
+    Subscribe(
+      id: id,
+      name: name,
+      year: "2026",
+      type: type,
+      poster: "https://image.tmdb.org/t/p/w500/8cdWjvZQUExUUTzyp4t6EDMubfO.jpg",
+      vote: 8.4,
+      state: state,
+      last_update: "2026-07-03 10:20:00",
+      tmdbid: id,
+      best_version: 1,
+      total_episode: type == "电视剧" ? 12 : nil,
+      start_episode: type == "电视剧" ? 1 : nil,
+      lack_episode: lack,
+      quality: "WEB-DL",
+      resolution: "1080[pi]|x1080",
+      include: "Alpha",
+      sites: [1, 3],
+      downloader: "qb-main",
+      save_path: "/downloads/tv",
+      description: "预览订阅描述"
+    )
+  }
+
+  private static func subscribeShare(id: Int, title: String) -> SubscribeShare {
+    decode(
+      SubscribeShare.self,
+      """
+      {
+        "id": \(id),
+        "share_title": "\(title)",
+        "share_comment": "预览订阅分享说明",
+        "share_user": "preview-user",
+        "share_uid": "preview",
+        "name": "\(title)",
+        "year": "2026",
+        "type": "电视剧",
+        "tmdbid": \(id),
+        "poster": "https://image.tmdb.org/t/p/w500/8cdWjvZQUExUUTzyp4t6EDMubfO.jpg",
+        "vote": 8.8,
+        "count": 128
+      }
+      """
+    )
+  }
+
+  private static func season(number: Int, name: String, episodes: Int, vote: Double) -> TmdbSeason {
+    decode(
+      TmdbSeason.self,
+      """
+      {
+        "air_date": "2026-01-\(String(format: "%02d", min(number, 9)))",
+        "episode_count": \(episodes),
+        "name": "\(name)",
+        "overview": "预览用分季描述，用于检查长文本、评分、缺集徽标和焦点状态。",
+        "poster_path": "/8cdWjvZQUExUUTzyp4t6EDMubfO.jpg",
+        "season_number": \(number),
+        "vote_average": \(vote)
+      }
+      """
+    )
+  }
+
+  private static func episodeGroup(id: String, name: String) -> EpisodeGroup {
+    decode(
+      EpisodeGroup.self,
+      """
+      {
+        "id": "\(id)",
+        "name": "\(name)",
+        "group_count": 3,
+        "episode_count": 22
+      }
+      """
+    )
+  }
+
+  private static func person(
+    id: Int,
+    name: String,
+    character: String? = nil,
+    biography: String? = nil
+  ) -> Person {
+    let characterLine = character.map { #","character":"\#($0)""# } ?? ""
+    let biographyLine = biography.map { #","biography":"\#($0)""# } ?? ""
+    return decode(
+      Person.self,
+      """
+      {
+        "source": "themoviedb",
+        "id": \(id),
+        "name": "\(name)",
+        "original_name": "Makoto Hayashibara",
+        "profile_path": "/r3A7ev7QkjOGocVn3kQrJ0eOouk.jpg",
+        "birthday": "1982-04-11",
+        "place_of_birth": "Tokyo, Japan",
+        "popularity": 12.3\(characterLine)\(biographyLine)
+      }
+      """
+    )
+  }
+
+  private static func context(
+    index: Int,
+    title: String,
+    site: String,
+    size: Int64,
+    seeders: Int,
+    filtered: Bool
+  ) -> Context {
+    var result = Context(
+      media_info: baseTVMedia(id: 81_000 + index, title: "边境信号"),
+      torrent_info: TorrentInfo(
+        site: index,
+        site_name: site,
+        site_order: index,
+        title: title,
+        description: "预览资源描述，包含字幕、杜比视界和多版本信息。",
+        enclosure: "https://example.com/\(index).torrent",
+        page_url: "https://example.com/torrents/\(index)",
+        size: size,
+        seeders: seeders,
+        peers: max(seeders * 2, 1),
+        pubdate: "2026-07-0\(index) 10:00:00",
+        uploadvolumefactor: index == 1 ? 2 : 1,
+        downloadvolumefactor: index == 1 ? 0 : 1,
+        pri_order: 10 - index,
+        labels: ["preview"],
+        volume_factor: index == 1 ? "Free" : nil
+      ),
+      meta_info: MetaInfo(
+        title: "Frontier Signal",
+        year: "2026",
+        resource_team: index == 3 ? "LowSeeds" : "Alpha",
+        video_encode: index == 1 ? "HEVC" : "H264",
+        resource_pix: index == 1 ? "2160p" : "1080p",
+        name: "边境信号",
+        season_episode: "S01E0\(index)",
+        subtitle: "简繁字幕",
+        web_source: "WEB-DL",
+        edition: index == 1 ? "DV HDR" : "SDR",
+        total_season: 1,
+        total_episode: 12
+      )
+    )
+    result.isFilteredOut = filtered
+    return result
+  }
+
+  private static func downloading(
+    hash: String,
+    title: String,
+    state: String,
+    progress: Double,
+    dlspeed: String,
+    left: String
+  ) -> DownloadingInfo {
+    decode(
+      DownloadingInfo.self,
+      """
+      {
+        "hash": "\(hash)",
+        "title": "\(title)",
+        "name": "边境信号",
+        "state": "\(state)",
+        "progress": \(progress),
+        "dlspeed": "\(dlspeed)",
+        "upspeed": "2.1 MB",
+        "size": 8600000000,
+        "left_time": "\(left)",
+        "season_episode": "S01E01",
+        "username": "preview",
+        "media": {
+          "image": "https://image.tmdb.org/t/p/original/3V4kLQg0kSqPLctI5ziYWabAZYF.jpg",
+          "title": "边境信号",
+          "season": "S01",
+          "episode": "E01"
+        }
+      }
+      """
+    )
+  }
+
+  private static func transfer(id: Int, title: String, status: Bool, mode: String) -> TransferHistory {
+    decode(
+      TransferHistory.self,
+      """
+      {
+        "id": \(id),
+        "title": "\(title)",
+        "type": "电视剧",
+        "seasons": "S01",
+        "episodes": "E01",
+        "category": "科幻",
+        "src": "/downloads/\(title).mkv",
+        "dest": "/media/TV/\(title)/S01E01.mkv",
+        "src_storage": "local",
+        "dest_storage": "nas",
+        "mode": "\(mode)",
+        "status": \(status),
+        "errmsg": \(status ? "null" : "\"预览：目标文件已存在\""),
+        "src_fileitem": {
+          "name": "\(title).mkv",
+          "path": "/downloads/\(title).mkv",
+          "type": "file",
+          "size": 8600000000
+        },
+        "date": "2026-07-03 10:20:00"
+      }
+      """
+    )
+  }
+
+  private static func fileItem(name: String, path: String) -> FileItem {
+    FileItem(name: name, path: path, type: "file", size: 8_600_000_000)
+  }
+
+  private static func genre(_ name: String) -> MediaGenre {
+    decode(MediaGenre.self, "\"\(name)\"")
+  }
+
+  private static func country(_ name: String) -> ProductionCountry {
+    decode(ProductionCountry.self, "\"\(name)\"")
+  }
+
+  private static func decode<T: Decodable>(_ type: T.Type, _ json: String) -> T {
+    guard let data = json.data(using: .utf8) else {
+      fatalError("Invalid UI preview fixture")
+    }
+    do {
+      return try JSONDecoder().decode(type, from: data)
+    } catch {
+      fatalError("Invalid UI preview fixture for \(type): \(error)")
+    }
+  }
+}
+#endif

--- a/MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift
+++ b/MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift
@@ -7,20 +7,22 @@ struct PreviewCatalogView: View {
   @State private var didResetPreviewState = false
 
   var body: some View {
-    Group {
+    ZStack {
+      NavigationStack {
+        UIPreviewCatalogHomeView(isActive: selectedScene == nil) { scene in
+          selectedScene = scene
+        }
+        .navigationTitle("UI 预览")
+      }
+      .opacity(selectedScene == nil ? 1 : 0)
+      .disabled(selectedScene != nil)
+
       if let selectedScene {
         UIPreviewSceneDestination(scene: selectedScene)
           .id(selectedScene.id)
           .onExitCommand {
             self.selectedScene = nil
           }
-      } else {
-        NavigationStack {
-          UIPreviewCatalogHomeView { scene in
-            selectedScene = scene
-          }
-          .navigationTitle("UI 预览")
-        }
       }
     }
     .mediaActionAlerts()
@@ -35,72 +37,69 @@ struct PreviewCatalogView: View {
 }
 
 private struct UIPreviewCatalogHomeView: View {
+  let isActive: Bool
   let selectScene: (UIPreviewScene) -> Void
-  @FocusState private var focusedSceneID: String?
+  @State private var expandedSectionIDs: Set<String> = []
+  @State private var lastFocusedControlID: String?
+  @FocusState private var focusedControlID: String?
 
   var body: some View {
     ScrollView {
       VStack(alignment: .leading, spacing: 34) {
         ForEach(UIPreviewCatalog.sections) { section in
           VStack(alignment: .leading, spacing: 14) {
-            Text(section.title)
-              .font(.title3.bold())
-              .foregroundStyle(.secondary)
+            Button {
+              toggleSection(section.id)
+            } label: {
+              Label(section.title, systemImage: expandedSectionIDs.contains(section.id) ? "chevron.down" : "chevron.right")
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .focused($focusedControlID, equals: section.id)
 
-            VStack(spacing: 10) {
-              ForEach(section.scenes) { scene in
-                let isFocused = focusedSceneID == scene.id
-
-                Button {
-                  selectScene(scene)
-                } label: {
-                  VStack(alignment: .leading, spacing: 8) {
-                    Text(scene.title)
-                      .font(.headline)
-                      .foregroundStyle(isFocused ? .black : .primary)
-                    Text(scene.note)
-                      .font(.caption)
-                      .foregroundStyle(isFocused ? .black.opacity(0.65) : .secondary)
+            if expandedSectionIDs.contains(section.id) {
+              VStack(spacing: 10) {
+                ForEach(section.scenes) { scene in
+                  Button {
+                    lastFocusedControlID = scene.id
+                    selectScene(scene)
+                  } label: {
+                    VStack(alignment: .leading) {
+                      Text(scene.title)
+                      Text(scene.note)
+                        .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                   }
-                  .frame(maxWidth: .infinity, alignment: .leading)
+                  .focused($focusedControlID, equals: scene.id)
                 }
-                .buttonStyle(UIPreviewCatalogButtonStyle())
-                .focused($focusedSceneID, equals: scene.id)
               }
             }
           }
         }
       }
-      .padding(.horizontal, 96)
+      .frame(width: 760, alignment: .leading)
       .padding(.vertical, 60)
+      .frame(maxWidth: .infinity, alignment: .center)
     }
     .onAppear {
-      focusedSceneID = focusedSceneID ?? UIPreviewCatalog.firstSceneID
+      focusedControlID = focusedControlID ?? UIPreviewCatalog.firstSectionID
+      lastFocusedControlID = lastFocusedControlID ?? focusedControlID
+    }
+    .onChange(of: focusedControlID) { _, newValue in
+      lastFocusedControlID = newValue ?? lastFocusedControlID
+    }
+    .onChange(of: isActive) { _, isActive in
+      guard isActive else { return }
+      focusedControlID = lastFocusedControlID ?? focusedControlID ?? UIPreviewCatalog.firstSectionID
     }
   }
-}
 
-private struct UIPreviewCatalogButtonStyle: ButtonStyle {
-  @Environment(\.isFocused) private var isFocused
-
-  func makeBody(configuration: Configuration) -> some View {
-    configuration.label
-      .padding(.horizontal, 26)
-      .padding(.vertical, 18)
-      .background {
-        RoundedRectangle(cornerRadius: 8, style: .continuous)
-          .fill(backgroundColor(isPressed: configuration.isPressed))
-      }
-      .scaleEffect(isFocused && !configuration.isPressed ? 1.02 : 1.0)
-      .animation(.easeOut(duration: 0.18), value: isFocused)
-      .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
-  }
-
-  private func backgroundColor(isPressed: Bool) -> Color {
-    if isFocused {
-      return .white
+  private func toggleSection(_ sectionID: String) {
+    if expandedSectionIDs.contains(sectionID) {
+      expandedSectionIDs.remove(sectionID)
+    } else {
+      expandedSectionIDs.insert(sectionID)
     }
-    return .white.opacity(isPressed ? 0.12 : 0.04)
   }
 }
 
@@ -504,6 +503,7 @@ private struct UIPreviewSettingsSceneView: View {
 @MainActor
 private struct UIPreviewSheetSceneView: View {
   let sheetCase: UIPreviewSheetCase
+  @State private var isSheetPresented = true
 
   init(sheetCase: UIPreviewSheetCase) {
     self.sheetCase = sheetCase
@@ -511,6 +511,21 @@ private struct UIPreviewSheetSceneView: View {
   }
 
   var body: some View {
+    VStack(spacing: 24) {
+      Text(sheetCase.title)
+        .font(.title)
+      Button("打开弹窗") {
+        isSheetPresented = true
+      }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .sheet(isPresented: $isSheetPresented) {
+      sheetContent
+    }
+  }
+
+  @ViewBuilder
+  private var sheetContent: some View {
     switch sheetCase {
     case .subscribe:
       SubscribeSheet(previewViewModel: UIPreviewFixtures.subscribeSheetViewModel())
@@ -671,6 +686,7 @@ private struct UIPreviewPickerComponents: View {
 
 private struct UIPreviewNotificationComponents: View {
   @StateObject private var manager = NotificationManager()
+  @FocusState private var isReturnAnchorFocused: Bool
 
   var body: some View {
     ZStack(alignment: .topTrailing) {
@@ -685,8 +701,15 @@ private struct UIPreviewNotificationComponents: View {
       Color.clear
         .withNotification()
         .environmentObject(manager)
+
+      Color.clear
+        .frame(width: 1, height: 1)
+        .focusable()
+        .focused($isReturnAnchorFocused)
+        .accessibilityHidden(true)
     }
     .onAppear {
+      isReturnAnchorFocused = true
       manager.show(message: "悬浮通知预览", type: .success, duration: 20)
     }
   }
@@ -799,8 +822,8 @@ private extension UIPreviewSceneKind {
 }
 
 private enum UIPreviewCatalog {
-  static var firstSceneID: String? {
-    sections.first?.scenes.first?.id
+  static var firstSectionID: String? {
+    sections.first?.id
   }
 
   static let sections: [UIPreviewSection] = [

--- a/MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift
+++ b/MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift
@@ -6,6 +6,12 @@ struct PreviewCatalogView: View {
   @State private var selectedScene: UIPreviewScene?
   @State private var didResetPreviewState = false
 
+  init(initialSceneID: String? = nil) {
+    UIPreviewFixtures.resetPreviewState()
+    _didResetPreviewState = State(initialValue: true)
+    _selectedScene = State(initialValue: UIPreviewCatalog.scene(id: initialSceneID))
+  }
+
   var body: some View {
     ZStack {
       NavigationStack {
@@ -138,18 +144,99 @@ private struct UIPreviewAppSceneView: View {
   var body: some View {
     Group {
       switch previewCase {
+      case .startupPreparing:
+        UIPreviewStartupPreparingView()
       case .loggedIn:
         UIPreviewLoggedInRootView()
-      case .login:
-        LoginView()
+      case .loggedInLimitedTabs:
+        UIPreviewLoggedInRootView(
+          permissions: [.discovery],
+          canRequestSuperUserEndpoints: false
+        )
+      case .backendVersionWarning:
+        UIPreviewLoggedInRootAlertView(alertCase: .backendVersion)
+      case .accountPermissionWarning:
+        UIPreviewLoggedInRootAlertView(alertCase: .accountPermission)
+      case .login, .loginReady, .loginLoading, .loginFailed:
+        LoginView(previewViewModel: UIPreviewFixtures.loginViewModel(previewCase))
       }
     }
     .onAppear {
       switch previewCase {
-      case .loggedIn:
+      case .startupPreparing, .loggedIn, .backendVersionWarning:
         UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true)
-      case .login:
+      case .loggedInLimitedTabs, .accountPermissionWarning:
+        UIPreviewFixtures.applyPermissions([.discovery], canRequestSuperUserEndpoints: false)
+      case .login, .loginReady, .loginLoading, .loginFailed:
         UIPreviewFixtures.applyPermissions([], canRequestSuperUserEndpoints: false)
+      }
+    }
+  }
+}
+
+private struct UIPreviewStartupPreparingView: View {
+  var body: some View {
+    ProgressView("正在准备会话...")
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+}
+
+private enum UIPreviewLoggedInRootAlertCase {
+  case backendVersion
+  case accountPermission
+}
+
+private struct UIPreviewRootAlert: Identifiable {
+  let id: String
+  let title: String
+  let message: String
+}
+
+@MainActor
+private struct UIPreviewLoggedInRootAlertView: View {
+  let alertCase: UIPreviewLoggedInRootAlertCase
+
+  @State private var activeAlert: UIPreviewRootAlert?
+
+  var body: some View {
+    UIPreviewLoggedInRootView(
+      permissions: alertCase == .accountPermission ? [.discovery] : .allPreviewPermissions,
+      canRequestSuperUserEndpoints: alertCase != .accountPermission
+    )
+    .alert(item: $activeAlert) { warning in
+      Alert(
+        title: Text(warning.title),
+        message: Text(warning.message),
+        dismissButton: .default(Text("继续使用"))
+      )
+    }
+    .onAppear {
+      Task { @MainActor in
+        await Task.yield()
+        switch alertCase {
+        case .backendVersion:
+          let warning = BackendVersionWarning(
+            backendVersion: "v2.12.0",
+            requiredVersion: AppVersionInfo.compatibleMoviePilotVersion
+          )
+          activeAlert = UIPreviewRootAlert(
+            id: warning.id,
+            title: warning.title,
+            message: warning.message
+          )
+        case .accountPermission:
+          let warning = AccountPermissionWarning(
+            id: "preview-account-permission-warning",
+            title: "账号权限不足",
+            message: "当前账号缺少搜索、订阅权限。MoviePilot-TV 兼容验证至少要求账号具备探索、搜索和订阅权限；继续使用时部分入口会隐藏，页面布局或焦点可能不完整。",
+            missingPermissions: [.search, .subscribe]
+          )
+          activeAlert = UIPreviewRootAlert(
+            id: warning.id,
+            title: warning.title,
+            message: warning.message
+          )
+        }
       }
     }
   }
@@ -170,10 +257,14 @@ private struct UIPreviewLoggedInRootView: View {
   private let permissions: Set<UserPermissionKey>
   private let canRequestSuperUserEndpoints: Bool
   private let systemPresentation: SystemViewUIPreviewPresentation?
+  private let downloadPresentation: DownloadTaskUIPreviewPresentation?
   private let transferPresentation: TransferHistoryUIPreviewPresentation?
+  private let homePreviewDestinations: HomeViewUIPreviewDestinations?
   private let homeInitialPath: NavigationPath
   private let searchInitialPath: NavigationPath
   private let searchPreviewDestinations: SearchViewUIPreviewDestinations?
+  private let showsSearchSiteSelection: Bool
+  private let explorePreviewForkShare: SubscribeShare?
 
   init(
     selectedTab: ContentViewModel.Tab = .home,
@@ -188,10 +279,14 @@ private struct UIPreviewLoggedInRootView: View {
     permissions: Set<UserPermissionKey> = .allPreviewPermissions,
     canRequestSuperUserEndpoints: Bool = true,
     systemPresentation: SystemViewUIPreviewPresentation? = nil,
+    downloadPresentation: DownloadTaskUIPreviewPresentation? = nil,
     transferPresentation: TransferHistoryUIPreviewPresentation? = nil,
+    homePreviewDestinations: HomeViewUIPreviewDestinations? = nil,
     homeInitialPath: NavigationPath = NavigationPath(),
     searchInitialPath: NavigationPath = NavigationPath(),
-    searchPreviewDestinations: SearchViewUIPreviewDestinations? = nil
+    searchPreviewDestinations: SearchViewUIPreviewDestinations? = nil,
+    showsSearchSiteSelection: Bool = false,
+    explorePreviewForkShare: SubscribeShare? = nil
   ) {
     UIPreviewFixtures.applyPermissions(
       permissions,
@@ -209,15 +304,24 @@ private struct UIPreviewLoggedInRootView: View {
     self.permissions = permissions
     self.canRequestSuperUserEndpoints = canRequestSuperUserEndpoints
     self.systemPresentation = systemPresentation
+    self.downloadPresentation = downloadPresentation
     self.transferPresentation = transferPresentation
+    self.homePreviewDestinations = homePreviewDestinations
     self.homeInitialPath = homeInitialPath
     self.searchInitialPath = searchInitialPath
     self.searchPreviewDestinations = searchPreviewDestinations
+    self.showsSearchSiteSelection = showsSearchSiteSelection
+    self.explorePreviewForkShare = explorePreviewForkShare
   }
 
   var body: some View {
     TabView(selection: $selectedTab) {
-      HomeView(viewModel: homeViewModel, loadsDataOnAppear: false, initialPath: homeInitialPath)
+      HomeView(
+        viewModel: homeViewModel,
+        loadsDataOnAppear: false,
+        initialPath: homeInitialPath,
+        uiPreviewDestinations: homePreviewDestinations
+      )
         .tabItem { Label("媒体库", systemImage: "play.tv") }
         .tag(ContentViewModel.Tab.home)
 
@@ -228,7 +332,7 @@ private struct UIPreviewLoggedInRootView: View {
       }
 
       if visibleTabs.contains(.explore) {
-        ExploreView(viewModel: exploreViewModel)
+        ExploreView(viewModel: exploreViewModel, uiPreviewForkShare: explorePreviewForkShare)
           .tabItem { Label("探索", systemImage: "safari") }
           .tag(ContentViewModel.Tab.explore)
       }
@@ -238,7 +342,8 @@ private struct UIPreviewLoggedInRootView: View {
           viewModel: searchViewModel,
           loadsSitesOnAppear: false,
           initialPath: searchInitialPath,
-          uiPreviewDestinations: searchPreviewDestinations
+          uiPreviewDestinations: searchPreviewDestinations,
+          showsSiteSelection: showsSearchSiteSelection
         )
         .tabItem { Label("搜索", systemImage: "magnifyingglass") }
         .tag(ContentViewModel.Tab.search)
@@ -250,6 +355,7 @@ private struct UIPreviewLoggedInRootView: View {
           downloadTaskViewModel: downloadViewModel,
           transferHistoryViewModel: transferViewModel,
           refreshesOnAppear: false,
+          downloadPresentation: downloadPresentation,
           transferPresentation: transferPresentation
         )
         .tabItem { Label("状态", systemImage: "slider.horizontal.3") }
@@ -313,15 +419,32 @@ private struct UIPreviewPageSceneView: View {
 
   var body: some View {
     switch previewCase {
-    case .homeLoading, .homeEmpty, .homeFull:
-      UIPreviewLoggedInRootView(selectedTab: .home, homeMode: previewCase.homeMode)
-    case .recommendLoading, .recommendEmpty, .recommendFull:
-      UIPreviewLoggedInRootView(selectedTab: .recommend, recommendMode: previewCase.recommendMode)
-    case .exploreTmdb, .exploreShare:
-      UIPreviewLoggedInRootView(selectedTab: .explore, exploreMode: previewCase.exploreMode)
-    case .collectionLoading, .collectionFull:
+    case .homeLoading, .homeEmpty, .homeFull, .homeLatestEmptyServer, .homeSubscriptionsOnly,
+      .homeNoSubscribePermission, .homeNoSearchPermission, .homeSubscribeSheet,
+      .homeUnsubscribeConfirmation:
+      UIPreviewLoggedInRootView(
+        selectedTab: .home,
+        homeMode: previewCase.homeMode,
+        permissions: previewCase.permissions,
+        homePreviewDestinations: HomeViewUIPreviewDestinations(homePresentation: previewCase.homePresentation)
+      )
+    case .recommendInitial, .recommendLoading, .recommendEmpty, .recommendFull, .recommendLimitedPermissions:
+      UIPreviewLoggedInRootView(
+        selectedTab: .recommend,
+        recommendMode: previewCase.recommendMode,
+        permissions: previewCase.permissions
+      )
+    case .exploreInitial, .exploreLoading, .exploreTmdb, .exploreDouban, .exploreBangumi, .explorePopular,
+      .exploreShare, .exploreShareSheet, .exploreNoSubscribePermission, .exploreEmpty:
+      UIPreviewLoggedInRootView(
+        selectedTab: .explore,
+        exploreMode: previewCase.exploreMode,
+        permissions: previewCase.permissions,
+        explorePreviewForkShare: previewCase.explorePreviewForkShare
+      )
+    case .collectionLoading, .collectionEmpty, .collectionFull, .collectionLoadingMore:
       UIPreviewCollectionScene(mode: previewCase.collectionMode)
-    case .personLoading, .personFull:
+    case .personLoading, .personNoBiography, .personBiographySheet, .personFull, .personLoadingMore:
       UIPreviewPersonScene(mode: previewCase.personMode)
     }
   }
@@ -354,7 +477,11 @@ private struct UIPreviewPersonScene: View {
     UIPreviewLoggedInRootView(
       selectedTab: .search,
       searchInitialPath: viewModel.person.previewNavigationPath(),
-      searchPreviewDestinations: SearchViewUIPreviewDestinations(personViewModel: viewModel)
+      searchPreviewDestinations: SearchViewUIPreviewDestinations(
+        personViewModel: viewModel,
+        personShowsBiographySheet: mode == .biographySheet
+      ),
+      showsSearchSiteSelection: false
     )
   }
 }
@@ -374,6 +501,11 @@ private struct UIPreviewDetailSceneView: View {
       selectedTab: .home,
       permissions: detailCase.permissions,
       canRequestSuperUserEndpoints: detailCase.permissions.contains(.manage),
+      homePreviewDestinations: HomeViewUIPreviewDestinations(
+        mediaDetailPresentation: detailCase.presentation,
+        mediaDetailSites: UIPreviewFixtures.sites,
+        mediaDetailRows: UIPreviewFixtures.detailRows(for: detailCase)
+      ),
       homeInitialPath: initialPath
     )
   }
@@ -402,7 +534,10 @@ private struct UIPreviewSeasonSceneView: View {
         mediaInfo: viewModel.mediaInfo,
         initialSeason: nil
       ).previewNavigationPath(),
-      searchPreviewDestinations: SearchViewUIPreviewDestinations(seasonViewModel: viewModel)
+      searchPreviewDestinations: SearchViewUIPreviewDestinations(
+        seasonViewModel: viewModel,
+        seasonPresentation: seasonCase.presentation
+      )
     )
     .onAppear {
       UIPreviewFixtures.applyPermissions(seasonCase.permissions)
@@ -416,10 +551,20 @@ private struct UIPreviewSearchSceneView: View {
 
   var body: some View {
     switch searchCase {
-    case .unifiedResults, .unifiedEmpty, .resourceLoading, .resourceResults, .resourceEmpty:
-      UIPreviewLoggedInRootView(selectedTab: .search, searchCase: searchCase)
-    case .resourcePageLoading, .resourcePageResults:
-      UIPreviewResourceResultScene(mode: searchCase.resourcePageMode)
+    case .notSearched, .unifiedLoading, .unifiedResults, .unifiedLoadingMore, .unifiedShareSheet, .unifiedEmpty, .siteSelection,
+      .unifiedResultsNoSubscribePermission, .resourceLoading, .resourceResults, .resourceEmpty:
+      UIPreviewLoggedInRootView(
+        selectedTab: .search,
+        searchCase: searchCase,
+        permissions: searchCase.permissions,
+        searchPreviewDestinations: SearchViewUIPreviewDestinations(forkShare: searchCase.searchPreviewForkShare),
+        showsSearchSiteSelection: searchCase.showsSiteSelection
+      )
+    case .resourcePageLoading, .resourcePageEmpty, .resourcePageResults, .resourcePageFilterSelection:
+      UIPreviewResourceResultScene(
+        mode: searchCase.resourcePageMode,
+        torrentsPresentation: searchCase.resourceTorrentsPresentation
+      )
     }
   }
 }
@@ -427,6 +572,7 @@ private struct UIPreviewSearchSceneView: View {
 @MainActor
 private struct UIPreviewResourceResultScene: View {
   let mode: UIPreviewResourcePageMode
+  var torrentsPresentation: TorrentsResultUIPreviewPresentation? = nil
 
   var body: some View {
     let media = UIPreviewFixtures.baseTVMedia(id: 97_101, title: "边境信号")
@@ -446,7 +592,8 @@ private struct UIPreviewResourceResultScene: View {
       selectedTab: .search,
       searchInitialPath: request.previewNavigationPath(),
       searchPreviewDestinations: SearchViewUIPreviewDestinations(
-        resourceResultViewModel: UIPreviewFixtures.resourceResultViewModel(mode)
+        resourceResultViewModel: UIPreviewFixtures.resourceResultViewModel(mode),
+        resourceTorrentsPresentation: torrentsPresentation
       )
     )
   }
@@ -465,21 +612,18 @@ private struct UIPreviewStatusSceneView: View {
         downloadMode: statusCase == .statusEmpty ? .empty : .multiState,
         transferMode: statusCase == .statusEmpty ? .empty : .aiRedoing
       )
-    case .downloadEmpty, .downloadMultiState:
+    case .downloadEmpty, .downloadMultiState, .downloadCollapsed, .downloadDeleteConfirmation:
       UIPreviewLoggedInRootView(
         selectedTab: .status,
-        downloadMode: statusCase.downloadMode
+        downloadMode: statusCase.downloadMode,
+        downloadPresentation: statusCase.downloadPresentation
       )
-    case .transferLoading, .transferEmpty, .transferAiRedoing:
+    case .transferLoading, .transferLoadingMore, .transferEmpty, .transferAiRedoing, .transferDetail, .transferSingleDelete,
+      .transferBatchDelete, .transferBatchReorganize:
       UIPreviewLoggedInRootView(
         selectedTab: .status,
-        transferMode: statusCase.transferMode
-      )
-    case .transferDetail:
-      UIPreviewLoggedInRootView(
-        selectedTab: .status,
-        transferMode: .aiRedoing,
-        transferPresentation: .detail
+        transferMode: statusCase.transferMode,
+        transferPresentation: statusCase.transferPresentation
       )
     }
   }
@@ -503,11 +647,14 @@ private struct UIPreviewSettingsSceneView: View {
 @MainActor
 private struct UIPreviewSheetSceneView: View {
   let sheetCase: UIPreviewSheetCase
-  @State private var isSheetPresented = true
+  @StateObject private var notificationManager = NotificationManager()
+  @State private var isSheetPresented = false
+  @State private var didShowPreviewErrorNotification = false
+  @State private var previewErrorNotificationMessage: String?
 
   init(sheetCase: UIPreviewSheetCase) {
     self.sheetCase = sheetCase
-    UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true)
+    UIPreviewFixtures.applyPermissions(sheetCase.permissions, canRequestSuperUserEndpoints: true)
   }
 
   var body: some View {
@@ -521,26 +668,78 @@ private struct UIPreviewSheetSceneView: View {
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .sheet(isPresented: $isSheetPresented) {
       sheetContent
+        .environmentObject(notificationManager)
+        .overlay(alignment: .topTrailing) {
+          notificationOverlay
+        }
+    }
+    .onAppear {
+      Task { @MainActor in
+        await Task.yield()
+        isSheetPresented = true
+        showPreviewErrorNotificationIfNeeded()
+      }
+    }
+    .overlay(alignment: .topTrailing) {
+      notificationOverlay
+    }
+    .environmentObject(notificationManager)
+  }
+
+  private func showPreviewErrorNotificationIfNeeded() {
+    guard !didShowPreviewErrorNotification else { return }
+    guard let message = sheetCase.previewErrorNotificationMessage else { return }
+    didShowPreviewErrorNotification = true
+
+    Task { @MainActor in
+      try? await Task.sleep(nanoseconds: 700_000_000)
+      previewErrorNotificationMessage = message
+      notificationManager.show(message: message, type: .error)
     }
   }
 
   @ViewBuilder
   private var sheetContent: some View {
     switch sheetCase {
-    case .subscribe:
-      SubscribeSheet(previewViewModel: UIPreviewFixtures.subscribeSheetViewModel())
+    case .subscribeLoading:
+      SubscribeSheet(previewViewModel: UIPreviewFixtures.subscribeSheetViewModel(isLoading: true))
         .previewRoot(sheetCase.title)
-    case .addDownload:
-      AddDownloadSheet(previewViewModel: UIPreviewFixtures.addDownloadViewModel())
-        .environmentObject(NotificationManager())
+    case .subscribeMovie:
+      SubscribeSheet(previewViewModel: UIPreviewFixtures.subscribeSheetViewModel(type: "电影"))
         .previewRoot(sheetCase.title)
-    case .reorganize:
-      ReorganizeSheet(previewViewModel: UIPreviewFixtures.reorganizeViewModel()) {}
-        .environmentObject(NotificationManager())
+    case .subscribe, .subscribeAdvanced, .subscribeSiteSelection, .subscribeFilterGroupSelection, .subscribeSaving:
+      SubscribeSheet(
+        previewViewModel: UIPreviewFixtures.subscribeSheetViewModel(
+          isSaving: sheetCase == .subscribeSaving
+        ),
+        presentation: sheetCase.subscribePresentation
+      )
+        .previewRoot(sheetCase.title)
+    case .addDownloadLoading:
+      AddDownloadSheet(previewViewModel: UIPreviewFixtures.addDownloadViewModel(isLoading: true))
+        .previewRoot(sheetCase.title)
+    case .addDownload, .addDownloadAdvanced, .addDownloadSubmitting, .addDownloadNoSearchPermission,
+      .addDownloadError:
+      AddDownloadSheet(
+        previewViewModel: UIPreviewFixtures.addDownloadViewModel(
+          isSubmitting: sheetCase == .addDownloadSubmitting
+        ),
+        presentation: sheetCase.addDownloadPresentation
+      )
+        .previewRoot(sheetCase.title)
+    case .reorganizeLoading:
+      ReorganizeSheet(previewViewModel: UIPreviewFixtures.reorganizeViewModel(isLoading: true)) {}
+        .previewRoot(sheetCase.title)
+    case .reorganize, .reorganizeAdvanced, .reorganizeDouban, .reorganizeSubmitting, .reorganizeError:
+      ReorganizeSheet(
+        previewViewModel: UIPreviewFixtures.reorganizeViewModel(
+          isSubmitting: sheetCase == .reorganizeSubmitting
+        ),
+        presentation: sheetCase.reorganizePresentation
+      ) {}
         .previewRoot(sheetCase.title)
     case .reorganizeBatch:
       ReorganizeSheet(previewViewModel: UIPreviewFixtures.reorganizeBatchViewModel()) {}
-        .environmentObject(NotificationManager())
         .previewRoot(sheetCase.title)
     case .forkSubscribe:
       ForkSubscribeSheet(
@@ -558,6 +757,27 @@ private struct UIPreviewSheetSceneView: View {
     case .multiSelection:
       UIPreviewMultiSelectionSheet()
         .previewRoot(sheetCase.title)
+    }
+  }
+
+  @ViewBuilder
+  private var notificationOverlay: some View {
+    if let previewErrorNotificationMessage {
+      NotificationView(
+        message: previewErrorNotificationMessage,
+        type: .error
+      )
+      .padding(.top, 60)
+      .padding(.trailing, 60)
+      .transition(.move(edge: .top).combined(with: .opacity))
+    } else if notificationManager.isShowing {
+      NotificationView(
+        message: notificationManager.message,
+        type: notificationManager.type
+      )
+      .padding(.top, 60)
+      .padding(.trailing, 60)
+      .transition(.move(edge: .top).combined(with: .opacity))
     }
   }
 }
@@ -586,21 +806,36 @@ private struct UIPreviewComponentSceneView: View {
   init(componentCase: UIPreviewComponentCase, navigationPath: Binding<NavigationPath>) {
     self.componentCase = componentCase
     _navigationPath = navigationPath
-    UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true)
+    UIPreviewFixtures.applyPermissions(componentCase.permissions, canRequestSuperUserEndpoints: true)
   }
 
   var body: some View {
     switch componentCase {
-    case .mediaCards:
+    case .mediaCards, .mediaCardsContextMenu, .mediaCardsLimitedPermissions:
       NavigationStack(path: $navigationPath) {
-        UIPreviewMediaCards(navigationPath: $navigationPath)
+        UIPreviewMediaCards(
+          navigationPath: $navigationPath,
+          showsContextMenu: componentCase != .mediaCards
+        )
           .uiPreviewNavigationDestinations(path: $navigationPath)
       }
-    case .torrentCards:
+    case .torrentCards, .torrentCardsNoSearchPermission:
       UIPreviewTorrentCards()
+        .previewRoot(componentCase.title)
+    case .torrentDownloadSheet:
+      UIPreviewTorrentDownloadSheet()
+        .previewRoot(componentCase.title)
+    case .sheetPickerSelection:
+      UIPreviewSheetPickerSelection()
+        .previewRoot(componentCase.title)
+    case .subscriptionAlert:
+      UIPreviewSubscriptionAlert()
         .previewRoot(componentCase.title)
     case .pickers:
       UIPreviewPickerComponents()
+        .previewRoot(componentCase.title)
+    case .mediaActionLoading, .mediaActionNotFound:
+      UIPreviewMediaActionComponents(componentCase: componentCase)
         .previewRoot(componentCase.title)
     case .notification:
       UIPreviewNotificationComponents()
@@ -609,27 +844,83 @@ private struct UIPreviewComponentSceneView: View {
   }
 }
 
+@MainActor
 private struct UIPreviewMediaCards: View {
   @Binding var navigationPath: NavigationPath
+  let showsContextMenu: Bool
+  @StateObject private var subscriptionHandler = SubscriptionHandler()
+  private let items: [MediaInfo]
+
+  init(navigationPath: Binding<NavigationPath>, showsContextMenu: Bool) {
+    _navigationPath = navigationPath
+    self.showsContextMenu = showsContextMenu
+    let items = [
+      UIPreviewFixtures.movieMedia(id: 98_001, title: "长标题电影：跨越三行也不能挤坏焦点卡片"),
+      UIPreviewFixtures.baseTVMedia(id: 98_002, title: "无海报剧集", hasArtwork: false),
+      UIPreviewFixtures.collectionMedia(id: 98_003, title: "边境信号系列"),
+      UIPreviewFixtures.shareMedia(id: 98_004, title: "订阅分享卡片"),
+      UIPreviewFixtures.externalSourceMedia(id: 98_005, title: "外部来源：边境信号"),
+    ]
+    self.items = items
+    Self.installSubscribedContextMenuPreviewTask(for: items)
+  }
+
+  private static func installSubscribedContextMenuPreviewTask(for items: [MediaInfo]) {
+    guard !items.isEmpty else { return }
+    let subscribedItem = items[0]
+    let task = MediaPreloadTask(partialMedia: subscribedItem)
+    task.fullDetail = subscribedItem
+    task.isDetailReady = true
+    task.tmdbId = subscribedItem.tmdb_id
+    task.isSubscribed = true
+    MediaPreloader.shared.installPreviewTask(task, for: subscribedItem)
+  }
+
+  private var headerView: some View {
+    Text("媒体卡片 / 网格 / 加载更多")
+      .font(.largeTitle.bold())
+      .foregroundStyle(.secondary)
+  }
 
   var body: some View {
-    MediaGridView(
-      items: [
-        UIPreviewFixtures.movieMedia(id: 98_001, title: "长标题电影：跨越三行也不能挤坏焦点卡片"),
-        UIPreviewFixtures.baseTVMedia(id: 98_002, title: "无海报剧集", hasArtwork: false),
-        UIPreviewFixtures.collectionMedia(id: 98_003, title: "边境信号系列"),
-        UIPreviewFixtures.shareMedia(id: 98_004, title: "订阅分享卡片"),
-      ],
-      isLoading: false,
-      isLoadingMore: true,
-      onLoadMore: { _ in },
-      navigationPath: $navigationPath,
-      header: {
-        Text("媒体卡片 / 网格 / 加载更多")
-          .font(.largeTitle.bold())
-          .foregroundStyle(.secondary)
+    if showsContextMenu {
+      MediaGridView(
+        items: items,
+        isLoading: false,
+        isLoadingMore: true,
+        onLoadMore: { _ in },
+        navigationPath: $navigationPath,
+        header: { headerView },
+        contextMenu: { item in
+          MediaContextMenuItems(
+            item: item,
+            navigationPath: $navigationPath,
+            subscriptionHandler: subscriptionHandler
+          )
+        },
+        onShareTapped: { share in
+          guard APIService.shared.canAccess(.subscribe) else { return }
+          subscriptionHandler.forkSheetRequest = share
+        }
+      )
+      .mediaSubscriptionAlerts(using: subscriptionHandler, navigationPath: $navigationPath)
+      .sheet(item: $subscriptionHandler.forkSheetRequest) { share in
+        ForkSubscribeSheet(
+          share: share,
+          onFork: { _ in },
+          subscriptionHandler: subscriptionHandler
+        )
       }
-    )
+    } else {
+      MediaGridView(
+        items: items,
+        isLoading: false,
+        isLoadingMore: true,
+        onLoadMore: { _ in },
+        navigationPath: $navigationPath,
+        header: { headerView }
+      )
+    }
   }
 }
 
@@ -644,6 +935,61 @@ private struct UIPreviewTorrentCards: View {
       .padding(60)
     }
     .focusSection()
+  }
+}
+
+private struct UIPreviewTorrentDownloadSheet: View {
+  @StateObject private var notificationManager = NotificationManager()
+  @State private var isSheetPresented = false
+
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 24) {
+        Text("种子卡片下载入口")
+          .font(.largeTitle.bold())
+          .foregroundStyle(.secondary)
+
+        TorrentCard(
+          context: UIPreviewFixtures.contexts[0],
+          overrideMediaInfo: UIPreviewFixtures.baseTVMedia(id: 98_012, title: "边境信号")
+        )
+        .frame(maxWidth: 620)
+      }
+      .padding(80)
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .focusSection()
+    .sheet(isPresented: $isSheetPresented) {
+      AddDownloadSheet(previewViewModel: UIPreviewFixtures.addDownloadViewModel())
+        .previewRoot("组件 · 种子卡片下载弹窗")
+        .environmentObject(notificationManager)
+        .overlay(alignment: .topTrailing) {
+          notificationOverlay
+        }
+    }
+    .overlay(alignment: .topTrailing) {
+      notificationOverlay
+    }
+    .environmentObject(notificationManager)
+    .onAppear {
+      Task { @MainActor in
+        await Task.yield()
+        isSheetPresented = true
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var notificationOverlay: some View {
+    if notificationManager.isShowing {
+      NotificationView(
+        message: notificationManager.message,
+        type: notificationManager.type
+      )
+      .padding(.top, 60)
+      .padding(.trailing, 60)
+      .transition(.move(edge: .top).combined(with: .opacity))
+    }
   }
 }
 
@@ -684,6 +1030,88 @@ private struct UIPreviewPickerComponents: View {
   }
 }
 
+private struct UIPreviewSheetPickerSelection: View {
+  @State private var pickerSelection = "1080p"
+
+  var body: some View {
+    VStack {
+      SheetPicker(
+        title: "分辨率",
+        selection: $pickerSelection,
+        options: [
+          PickerOption(title: "全部", value: ""),
+          PickerOption(title: "1080P", value: "1080p"),
+          PickerOption(title: "4K", value: "4k"),
+        ],
+        uiPreviewPresentation: .options
+      )
+      .frame(width: 980)
+      .applySheetStyles()
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+}
+
+private struct UIPreviewSubscriptionAlert: View {
+  @StateObject private var handler = SubscriptionHandler()
+  @State private var navigationPath = NavigationPath()
+
+  var body: some View {
+    VStack(spacing: 24) {
+      Image(systemName: "bell.badge")
+        .font(.system(size: 90, weight: .semibold))
+      Text("组件 · 订阅结果提示")
+        .font(.largeTitle.bold())
+      Text("全局订阅动作 Alert")
+        .font(.title3)
+        .foregroundStyle(.secondary)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .mediaSubscriptionAlerts(using: handler, navigationPath: $navigationPath)
+    .onAppear {
+      Task { @MainActor in
+        await Task.yield()
+        handler.showAlert(title: "边境信号", message: "已订阅，请勿重复操作")
+      }
+    }
+  }
+}
+
+@MainActor
+private struct UIPreviewMediaActionComponents: View {
+  let componentCase: UIPreviewComponentCase
+  @StateObject private var handler = MediaActionHandler()
+
+  var body: some View {
+    VStack(spacing: 24) {
+      Image(systemName: "film.stack")
+        .font(.system(size: 90, weight: .semibold))
+      Text(componentCase.title)
+        .font(.largeTitle.bold())
+      Text(componentCase.note)
+        .font(.title3)
+        .foregroundStyle(.secondary)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .mediaActionAlerts()
+    .environmentObject(handler)
+    .onAppear {
+      Task { @MainActor in
+        await Task.yield()
+        switch componentCase {
+        case .mediaActionLoading:
+          handler.isRecognizingTmdb = true
+        case .mediaActionNotFound:
+          handler.showTMDBNotFoundAlert = true
+        case .mediaCards, .mediaCardsContextMenu, .mediaCardsLimitedPermissions, .torrentCards, .torrentCardsNoSearchPermission,
+          .torrentDownloadSheet, .sheetPickerSelection, .subscriptionAlert, .pickers, .notification:
+          break
+        }
+      }
+    }
+  }
+}
+
 private struct UIPreviewNotificationComponents: View {
   @StateObject private var manager = NotificationManager()
   @FocusState private var isReturnAnchorFocused: Bool
@@ -698,9 +1126,12 @@ private struct UIPreviewNotificationComponents: View {
       }
       .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-      Color.clear
-        .withNotification()
-        .environmentObject(manager)
+      if manager.isShowing {
+        NotificationView(message: manager.message, type: manager.type)
+          .padding(.top, 60)
+          .padding(.trailing, 60)
+          .transition(.move(edge: .top).combined(with: .opacity))
+      }
 
       Color.clear
         .frame(width: 1, height: 1)
@@ -826,13 +1257,25 @@ private enum UIPreviewCatalog {
     sections.first?.id
   }
 
+  static func scene(id: String?) -> UIPreviewScene? {
+    guard let id else { return nil }
+    return sections.lazy.flatMap(\.scenes).first { $0.id == id }
+  }
+
   static let sections: [UIPreviewSection] = [
     UIPreviewSection(
       id: "app",
       title: "App 入口 / Tab 页面",
       scenes: [
         scene(.app(.loggedIn), id: "app-loggedIn", title: "启动入口 · 正常已登录"),
+        scene(.app(.startupPreparing), id: "app-startupPreparing", title: "启动入口 · 启动会话准备中"),
+        scene(.app(.loggedInLimitedTabs), id: "app-loggedInLimitedTabs", title: "启动入口 · 低权限 Tab"),
+        scene(.app(.backendVersionWarning), id: "app-backendVersionWarning", title: "启动入口 · 后端版本告警"),
+        scene(.app(.accountPermissionWarning), id: "app-accountPermissionWarning", title: "启动入口 · 账号权限告警"),
         scene(.app(.login), id: "app-login", title: "启动入口 · 登录页"),
+        scene(.app(.loginReady), id: "app-loginReady", title: "启动入口 · 可提交登录"),
+        scene(.app(.loginLoading), id: "app-loginLoading", title: "启动入口 · 登录中"),
+        scene(.app(.loginFailed), id: "app-loginFailed", title: "启动入口 · 登录失败"),
       ]
     ),
     UIPreviewSection(
@@ -840,12 +1283,61 @@ private enum UIPreviewCatalog {
       title: "详情页",
       scenes: [
         scene(.detail(.loading), id: "detail-loading", title: "详情页 · 加载中"),
+        scene(.detail(.detailLoadFailed), id: "detail-detailLoadFailed", title: "详情页 · 详情加载失败"),
+        scene(.detail(.movieUnsubscribed), id: "detail-movieUnsubscribed", title: "详情页 · 电影，未订阅"),
+        scene(.detail(.movieSubscribed), id: "detail-movieSubscribed", title: "详情页 · 电影，已订阅"),
         scene(.detail(.tvWithSeasons), id: "detail-tvWithSeasons", title: "详情页 · 电视剧，有分季"),
+        scene(
+          .detail(.tvWithSeasonsNoSubscribePermission),
+          id: "detail-tvWithSeasonsNoSubscribePermission",
+          title: "详情页 · 有分季且无订阅权限"
+        ),
         scene(.detail(.tvWithoutSeasons), id: "detail-tvWithoutSeasons", title: "详情页 · 电视剧，无分季"),
         scene(.detail(.seasonLoadFailed), id: "detail-seasonLoadFailed", title: "详情页 · 分季加载失败"),
         scene(.detail(.noArtwork), id: "detail-noArtwork", title: "详情页 · 无海报 / 无背景图"),
+        scene(.detail(.contentPage), id: "detail-contentPage", title: "详情页 · 第二页内容"),
+        scene(
+          .detail(.contentPageRowsLoadingMore),
+          id: "detail-contentPageRowsLoadingMore",
+          title: "详情页 · 第二页行加载更多"
+        ),
+        scene(
+          .detail(.contentPageNoSearchAndNoSubscribePermission),
+          id: "detail-contentPageNoSearchAndNoSubscribePermission",
+          title: "详情页 · 第二页无操作权限"
+        ),
+        scene(
+          .detail(.contentPageSingleEpisodeGroup),
+          id: "detail-contentPageSingleEpisodeGroup",
+          title: "详情页 · 分季单剧集组"
+        ),
+        scene(
+          .detail(.contentPageManySeasons),
+          id: "detail-contentPageManySeasons",
+          title: "详情页 · 多分季 / 多剧集组"
+        ),
+        scene(.detail(.tmdbJumpLoading), id: "detail-tmdbJumpLoading", title: "详情页 · TMDB 跳转识别中"),
+        scene(.detail(.siteSelection), id: "detail-siteSelection", title: "详情页 · 站点选择弹窗"),
+        scene(.detail(.subscribeSheet), id: "detail-subscribeSheet", title: "详情页 · 订阅弹窗"),
+        scene(.detail(.unsubscribeConfirmation), id: "detail-unsubscribeConfirmation", title: "详情页 · 取消订阅确认"),
+        scene(.detail(.unsubscribing), id: "detail-unsubscribing", title: "详情页 · 取消订阅中"),
         scene(.detail(.noSubscribePermission), id: "detail-noSubscribePermission", title: "详情页 · 无订阅权限"),
         scene(.detail(.noSearchPermission), id: "detail-noSearchPermission", title: "详情页 · 无搜索权限"),
+        scene(
+          .detail(.tvWithoutSeasonsNoSubscribePermission),
+          id: "detail-tvWithoutSeasonsNoSubscribePermission",
+          title: "详情页 · 无分季且无订阅权限"
+        ),
+        scene(
+          .detail(.tvWithoutSeasonsNoSearchPermission),
+          id: "detail-tvWithoutSeasonsNoSearchPermission",
+          title: "详情页 · 无分季且无搜索权限"
+        ),
+        scene(
+          .detail(.noSearchAndNoSubscribePermission),
+          id: "detail-noSearchAndNoSubscribePermission",
+          title: "详情页 · 无搜索且无订阅权限"
+        ),
       ]
     ),
     UIPreviewSection(
@@ -857,6 +1349,10 @@ private enum UIPreviewCatalog {
         scene(.season(.empty), id: "season-empty", title: "分季页 · 空数据"),
         scene(.season(.failed), id: "season-failed", title: "分季页 · 加载失败"),
         scene(.season(.mixedSubscription), id: "season-mixedSubscription", title: "分季页 · 已订阅 / 缺集混合"),
+        scene(.season(.noSubscribePermission), id: "season-noSubscribePermission", title: "分季页 · 无订阅权限"),
+        scene(.season(.seasonDetail), id: "season-seasonDetail", title: "分季页 · 分季详情弹窗"),
+        scene(.season(.subscribeSheet), id: "season-subscribeSheet", title: "分季页 · 新增订阅弹窗"),
+        scene(.season(.unsubscribeConfirmation), id: "season-unsubscribeConfirmation", title: "分季页 · 取消订阅确认"),
       ]
     ),
     UIPreviewSection(
@@ -866,28 +1362,65 @@ private enum UIPreviewCatalog {
         scene(.page(.homeLoading), id: "page-homeLoading", title: "首页 · 加载中"),
         scene(.page(.homeEmpty), id: "page-homeEmpty", title: "首页 · 空数据"),
         scene(.page(.homeFull), id: "page-homeFull", title: "首页 · 完整数据"),
+        scene(.page(.homeLatestEmptyServer), id: "page-homeLatestEmptyServer", title: "首页 · 最近添加空服务器"),
+        scene(.page(.homeSubscriptionsOnly), id: "page-homeSubscriptionsOnly", title: "首页 · 仅订阅"),
+        scene(.page(.homeNoSubscribePermission), id: "page-homeNoSubscribePermission", title: "首页 · 无订阅权限"),
+        scene(.page(.homeNoSearchPermission), id: "page-homeNoSearchPermission", title: "首页 · 无搜索权限"),
+        scene(.page(.homeSubscribeSheet), id: "page-homeSubscribeSheet", title: "首页 · 订阅编辑弹窗"),
+        scene(.page(.homeUnsubscribeConfirmation), id: "page-homeUnsubscribeConfirmation", title: "首页 · 取消订阅确认"),
+        scene(.page(.recommendInitial), id: "page-recommendInitial", title: "推荐 · 初始化中"),
         scene(.page(.recommendLoading), id: "page-recommendLoading", title: "推荐 · 加载中"),
         scene(.page(.recommendEmpty), id: "page-recommendEmpty", title: "推荐 · 空数据"),
         scene(.page(.recommendFull), id: "page-recommendFull", title: "推荐 · 完整数据"),
+        scene(.page(.recommendLimitedPermissions), id: "page-recommendLimitedPermissions", title: "推荐 · 低权限菜单"),
+        scene(.page(.exploreInitial), id: "page-exploreInitial", title: "探索 · 初始化中"),
+        scene(.page(.exploreLoading), id: "page-exploreLoading", title: "探索 · 加载中"),
         scene(.page(.exploreTmdb), id: "page-exploreTmdb", title: "探索 · TMDB 筛选"),
+        scene(.page(.exploreDouban), id: "page-exploreDouban", title: "探索 · 豆瓣筛选"),
+        scene(.page(.exploreBangumi), id: "page-exploreBangumi", title: "探索 · Bangumi 筛选"),
+        scene(.page(.explorePopular), id: "page-explorePopular", title: "探索 · 热门订阅"),
         scene(.page(.exploreShare), id: "page-exploreShare", title: "探索 · 订阅分享"),
+        scene(.page(.exploreShareSheet), id: "page-exploreShareSheet", title: "探索 · 订阅分享弹窗"),
+        scene(
+          .page(.exploreNoSubscribePermission),
+          id: "page-exploreNoSubscribePermission",
+          title: "探索 · 无订阅权限"
+        ),
+        scene(.page(.exploreEmpty), id: "page-exploreEmpty", title: "探索 · 空结果"),
         scene(.page(.collectionLoading), id: "page-collectionLoading", title: "合集详情 · 加载中"),
+        scene(.page(.collectionEmpty), id: "page-collectionEmpty", title: "合集详情 · 空数据"),
         scene(.page(.collectionFull), id: "page-collectionFull", title: "合集详情 · 完整数据"),
+        scene(.page(.collectionLoadingMore), id: "page-collectionLoadingMore", title: "合集详情 · 加载更多中"),
         scene(.page(.personLoading), id: "page-personLoading", title: "人物详情 · 加载中"),
+        scene(.page(.personNoBiography), id: "page-personNoBiography", title: "人物详情 · 无简介"),
+        scene(.page(.personBiographySheet), id: "page-personBiographySheet", title: "人物详情 · 简介弹窗"),
         scene(.page(.personFull), id: "page-personFull", title: "人物详情 · 完整数据"),
+        scene(.page(.personLoadingMore), id: "page-personLoadingMore", title: "人物详情 · 加载更多中"),
       ]
     ),
     UIPreviewSection(
       id: "search",
       title: "搜索链路",
       scenes: [
+        scene(.search(.notSearched), id: "search-notSearched", title: "搜索 · 未搜索"),
+        scene(.search(.unifiedLoading), id: "search-unifiedLoading", title: "搜索 · 聚合加载中"),
         scene(.search(.unifiedResults), id: "search-unifiedResults", title: "搜索 · 聚合结果"),
+        scene(.search(.unifiedLoadingMore), id: "search-unifiedLoadingMore", title: "搜索 · 聚合行加载更多"),
+        scene(.search(.unifiedShareSheet), id: "search-unifiedShareSheet", title: "搜索 · 订阅分享弹窗"),
+        scene(
+          .search(.unifiedResultsNoSubscribePermission),
+          id: "search-unifiedResultsNoSubscribePermission",
+          title: "搜索 · 聚合结果无订阅权限"
+        ),
         scene(.search(.unifiedEmpty), id: "search-unifiedEmpty", title: "搜索 · 聚合空结果"),
+        scene(.search(.siteSelection), id: "search-siteSelection", title: "搜索 · 站点选择弹窗"),
         scene(.search(.resourceLoading), id: "search-resourceLoading", title: "搜索 · 资源加载中"),
         scene(.search(.resourceResults), id: "search-resourceResults", title: "搜索 · 资源结果"),
         scene(.search(.resourceEmpty), id: "search-resourceEmpty", title: "搜索 · 资源空结果"),
         scene(.search(.resourcePageLoading), id: "search-resourcePageLoading", title: "资源结果页 · 加载中"),
+        scene(.search(.resourcePageEmpty), id: "search-resourcePageEmpty", title: "资源结果页 · 空数据"),
         scene(.search(.resourcePageResults), id: "search-resourcePageResults", title: "资源结果页 · 完整数据"),
+        scene(.search(.resourcePageFilterSelection), id: "search-resourcePageFilterSelection", title: "资源结果页 · 筛选弹窗"),
       ]
     ),
     UIPreviewSection(
@@ -898,10 +1431,16 @@ private enum UIPreviewCatalog {
         scene(.status(.statusFull), id: "status-statusFull", title: "状态页 · 完整数据"),
         scene(.status(.downloadEmpty), id: "status-downloadEmpty", title: "下载任务 · 空数据"),
         scene(.status(.downloadMultiState), id: "status-downloadMultiState", title: "下载任务 · 多状态任务"),
+        scene(.status(.downloadCollapsed), id: "status-downloadCollapsed", title: "下载任务 · 收起"),
+        scene(.status(.downloadDeleteConfirmation), id: "status-downloadDeleteConfirmation", title: "下载任务 · 删除确认"),
         scene(.status(.transferLoading), id: "status-transferLoading", title: "整理历史 · 加载中"),
+        scene(.status(.transferLoadingMore), id: "status-transferLoadingMore", title: "整理历史 · 加载更多中"),
         scene(.status(.transferEmpty), id: "status-transferEmpty", title: "整理历史 · 空数据"),
         scene(.status(.transferAiRedoing), id: "status-transferAiRedoing", title: "整理历史 · 多选 / AI 整理中"),
         scene(.status(.transferDetail), id: "status-transferDetail", title: "整理历史 · 详情弹窗"),
+        scene(.status(.transferSingleDelete), id: "status-transferSingleDelete", title: "整理历史 · 单项删除确认"),
+        scene(.status(.transferBatchDelete), id: "status-transferBatchDelete", title: "整理历史 · 批量删除确认"),
+        scene(.status(.transferBatchReorganize), id: "status-transferBatchReorganize", title: "整理历史 · 批量重整弹窗"),
       ]
     ),
     UIPreviewSection(
@@ -911,6 +1450,21 @@ private enum UIPreviewCatalog {
         scene(.settings(.fullAccess), id: "settings-fullAccess", title: "设置 · 全权限"),
         scene(.settings(.noSubscribe), id: "settings-noSubscribe", title: "设置 · 无订阅权限"),
         scene(.settings(.noSearch), id: "settings-noSearch", title: "设置 · 无搜索权限"),
+        scene(.settings(.noSuperUser), id: "settings-noSuperUser", title: "设置 · 无超级用户权限"),
+        scene(.settings(.limitedPermissions), id: "settings-limitedPermissions", title: "设置 · 低权限"),
+        scene(.settings(.connection), id: "settings-connection", title: "设置 · 连接页"),
+        scene(.settings(.connectionRefreshing), id: "settings-connectionRefreshing", title: "设置 · 刷新登录凭据中"),
+        scene(.settings(.siteSelection), id: "settings-siteSelection", title: "设置 · 站点选择页"),
+        scene(.settings(.siteEmpty), id: "settings-siteEmpty", title: "设置 · 站点空列表"),
+        scene(.settings(.hardFilter), id: "settings-hardFilter", title: "设置 · 硬过滤页"),
+        scene(.settings(.hardFilterLoading), id: "settings-hardFilterLoading", title: "设置 · 硬过滤加载中"),
+        scene(.settings(.hardFilterEmpty), id: "settings-hardFilterEmpty", title: "设置 · 硬过滤空列表"),
+        scene(.settings(.softFilter), id: "settings-softFilter", title: "设置 · 软过滤页"),
+        scene(.settings(.softFilterLoading), id: "settings-softFilterLoading", title: "设置 · 软过滤加载中"),
+        scene(.settings(.softFilterEmpty), id: "settings-softFilterEmpty", title: "设置 · 软过滤空列表"),
+        scene(.settings(.siteLoading), id: "settings-siteLoading", title: "设置 · 站点加载中"),
+        scene(.settings(.rulesLoading), id: "settings-rulesLoading", title: "设置 · 过滤规则加载中"),
+        scene(.settings(.rulesEmpty), id: "settings-rulesEmpty", title: "设置 · 过滤规则空列表"),
         scene(.settings(.appInfo), id: "settings-appInfo", title: "设置 · APP 信息"),
         scene(.settings(.logoutConfirmation), id: "settings-logoutConfirmation", title: "设置 · 退出登录确认"),
       ]
@@ -919,11 +1473,35 @@ private enum UIPreviewCatalog {
       id: "sheet",
       title: "弹窗",
       scenes: [
+        scene(.sheet(.subscribeLoading), id: "sheet-subscribeLoading", title: "订阅弹窗 · 加载中"),
         scene(.sheet(.subscribe), id: "sheet-subscribe", title: "订阅弹窗 · 新增"),
+        scene(.sheet(.subscribeMovie), id: "sheet-subscribeMovie", title: "订阅弹窗 · 电影新增"),
+        scene(.sheet(.subscribeAdvanced), id: "sheet-subscribeAdvanced", title: "订阅弹窗 · 高级配置"),
+        scene(.sheet(.subscribeSiteSelection), id: "sheet-subscribeSiteSelection", title: "订阅弹窗 · 站点选择"),
+        scene(
+          .sheet(.subscribeFilterGroupSelection),
+          id: "sheet-subscribeFilterGroupSelection",
+          title: "订阅弹窗 · 过滤组选择"
+        ),
+        scene(.sheet(.subscribeSaving), id: "sheet-subscribeSaving", title: "订阅弹窗 · 保存中"),
         scene(.sheet(.forkSubscribe), id: "sheet-forkSubscribe", title: "订阅分享弹窗 · 复用"),
+        scene(.sheet(.addDownloadLoading), id: "sheet-addDownloadLoading", title: "下载弹窗 · 加载中"),
         scene(.sheet(.addDownload), id: "sheet-addDownload", title: "下载弹窗 · 添加下载"),
+        scene(.sheet(.addDownloadAdvanced), id: "sheet-addDownloadAdvanced", title: "下载弹窗 · 高级配置"),
+        scene(.sheet(.addDownloadSubmitting), id: "sheet-addDownloadSubmitting", title: "下载弹窗 · 提交中"),
+        scene(
+          .sheet(.addDownloadNoSearchPermission),
+          id: "sheet-addDownloadNoSearchPermission",
+          title: "下载弹窗 · 无搜索权限"
+        ),
+        scene(.sheet(.addDownloadError), id: "sheet-addDownloadError", title: "下载弹窗 · 错误通知"),
+        scene(.sheet(.reorganizeLoading), id: "sheet-reorganizeLoading", title: "整理弹窗 · 加载中"),
         scene(.sheet(.reorganize), id: "sheet-reorganize", title: "整理弹窗 · 单项重整"),
         scene(.sheet(.reorganizeBatch), id: "sheet-reorganizeBatch", title: "整理弹窗 · 批量重整"),
+        scene(.sheet(.reorganizeDouban), id: "sheet-reorganizeDouban", title: "整理弹窗 · 豆瓣识别源"),
+        scene(.sheet(.reorganizeAdvanced), id: "sheet-reorganizeAdvanced", title: "整理弹窗 · 高级配置"),
+        scene(.sheet(.reorganizeSubmitting), id: "sheet-reorganizeSubmitting", title: "整理弹窗 · 提交中"),
+        scene(.sheet(.reorganizeError), id: "sheet-reorganizeError", title: "整理弹窗 · 错误通知"),
         scene(.sheet(.seasonDetail), id: "sheet-seasonDetail", title: "分季详情弹窗"),
         scene(.sheet(.multiSelection), id: "sheet-multiSelection", title: "多选弹窗 · 站点选择"),
       ]
@@ -933,8 +1511,28 @@ private enum UIPreviewCatalog {
       title: "核心组件",
       scenes: [
         scene(.component(.mediaCards), id: "component-mediaCards", title: "组件 · 媒体卡片"),
+        scene(
+          .component(.mediaCardsContextMenu),
+          id: "component-mediaCardsContextMenu",
+          title: "组件 · 媒体卡片完整菜单"
+        ),
+        scene(
+          .component(.mediaCardsLimitedPermissions),
+          id: "component-mediaCardsLimitedPermissions",
+          title: "组件 · 媒体卡片低权限菜单"
+        ),
         scene(.component(.torrentCards), id: "component-torrentCards", title: "组件 · 种子卡片"),
+        scene(
+          .component(.torrentCardsNoSearchPermission),
+          id: "component-torrentCardsNoSearchPermission",
+          title: "组件 · 种子卡片无搜索权限"
+        ),
+        scene(.component(.torrentDownloadSheet), id: "component-torrentDownloadSheet", title: "组件 · 种子卡片下载弹窗"),
+        scene(.component(.sheetPickerSelection), id: "component-sheetPickerSelection", title: "组件 · 单选弹窗"),
+        scene(.component(.subscriptionAlert), id: "component-subscriptionAlert", title: "组件 · 订阅结果提示"),
         scene(.component(.pickers), id: "component-pickers", title: "组件 · 选择器 / 输入框"),
+        scene(.component(.mediaActionLoading), id: "component-mediaActionLoading", title: "组件 · TMDB 识别中"),
+        scene(.component(.mediaActionNotFound), id: "component-mediaActionNotFound", title: "组件 · TMDB 未识别提示"),
         scene(.component(.notification), id: "component-notification", title: "组件 · 通知"),
       ]
     ),
@@ -961,57 +1559,120 @@ private protocol UIPreviewCase: CaseIterable, Hashable, RawRepresentable where R
 
 private enum UIPreviewAppCase: String, UIPreviewCase {
   case loggedIn
+  case startupPreparing
+  case loggedInLimitedTabs
+  case backendVersionWarning
+  case accountPermissionWarning
   case login
+  case loginReady
+  case loginLoading
+  case loginFailed
 
   var title: String {
     switch self {
     case .loggedIn: return "启动入口 · 正常已登录"
+    case .startupPreparing: return "启动入口 · 启动会话准备中"
+    case .loggedInLimitedTabs: return "启动入口 · 低权限 Tab"
+    case .backendVersionWarning: return "启动入口 · 后端版本告警"
+    case .accountPermissionWarning: return "启动入口 · 账号权限告警"
     case .login: return "启动入口 · 登录页"
+    case .loginReady: return "启动入口 · 可提交登录"
+    case .loginLoading: return "启动入口 · 登录中"
+    case .loginFailed: return "启动入口 · 登录失败"
     }
   }
 
   var note: String {
     switch self {
     case .loggedIn: return "TabView 根入口，覆盖首页/推荐/探索/搜索/状态/设置焦点切换。"
-    case .login: return "未登录根入口，检查服务器地址、用户名、密码和登录按钮焦点。"
+    case .startupPreparing: return "已登录启动时刷新存储会话的全屏准备状态。"
+    case .loggedInLimitedTabs: return "低权限账号只显示可访问 Tab，检查 Tab 数量变化和焦点落点。"
+    case .backendVersionWarning: return "启动后弹出 MoviePilot 后端版本兼容告警。"
+    case .accountPermissionWarning: return "启动后弹出账号推荐权限不足告警。"
+    case .login: return "未登录根入口，检查空表单和禁用登录按钮。"
+    case .loginReady: return "未登录根入口，表单已填充，检查可提交按钮焦点。"
+    case .loginLoading: return "登录按钮进入 ProgressView，检查按钮宽度和焦点稳定。"
+    case .loginFailed: return "登录失败红色错误文案，检查表单间距和按钮状态。"
     }
   }
 }
 
-private enum UIPreviewHomeMode { case loading, empty, full }
-private enum UIPreviewRecommendMode { case loading, empty, full }
-private enum UIPreviewExploreMode { case tmdb, share }
-private enum UIPreviewCollectionMode { case loading, full }
-private enum UIPreviewPersonMode { case loading, full }
+private enum UIPreviewHomeMode { case loading, empty, full, latestEmptyServer, subscriptionsOnly, noSubscribePermission }
+private enum UIPreviewRecommendMode { case initial, loading, empty, full }
+private enum UIPreviewExploreMode { case initial, loading, tmdb, douban, bangumi, popular, share, noSubscribePermission, empty }
+private enum UIPreviewCollectionMode { case loading, empty, full, loadingMore }
+private enum UIPreviewPersonMode { case loading, noBiography, full, biographySheet, loadingMore }
 
 private enum UIPreviewPageCase: String, UIPreviewCase {
   case homeLoading
   case homeEmpty
   case homeFull
+  case homeLatestEmptyServer
+  case homeSubscriptionsOnly
+  case homeNoSubscribePermission
+  case homeNoSearchPermission
+  case homeSubscribeSheet
+  case homeUnsubscribeConfirmation
+  case recommendInitial
   case recommendLoading
   case recommendEmpty
   case recommendFull
+  case recommendLimitedPermissions
+  case exploreInitial
+  case exploreLoading
   case exploreTmdb
+  case exploreDouban
+  case exploreBangumi
+  case explorePopular
   case exploreShare
+  case exploreShareSheet
+  case exploreNoSubscribePermission
+  case exploreEmpty
   case collectionLoading
+  case collectionEmpty
   case collectionFull
+  case collectionLoadingMore
   case personLoading
+  case personNoBiography
+  case personBiographySheet
   case personFull
+  case personLoadingMore
 
   var title: String {
     switch self {
     case .homeLoading: return "首页 · 加载中"
     case .homeEmpty: return "首页 · 空数据"
     case .homeFull: return "首页 · 完整数据"
+    case .homeLatestEmptyServer: return "首页 · 最近添加空服务器"
+    case .homeSubscriptionsOnly: return "首页 · 仅订阅"
+    case .homeNoSubscribePermission: return "首页 · 无订阅权限"
+    case .homeNoSearchPermission: return "首页 · 无搜索权限"
+    case .homeSubscribeSheet: return "首页 · 订阅编辑弹窗"
+    case .homeUnsubscribeConfirmation: return "首页 · 取消订阅确认"
+    case .recommendInitial: return "推荐 · 初始化中"
     case .recommendLoading: return "推荐 · 加载中"
     case .recommendEmpty: return "推荐 · 空数据"
     case .recommendFull: return "推荐 · 完整数据"
+    case .recommendLimitedPermissions: return "推荐 · 低权限菜单"
+    case .exploreInitial: return "探索 · 初始化中"
+    case .exploreLoading: return "探索 · 加载中"
     case .exploreTmdb: return "探索 · TMDB 筛选"
+    case .exploreDouban: return "探索 · 豆瓣筛选"
+    case .exploreBangumi: return "探索 · Bangumi 筛选"
+    case .explorePopular: return "探索 · 热门订阅"
     case .exploreShare: return "探索 · 订阅分享"
+    case .exploreShareSheet: return "探索 · 订阅分享弹窗"
+    case .exploreNoSubscribePermission: return "探索 · 无订阅权限"
+    case .exploreEmpty: return "探索 · 空结果"
     case .collectionLoading: return "合集详情 · 加载中"
+    case .collectionEmpty: return "合集详情 · 空数据"
     case .collectionFull: return "合集详情 · 完整数据"
+    case .collectionLoadingMore: return "合集详情 · 加载更多中"
     case .personLoading: return "人物详情 · 加载中"
+    case .personNoBiography: return "人物详情 · 无简介"
+    case .personBiographySheet: return "人物详情 · 简介弹窗"
     case .personFull: return "人物详情 · 完整数据"
+    case .personLoadingMore: return "人物详情 · 加载更多中"
     }
   }
 
@@ -1020,15 +1681,36 @@ private enum UIPreviewPageCase: String, UIPreviewCase {
     case .homeLoading: return "首页全屏 Loading，检查 Tab 切入后的焦点落点。"
     case .homeEmpty: return "无最近添加、无电影订阅、无电视剧订阅。"
     case .homeFull: return "最近添加服务器 Picker + 电影/电视剧订阅行 + 行操作菜单。"
+    case .homeLatestEmptyServer: return "最近添加服务器存在但当前服务器内容为空，检查空行文案。"
+    case .homeSubscriptionsOnly: return "无最近添加服务器，仅显示电影/电视剧订阅行。"
+    case .homeNoSubscribePermission: return "缺少订阅权限时，只保留最近添加媒体，订阅行为空。"
+    case .homeNoSearchPermission: return "缺少搜索权限时，最近添加卡片菜单不出现搜索资源入口。"
+    case .homeSubscribeSheet: return "首页订阅卡片编辑 Sheet。"
+    case .homeUnsubscribeConfirmation: return "首页订阅卡片取消订阅确认 Alert。"
+    case .recommendInitial: return "推荐页 paginator 尚未初始化。"
     case .recommendLoading: return "推荐页 Paginator 首次加载。"
     case .recommendEmpty: return "推荐页分类/货架存在但网格为空。"
     case .recommendFull: return "推荐页分类、货架和媒体网格完整组合。"
+    case .recommendLimitedPermissions: return "推荐页保留发现权限，卡片菜单隐藏订阅和资源搜索入口。"
+    case .exploreInitial: return "探索页 paginator 尚未初始化。"
+    case .exploreLoading: return "探索页 Paginator 首次加载。"
     case .exploreTmdb: return "探索页 TheMovieDb 多 Picker 过滤器。"
+    case .exploreDouban: return "探索页豆瓣排序、风格、地区、年代过滤器。"
+    case .exploreBangumi: return "探索页 Bangumi 分类、排序、年份过滤器。"
+    case .explorePopular: return "探索页热门订阅排序、风格和评分过滤器。"
     case .exploreShare: return "探索页订阅分享源，卡片触发 Fork 入口。"
+    case .exploreShareSheet: return "探索页订阅分享卡片点击后，通过真实 ExploreView sheet 展示 ForkSubscribeSheet。"
+    case .exploreNoSubscribePermission: return "探索页缺少订阅权限时，数据源不出现订阅分享。"
+    case .exploreEmpty: return "探索页筛选器存在但结果为空。"
     case .collectionLoading: return "合集详情真实根路径加载中。"
+    case .collectionEmpty: return "合集详情真实根路径空态。"
     case .collectionFull: return "合集详情网格 + 详情导航。"
+    case .collectionLoadingMore: return "合集详情已有内容时底部加载更多中。"
     case .personLoading: return "人物详情简介加载占位 + 作品加载。"
+    case .personNoBiography: return "人物详情无简介占位 + 作品网格。"
+    case .personBiographySheet: return "人物详情简介 Sheet 展开。"
     case .personFull: return "人物详情头像/简介/作品网格。"
+    case .personLoadingMore: return "人物详情已有作品时底部加载更多中。"
     }
   }
 
@@ -1036,12 +1718,25 @@ private enum UIPreviewPageCase: String, UIPreviewCase {
     switch self {
     case .homeLoading: return .loading
     case .homeEmpty: return .empty
+    case .homeLatestEmptyServer: return .latestEmptyServer
+    case .homeSubscriptionsOnly: return .subscriptionsOnly
+    case .homeNoSubscribePermission: return .noSubscribePermission
+    case .homeSubscribeSheet, .homeUnsubscribeConfirmation: return .full
     default: return .full
+    }
+  }
+
+  var homePresentation: HomeViewUIPreviewPresentation? {
+    switch self {
+    case .homeSubscribeSheet: return .subscribeSheet
+    case .homeUnsubscribeConfirmation: return .unsubscribeConfirmation
+    default: return nil
     }
   }
 
   var recommendMode: UIPreviewRecommendMode {
     switch self {
+    case .recommendInitial: return .initial
     case .recommendLoading: return .loading
     case .recommendEmpty: return .empty
     default: return .full
@@ -1049,59 +1744,191 @@ private enum UIPreviewPageCase: String, UIPreviewCase {
   }
 
   var exploreMode: UIPreviewExploreMode {
-    self == .exploreShare ? .share : .tmdb
+    switch self {
+    case .exploreInitial: return .initial
+    case .exploreLoading: return .loading
+    case .exploreDouban: return .douban
+    case .exploreBangumi: return .bangumi
+    case .explorePopular: return .popular
+    case .exploreShare: return .share
+    case .exploreShareSheet: return .share
+    case .exploreNoSubscribePermission: return .noSubscribePermission
+    case .exploreEmpty: return .empty
+    default: return .tmdb
+    }
+  }
+
+  var permissions: Set<UserPermissionKey> {
+    switch self {
+    case .homeNoSubscribePermission:
+      return [.discovery, .search, .manage]
+    case .homeNoSearchPermission:
+      return [.discovery, .subscribe, .manage]
+    case .exploreNoSubscribePermission:
+      return [.discovery, .search, .manage]
+    case .recommendLimitedPermissions:
+      return [.discovery]
+    case .homeLoading, .homeEmpty, .homeFull, .homeLatestEmptyServer, .homeSubscriptionsOnly,
+      .homeSubscribeSheet, .homeUnsubscribeConfirmation, .recommendInitial, .recommendLoading,
+      .recommendEmpty, .recommendFull, .exploreInitial, .exploreLoading, .exploreTmdb, .exploreDouban,
+      .exploreBangumi, .explorePopular, .exploreShare, .exploreShareSheet, .exploreEmpty, .collectionLoading,
+      .collectionEmpty, .collectionFull, .collectionLoadingMore, .personLoading, .personNoBiography,
+      .personBiographySheet, .personFull, .personLoadingMore:
+      return .allPreviewPermissions
+    }
   }
 
   var collectionMode: UIPreviewCollectionMode {
-    self == .collectionLoading ? .loading : .full
+    switch self {
+    case .collectionLoading: return .loading
+    case .collectionEmpty: return .empty
+    case .collectionLoadingMore: return .loadingMore
+    default: return .full
+    }
   }
 
   var personMode: UIPreviewPersonMode {
-    self == .personLoading ? .loading : .full
+    switch self {
+    case .personLoading: return .loading
+    case .personNoBiography: return .noBiography
+    case .personBiographySheet: return .biographySheet
+    case .personLoadingMore: return .loadingMore
+    default: return .full
+    }
+  }
+
+  var explorePreviewForkShare: SubscribeShare? {
+    switch self {
+    case .exploreShareSheet:
+      return UIPreviewFixtures.previewSubscribeShare
+    default:
+      return nil
+    }
   }
 }
 
 private enum UIPreviewDetailCase: String, UIPreviewCase {
   case loading
+  case detailLoadFailed
+  case movieUnsubscribed
+  case movieSubscribed
   case tvWithSeasons
+  case tvWithSeasonsNoSubscribePermission
   case tvWithoutSeasons
   case seasonLoadFailed
   case noArtwork
+  case contentPage
+  case contentPageRowsLoadingMore
+  case contentPageNoSearchAndNoSubscribePermission
+  case contentPageSingleEpisodeGroup
+  case contentPageManySeasons
+  case tmdbJumpLoading
+  case siteSelection
+  case subscribeSheet
+  case unsubscribeConfirmation
+  case unsubscribing
   case noSubscribePermission
   case noSearchPermission
+  case tvWithoutSeasonsNoSubscribePermission
+  case tvWithoutSeasonsNoSearchPermission
+  case noSearchAndNoSubscribePermission
 
   var title: String {
     switch self {
     case .loading: return "详情页 · 加载中"
+    case .detailLoadFailed: return "详情页 · 详情加载失败"
+    case .movieUnsubscribed: return "详情页 · 电影，未订阅"
+    case .movieSubscribed: return "详情页 · 电影，已订阅"
     case .tvWithSeasons: return "详情页 · 电视剧，有分季"
+    case .tvWithSeasonsNoSubscribePermission: return "详情页 · 有分季且无订阅权限"
     case .tvWithoutSeasons: return "详情页 · 电视剧，无分季"
     case .seasonLoadFailed: return "详情页 · 分季加载失败"
     case .noArtwork: return "详情页 · 无海报 / 无背景图"
+    case .contentPage: return "详情页 · 第二页内容"
+    case .contentPageRowsLoadingMore: return "详情页 · 第二页行加载更多"
+    case .contentPageNoSearchAndNoSubscribePermission: return "详情页 · 第二页无操作权限"
+    case .contentPageSingleEpisodeGroup: return "详情页 · 分季单剧集组"
+    case .contentPageManySeasons: return "详情页 · 多分季 / 多剧集组"
+    case .tmdbJumpLoading: return "详情页 · TMDB 跳转识别中"
+    case .siteSelection: return "详情页 · 站点选择弹窗"
+    case .subscribeSheet: return "详情页 · 订阅弹窗"
+    case .unsubscribeConfirmation: return "详情页 · 取消订阅确认"
+    case .unsubscribing: return "详情页 · 取消订阅中"
     case .noSubscribePermission: return "详情页 · 无订阅权限"
     case .noSearchPermission: return "详情页 · 无搜索权限"
+    case .tvWithoutSeasonsNoSubscribePermission: return "详情页 · 无分季且无订阅权限"
+    case .tvWithoutSeasonsNoSearchPermission: return "详情页 · 无分季且无搜索权限"
+    case .noSearchAndNoSubscribePermission: return "详情页 · 无搜索且无订阅权限"
     }
   }
 
   var note: String {
     switch self {
     case .loading: return "保持 Loading 遮罩，验证焦点不会落到下层详情。"
+    case .detailLoadFailed: return "完整详情接口失败时，容器退掉 Loading 并显示 partial detail fallback。"
+    case .movieUnsubscribed: return "电影直订阅 Header，检查订阅按钮和资源搜索并列。"
+    case .movieSubscribed: return "电影已订阅 Header，检查已订阅按钮和取消确认入口。"
     case .tvWithSeasons: return "Header 分季订阅 + 第二页分季横向 Shelf。"
+    case .tvWithSeasonsNoSubscribePermission: return "有分季数据但无订阅权限，检查 Header 和分季行不出现订阅入口。"
     case .tvWithoutSeasons: return "分季加载完成但为空，Header 显示不可用状态。"
     case .seasonLoadFailed: return "分季区域保留错误 Banner，可关闭错误提示。"
     case .noArtwork: return "背景和海报都为空，验证占位背景与文字可读性。"
+    case .contentPage: return "详情页第二页内容，检查分季/演职员/推荐行和背景模糊。"
+    case .contentPageRowsLoadingMore:
+      return "详情页第二页演员、推荐、类似行显示加载更多进度。"
+    case .contentPageNoSearchAndNoSubscribePermission:
+      return "关闭订阅和搜索后直接进入第二页，检查演员/职员/推荐/类似行焦点和滚动。"
+    case .contentPageSingleEpisodeGroup:
+      return "分季 Shelf 只有默认剧集组，检查无剧集组 Picker 的布局。"
+    case .contentPageManySeasons:
+      return "超过 10 季并带多个剧集组，检查展开按钮和查看全部卡片。"
+    case .tmdbJumpLoading: return "外部来源详情缺少 TMDB ID，Header 跳转按钮显示识别中。"
+    case .siteSelection: return "详情页资源搜索站点选择 Sheet。"
+    case .subscribeSheet: return "详情页 Header 订阅弹窗。"
+    case .unsubscribeConfirmation: return "详情页 Header 取消订阅确认。"
+    case .unsubscribing: return "已订阅电影 Header 中，订阅按钮显示取消订阅进行中的 ProgressView。"
     case .noSubscribePermission: return "隐藏订阅入口，只保留搜索和 TMDB 跳转。"
     case .noSearchPermission: return "隐藏搜索和站点筛选，只保留分季订阅。"
+    case .tvWithoutSeasonsNoSubscribePermission: return "无分季数据同时无订阅权限，检查 Header 不出现不可用订阅按钮。"
+    case .tvWithoutSeasonsNoSearchPermission: return "无分季数据同时无搜索权限，检查 Header 只保留不可用订阅状态。"
+    case .noSearchAndNoSubscribePermission: return "隐藏订阅和资源搜索入口，检查 Header 只保留基础信息。"
     }
   }
 
   var permissions: Set<UserPermissionKey> {
     switch self {
-    case .noSubscribePermission:
+    case .noSubscribePermission, .tvWithSeasonsNoSubscribePermission, .tvWithoutSeasonsNoSubscribePermission:
       return [.discovery, .search, .manage]
-    case .noSearchPermission:
+    case .noSearchPermission, .tvWithoutSeasonsNoSearchPermission:
       return [.discovery, .subscribe, .manage]
+    case .contentPageNoSearchAndNoSubscribePermission, .noSearchAndNoSubscribePermission:
+      return [.discovery, .manage]
     default:
       return .allPreviewPermissions
+    }
+  }
+
+  var isSubscribed: Bool {
+    self == .movieSubscribed || self == .unsubscribeConfirmation || self == .unsubscribing
+  }
+
+  var presentation: MediaDetailUIPreviewPresentation? {
+    switch self {
+    case .contentPage, .contentPageRowsLoadingMore, .contentPageNoSearchAndNoSubscribePermission,
+      .contentPageSingleEpisodeGroup, .contentPageManySeasons:
+      return .contentPage
+    case .tmdbJumpLoading:
+      return .tmdbJumpLoading
+    case .siteSelection:
+      return .siteSelection
+    case .subscribeSheet:
+      return .subscribeSheet
+    case .unsubscribeConfirmation:
+      return .unsubscribeConfirmation
+    case .unsubscribing:
+      return .unsubscribing
+    default:
+      return nil
     }
   }
 }
@@ -1112,6 +1939,10 @@ private enum UIPreviewSeasonCase: String, UIPreviewCase {
   case empty
   case failed
   case mixedSubscription
+  case noSubscribePermission
+  case seasonDetail
+  case subscribeSheet
+  case unsubscribeConfirmation
 
   var title: String {
     switch self {
@@ -1120,6 +1951,10 @@ private enum UIPreviewSeasonCase: String, UIPreviewCase {
     case .empty: return "分季页 · 空数据"
     case .failed: return "分季页 · 加载失败"
     case .mixedSubscription: return "分季页 · 已订阅 / 缺集混合"
+    case .noSubscribePermission: return "分季页 · 无订阅权限"
+    case .seasonDetail: return "分季页 · 分季详情弹窗"
+    case .subscribeSheet: return "分季页 · 新增订阅弹窗"
+    case .unsubscribeConfirmation: return "分季页 · 取消订阅确认"
     }
   }
 
@@ -1130,67 +1965,163 @@ private enum UIPreviewSeasonCase: String, UIPreviewCase {
     case .empty: return "无季集信息空态。"
     case .failed: return "错误 Banner + 空态组合。"
     case .mixedSubscription: return "已订阅、完整入库、部分缺失、整季缺失组合。"
+    case .noSubscribePermission: return "缺少订阅权限时，分季卡片显示锁定状态且不出现订阅菜单项。"
+    case .seasonDetail: return "分季页卡片详情 Sheet。"
+    case .subscribeSheet: return "未订阅分季新增订阅 Sheet。"
+    case .unsubscribeConfirmation: return "已订阅分季取消确认 Alert。"
     }
   }
 
   var permissions: Set<UserPermissionKey> {
-    .allPreviewPermissions
+    switch self {
+    case .noSubscribePermission:
+      return [.discovery, .search, .manage]
+    case .loading, .seasons, .empty, .failed, .mixedSubscription, .seasonDetail, .subscribeSheet,
+      .unsubscribeConfirmation:
+      return .allPreviewPermissions
+    }
+  }
+
+  var dataMode: UIPreviewSeasonCase {
+    switch self {
+    case .noSubscribePermission:
+      return .seasons
+    case .seasonDetail, .subscribeSheet, .unsubscribeConfirmation:
+      return .mixedSubscription
+    default:
+      return self
+    }
+  }
+
+  var presentation: SubscribeSeasonUIPreviewPresentation? {
+    switch self {
+    case .seasonDetail:
+      return .seasonDetail
+    case .subscribeSheet:
+      return .subscribeSheet
+    case .unsubscribeConfirmation:
+      return .unsubscribeConfirmation
+    default:
+      return nil
+    }
   }
 }
 
-private enum UIPreviewResourcePageMode { case loading, results }
+private enum UIPreviewResourcePageMode { case loading, empty, results }
 
 private enum UIPreviewSearchCase: String, UIPreviewCase {
+  case notSearched
+  case unifiedLoading
   case unifiedResults
+  case unifiedLoadingMore
+  case unifiedShareSheet
+  case unifiedResultsNoSubscribePermission
   case unifiedEmpty
+  case siteSelection
   case resourceLoading
   case resourceResults
   case resourceEmpty
   case resourcePageLoading
+  case resourcePageEmpty
   case resourcePageResults
+  case resourcePageFilterSelection
 
   var title: String {
     switch self {
+    case .notSearched: return "搜索 · 未搜索"
+    case .unifiedLoading: return "搜索 · 聚合加载中"
     case .unifiedResults: return "搜索 · 聚合结果"
+    case .unifiedLoadingMore: return "搜索 · 聚合行加载更多"
+    case .unifiedShareSheet: return "搜索 · 订阅分享弹窗"
+    case .unifiedResultsNoSubscribePermission: return "搜索 · 聚合结果无订阅权限"
     case .unifiedEmpty: return "搜索 · 聚合空结果"
+    case .siteSelection: return "搜索 · 站点选择弹窗"
     case .resourceLoading: return "搜索 · 资源加载中"
     case .resourceResults: return "搜索 · 资源结果"
     case .resourceEmpty: return "搜索 · 资源空结果"
     case .resourcePageLoading: return "资源结果页 · 加载中"
+    case .resourcePageEmpty: return "资源结果页 · 空数据"
     case .resourcePageResults: return "资源结果页 · 完整数据"
+    case .resourcePageFilterSelection: return "资源结果页 · 筛选弹窗"
     }
   }
 
   var note: String {
     switch self {
+    case .notSearched: return "搜索页未输入/未提交时，仅显示顶部搜索类型区。"
+    case .unifiedLoading: return "聚合搜索提交后加载中。"
     case .unifiedResults: return "最佳结果、电影、电视剧、合集、人物、订阅分享多行组合。"
+    case .unifiedLoadingMore: return "聚合搜索已有结果时，各横向结果行底部显示加载更多进度。"
+    case .unifiedShareSheet: return "聚合搜索订阅分享点击后，通过真实 SearchView sheet 展示 ForkSubscribeSheet。"
+    case .unifiedResultsNoSubscribePermission: return "聚合搜索结果中隐藏订阅分享行和复用入口。"
     case .unifiedEmpty: return "搜索完成但没有任何聚合结果。"
+    case .siteSelection: return "资源模式站点筛选 Sheet。"
     case .resourceLoading: return "资源模式流式进度文案和进度条。"
     case .resourceResults: return "资源模式结果筛选栏 + 种子卡片。"
     case .resourceEmpty: return "资源模式搜索完成但无资源。"
     case .resourcePageLoading: return "从详情/菜单进入的资源结果页加载中。"
+    case .resourcePageEmpty: return "从详情/菜单进入的资源结果页空态。"
     case .resourcePageResults: return "资源结果页背景图 + 筛选栏 + 种子卡片。"
+    case .resourcePageFilterSelection: return "资源结果页筛选栏弹出的站点多选 Sheet。"
     }
   }
 
   var resourcePageMode: UIPreviewResourcePageMode {
-    self == .resourcePageLoading ? .loading : .results
+    switch self {
+    case .resourcePageLoading: return .loading
+    case .resourcePageEmpty: return .empty
+    default: return .results
+    }
+  }
+
+  var showsSiteSelection: Bool {
+    self == .siteSelection
+  }
+
+  var permissions: Set<UserPermissionKey> {
+    switch self {
+    case .unifiedResultsNoSubscribePermission:
+      return [.discovery, .search, .manage]
+    case .notSearched, .unifiedLoading, .unifiedResults, .unifiedLoadingMore, .unifiedShareSheet, .unifiedEmpty, .siteSelection,
+      .resourceLoading, .resourceResults, .resourceEmpty, .resourcePageLoading, .resourcePageEmpty,
+      .resourcePageResults, .resourcePageFilterSelection:
+      return .allPreviewPermissions
+    }
+  }
+
+  var resourceTorrentsPresentation: TorrentsResultUIPreviewPresentation? {
+    self == .resourcePageFilterSelection ? .filterSelection : nil
+  }
+
+  var searchPreviewForkShare: SubscribeShare? {
+    switch self {
+    case .unifiedShareSheet:
+      return UIPreviewFixtures.previewSubscribeShare
+    default:
+      return nil
+    }
   }
 }
 
 private enum UIPreviewStatusMode { case empty, full }
 private enum UIPreviewDownloadMode { case empty, multiState }
-private enum UIPreviewTransferMode { case loading, empty, aiRedoing }
+private enum UIPreviewTransferMode { case loading, loadingMore, empty, aiRedoing }
 
 private enum UIPreviewStatusCase: String, UIPreviewCase {
   case statusEmpty
   case statusFull
   case downloadEmpty
   case downloadMultiState
+  case downloadCollapsed
+  case downloadDeleteConfirmation
   case transferLoading
+  case transferLoadingMore
   case transferEmpty
   case transferAiRedoing
   case transferDetail
+  case transferSingleDelete
+  case transferBatchDelete
+  case transferBatchReorganize
 
   var title: String {
     switch self {
@@ -1198,10 +2129,16 @@ private enum UIPreviewStatusCase: String, UIPreviewCase {
     case .statusFull: return "状态页 · 完整数据"
     case .downloadEmpty: return "下载任务 · 空数据"
     case .downloadMultiState: return "下载任务 · 多状态任务"
+    case .downloadCollapsed: return "下载任务 · 收起"
+    case .downloadDeleteConfirmation: return "下载任务 · 删除确认"
     case .transferLoading: return "整理历史 · 加载中"
+    case .transferLoadingMore: return "整理历史 · 加载更多中"
     case .transferEmpty: return "整理历史 · 空数据"
     case .transferAiRedoing: return "整理历史 · 多选 / AI 整理中"
     case .transferDetail: return "整理历史 · 详情弹窗"
+    case .transferSingleDelete: return "整理历史 · 单项删除确认"
+    case .transferBatchDelete: return "整理历史 · 批量删除确认"
+    case .transferBatchReorganize: return "整理历史 · 批量重整弹窗"
     }
   }
 
@@ -1211,10 +2148,16 @@ private enum UIPreviewStatusCase: String, UIPreviewCase {
     case .statusFull: return "统计卡、存储、下载器、下载任务、整理历史组合。"
     case .downloadEmpty: return "下载任务标题区、下载器 Picker 和空态。"
     case .downloadMultiState: return "下载中、暂停、错误、校验等状态徽标和 ActionRow。"
+    case .downloadCollapsed: return "下载任务收起后只保留标题和操作区。"
+    case .downloadDeleteConfirmation: return "下载任务行删除确认 Alert。"
     case .transferLoading: return "整理历史首次加载中。"
+    case .transferLoadingMore: return "整理历史已有列表时底部加载更多中。"
     case .transferEmpty: return "整理历史空态。"
     case .transferAiRedoing: return "多选、AI 整理中遮罩和行操作按钮。"
     case .transferDetail: return "整理历史长按详情弹窗，检查路径、存储名和状态信息。"
+    case .transferSingleDelete: return "整理历史单项删除确认 Alert。"
+    case .transferBatchDelete: return "整理历史批量删除确认 Alert。"
+    case .transferBatchReorganize: return "整理历史批量重整 Sheet。"
     }
   }
 
@@ -1229,8 +2172,35 @@ private enum UIPreviewStatusCase: String, UIPreviewCase {
   var transferMode: UIPreviewTransferMode {
     switch self {
     case .transferLoading: return .loading
+    case .transferLoadingMore: return .loadingMore
     case .transferEmpty: return .empty
     default: return .aiRedoing
+    }
+  }
+
+  var downloadPresentation: DownloadTaskUIPreviewPresentation? {
+    switch self {
+    case .downloadCollapsed:
+      return .collapsed
+    case .downloadDeleteConfirmation:
+      return .deleteConfirmation
+    default:
+      return nil
+    }
+  }
+
+  var transferPresentation: TransferHistoryUIPreviewPresentation? {
+    switch self {
+    case .transferDetail:
+      return .detail
+    case .transferSingleDelete:
+      return .singleDelete
+    case .transferBatchDelete:
+      return .batchDelete
+    case .transferBatchReorganize:
+      return .batchReorganize
+    default:
+      return nil
     }
   }
 }
@@ -1239,6 +2209,21 @@ private enum UIPreviewSettingsCase: String, UIPreviewCase {
   case fullAccess
   case noSubscribe
   case noSearch
+  case noSuperUser
+  case limitedPermissions
+  case connection
+  case connectionRefreshing
+  case siteSelection
+  case siteEmpty
+  case hardFilter
+  case hardFilterLoading
+  case hardFilterEmpty
+  case softFilter
+  case softFilterLoading
+  case softFilterEmpty
+  case siteLoading
+  case rulesLoading
+  case rulesEmpty
   case appInfo
   case logoutConfirmation
 
@@ -1247,6 +2232,21 @@ private enum UIPreviewSettingsCase: String, UIPreviewCase {
     case .fullAccess: return "设置 · 全权限"
     case .noSubscribe: return "设置 · 无订阅权限"
     case .noSearch: return "设置 · 无搜索权限"
+    case .noSuperUser: return "设置 · 无超级用户权限"
+    case .limitedPermissions: return "设置 · 低权限"
+    case .connection: return "设置 · 连接页"
+    case .connectionRefreshing: return "设置 · 刷新登录凭据中"
+    case .siteSelection: return "设置 · 站点选择页"
+    case .siteEmpty: return "设置 · 站点空列表"
+    case .hardFilter: return "设置 · 硬过滤页"
+    case .hardFilterLoading: return "设置 · 硬过滤加载中"
+    case .hardFilterEmpty: return "设置 · 硬过滤空列表"
+    case .softFilter: return "设置 · 软过滤页"
+    case .softFilterLoading: return "设置 · 软过滤加载中"
+    case .softFilterEmpty: return "设置 · 软过滤空列表"
+    case .siteLoading: return "设置 · 站点加载中"
+    case .rulesLoading: return "设置 · 过滤规则加载中"
+    case .rulesEmpty: return "设置 · 过滤规则空列表"
     case .appInfo: return "设置 · APP 信息"
     case .logoutConfirmation: return "设置 · 退出登录确认"
     }
@@ -1257,6 +2257,21 @@ private enum UIPreviewSettingsCase: String, UIPreviewCase {
     case .fullAccess: return "订阅、详情页、搜索站点、自定义过滤、连接信息全部可见。"
     case .noSubscribe: return "隐藏订阅设置，保留详情页和搜索设置。"
     case .noSearch: return "隐藏资源搜索设置，保留订阅和详情页设置。"
+    case .noSuperUser: return "保留订阅和搜索设置，隐藏需要超级用户端点的自定义过滤。"
+    case .limitedPermissions: return "只保留详情页、连接和 APP 信息，隐藏订阅、搜索与超级用户设置。"
+    case .connection: return "设置连接子页，检查登录凭据和状态信息。"
+    case .connectionRefreshing: return "设置连接子页刷新登录凭据中，检查按钮 ProgressView 和禁用态。"
+    case .siteSelection: return "默认搜索站点子页。"
+    case .siteEmpty: return "默认搜索站点子页空列表，检查全部站点和空状态提示。"
+    case .hardFilter: return "硬过滤规则选择子页。"
+    case .hardFilterLoading: return "硬过滤规则选择子页加载中。"
+    case .hardFilterEmpty: return "硬过滤规则选择子页空列表。"
+    case .softFilter: return "软过滤规则选择子页。"
+    case .softFilterLoading: return "软过滤规则选择子页加载中。"
+    case .softFilterEmpty: return "软过滤规则选择子页空列表。"
+    case .siteLoading: return "默认搜索站点子页加载中。"
+    case .rulesLoading: return "资源搜索根设置中的规则状态加载中。"
+    case .rulesEmpty: return "资源搜索根设置中的规则状态为空。"
     case .appInfo: return "设置页 App 信息 Sheet，检查版本、兼容版本和链接行。"
     case .logoutConfirmation: return "退出登录系统 Alert，检查取消/确认焦点。"
     }
@@ -1264,49 +2279,128 @@ private enum UIPreviewSettingsCase: String, UIPreviewCase {
 
   var permissions: Set<UserPermissionKey> {
     switch self {
-    case .fullAccess, .appInfo, .logoutConfirmation: return .allPreviewPermissions
+    case .fullAccess, .noSuperUser, .connection, .connectionRefreshing, .siteSelection, .siteEmpty,
+      .hardFilter, .hardFilterLoading, .hardFilterEmpty, .softFilter, .softFilterLoading,
+      .softFilterEmpty, .siteLoading, .rulesLoading, .rulesEmpty, .appInfo, .logoutConfirmation:
+      return .allPreviewPermissions
     case .noSubscribe: return [.discovery, .search, .manage]
     case .noSearch: return [.discovery, .subscribe, .manage]
+    case .limitedPermissions: return [.discovery]
     }
   }
 
   var canRequestSuperUserEndpoints: Bool {
     switch self {
-    case .fullAccess, .appInfo, .logoutConfirmation:
+    case .fullAccess, .connection, .connectionRefreshing, .siteSelection, .siteEmpty, .hardFilter,
+      .hardFilterLoading, .hardFilterEmpty, .softFilter, .softFilterLoading, .softFilterEmpty,
+      .siteLoading, .rulesLoading, .rulesEmpty, .appInfo, .logoutConfirmation:
       return true
-    case .noSubscribe, .noSearch:
+    case .noSubscribe, .noSearch, .noSuperUser, .limitedPermissions:
       return false
     }
   }
 
   var presentation: SystemViewUIPreviewPresentation? {
     switch self {
+    case .connection, .connectionRefreshing:
+      return .connection
+    case .siteSelection, .siteEmpty, .siteLoading:
+      return .siteSelection
+    case .hardFilter, .hardFilterLoading, .hardFilterEmpty:
+      return .hardFilter
+    case .softFilter, .softFilterLoading, .softFilterEmpty:
+      return .softFilter
     case .appInfo:
       return .appInfo
     case .logoutConfirmation:
       return .logoutConfirmation
-    case .fullAccess, .noSubscribe, .noSearch:
+    case .fullAccess, .noSubscribe, .noSearch, .noSuperUser, .limitedPermissions, .rulesLoading, .rulesEmpty:
       return nil
+    }
+  }
+
+  var hasEmptySites: Bool {
+    switch self {
+    case .noSearch, .limitedPermissions, .siteLoading, .siteEmpty:
+      return true
+    case .fullAccess, .noSubscribe, .noSuperUser, .connection, .connectionRefreshing, .siteSelection,
+      .hardFilter, .hardFilterLoading, .hardFilterEmpty, .softFilter, .softFilterLoading,
+      .softFilterEmpty, .rulesLoading, .rulesEmpty, .appInfo, .logoutConfirmation:
+      return false
+    }
+  }
+
+  var hasEmptyFilterRules: Bool {
+    switch self {
+    case .noSearch, .limitedPermissions, .rulesLoading, .rulesEmpty, .hardFilterLoading, .hardFilterEmpty,
+      .softFilterLoading, .softFilterEmpty:
+      return true
+    case .fullAccess, .noSubscribe, .noSuperUser, .connection, .connectionRefreshing, .siteSelection,
+      .siteEmpty, .hardFilter, .softFilter, .siteLoading, .appInfo, .logoutConfirmation:
+      return false
+    }
+  }
+
+  var isLoadingFilterRules: Bool {
+    switch self {
+    case .rulesLoading, .hardFilterLoading, .softFilterLoading:
+      return true
+    case .fullAccess, .noSubscribe, .noSearch, .noSuperUser, .limitedPermissions, .connection, .connectionRefreshing,
+      .siteSelection, .siteEmpty, .hardFilter, .hardFilterEmpty, .softFilter, .softFilterEmpty,
+      .siteLoading, .rulesEmpty, .appInfo, .logoutConfirmation:
+      return false
     }
   }
 }
 
 private enum UIPreviewSheetCase: String, UIPreviewCase {
+  case subscribeLoading
   case subscribe
+  case subscribeMovie
+  case subscribeAdvanced
+  case subscribeSiteSelection
+  case subscribeFilterGroupSelection
+  case subscribeSaving
   case forkSubscribe
+  case addDownloadLoading
   case addDownload
+  case addDownloadAdvanced
+  case addDownloadSubmitting
+  case addDownloadNoSearchPermission
+  case addDownloadError
+  case reorganizeLoading
   case reorganize
   case reorganizeBatch
+  case reorganizeDouban
+  case reorganizeAdvanced
+  case reorganizeSubmitting
+  case reorganizeError
   case seasonDetail
   case multiSelection
 
   var title: String {
     switch self {
+    case .subscribeLoading: return "订阅弹窗 · 加载中"
     case .subscribe: return "订阅弹窗 · 新增"
+    case .subscribeMovie: return "订阅弹窗 · 电影新增"
+    case .subscribeAdvanced: return "订阅弹窗 · 高级配置"
+    case .subscribeSiteSelection: return "订阅弹窗 · 站点选择"
+    case .subscribeFilterGroupSelection: return "订阅弹窗 · 过滤组选择"
+    case .subscribeSaving: return "订阅弹窗 · 保存中"
     case .forkSubscribe: return "订阅分享弹窗 · 复用"
+    case .addDownloadLoading: return "下载弹窗 · 加载中"
     case .addDownload: return "下载弹窗 · 添加下载"
+    case .addDownloadAdvanced: return "下载弹窗 · 高级配置"
+    case .addDownloadSubmitting: return "下载弹窗 · 提交中"
+    case .addDownloadNoSearchPermission: return "下载弹窗 · 无搜索权限"
+    case .addDownloadError: return "下载弹窗 · 错误通知"
+    case .reorganizeLoading: return "整理弹窗 · 加载中"
     case .reorganize: return "整理弹窗 · 单项重整"
     case .reorganizeBatch: return "整理弹窗 · 批量重整"
+    case .reorganizeDouban: return "整理弹窗 · 豆瓣识别源"
+    case .reorganizeAdvanced: return "整理弹窗 · 高级配置"
+    case .reorganizeSubmitting: return "整理弹窗 · 提交中"
+    case .reorganizeError: return "整理弹窗 · 错误通知"
     case .seasonDetail: return "分季详情弹窗"
     case .multiSelection: return "多选弹窗 · 站点选择"
     }
@@ -1314,28 +2408,121 @@ private enum UIPreviewSheetCase: String, UIPreviewCase {
 
   var note: String {
     switch self {
+    case .subscribeLoading: return "订阅弹窗配置加载中，检查全屏 ProgressView。"
     case .subscribe: return "新增订阅表单、站点/下载器/保存路径/高级配置入口。"
+    case .subscribeMovie: return "电影订阅表单，检查电视剧集数和剧集组字段隐藏。"
+    case .subscribeAdvanced: return "新增订阅表单高级配置展开。"
+    case .subscribeSiteSelection: return "新增订阅站点选择 Sheet。"
+    case .subscribeFilterGroupSelection: return "高级配置中的优先级规则组选择 Sheet。"
+    case .subscribeSaving: return "新增订阅保存中按钮进度。"
     case .forkSubscribe: return "订阅分享复用入口，检查海报、分享人和复用按钮焦点。"
+    case .addDownloadLoading: return "下载弹窗配置加载中，检查 Loading 居中和 Sheet 尺寸。"
     case .addDownload: return "添加下载表单、种子信息、下载器、保存路径和 TMDB ID。"
+    case .addDownloadAdvanced: return "添加下载高级配置展开。"
+    case .addDownloadSubmitting: return "添加下载提交中按钮进度。"
+    case .addDownloadNoSearchPermission: return "搜索权限缺失时，添加下载确认按钮禁用。"
+    case .addDownloadError: return "添加下载失败后，Sheet 关闭并显示错误通知。"
+    case .reorganizeLoading: return "整理弹窗配置加载中，检查 NavigationStack 内 Loading。"
     case .reorganize: return "重新整理表单、目的存储、整理方式、剧集定位和高级配置。"
     case .reorganizeBatch: return "整理历史批量重整表单，检查无单文件时的字段状态。"
+    case .reorganizeDouban: return "后端识别源为 Douban 时显示豆瓣 ID 字段。"
+    case .reorganizeAdvanced: return "整理弹窗高级配置展开。"
+    case .reorganizeSubmitting: return "整理弹窗提交中按钮进度。"
+    case .reorganizeError: return "整理失败后，表单保留并显示错误通知。"
     case .seasonDetail: return "分季详情弹窗，检查海报、播出日期、评分和简介。"
     case .multiSelection: return "多选 Sheet、禁用项说明和确认按钮焦点。"
+    }
+  }
+
+  var subscribePresentation: SubscribeSheetUIPreviewPresentation? {
+    switch self {
+    case .subscribeAdvanced:
+      return .advanced
+    case .subscribeSiteSelection:
+      return .siteSelection
+    case .subscribeFilterGroupSelection:
+      return .filterGroupSelection
+    default:
+      return nil
+    }
+  }
+
+  var addDownloadPresentation: AddDownloadSheetUIPreviewPresentation? {
+    switch self {
+    case .addDownloadAdvanced:
+      return .advanced
+    case .addDownloadError:
+      return .errorNotification
+    default:
+      return nil
+    }
+  }
+
+  var permissions: Set<UserPermissionKey> {
+    switch self {
+    case .addDownloadNoSearchPermission:
+      return [.discovery, .subscribe, .manage]
+    case .subscribeLoading, .subscribe, .subscribeMovie, .subscribeAdvanced, .subscribeSiteSelection,
+      .subscribeFilterGroupSelection, .subscribeSaving, .forkSubscribe, .addDownloadLoading,
+      .addDownload, .addDownloadAdvanced, .addDownloadSubmitting, .addDownloadError,
+      .reorganizeLoading, .reorganize, .reorganizeBatch, .reorganizeDouban, .reorganizeAdvanced,
+      .reorganizeSubmitting, .reorganizeError, .seasonDetail, .multiSelection:
+      return .allPreviewPermissions
+    }
+  }
+
+  var reorganizePresentation: ReorganizeSheetUIPreviewPresentation? {
+    switch self {
+    case .reorganizeAdvanced:
+      return .advanced
+    case .reorganizeDouban:
+      return .doubanRecognition
+    case .reorganizeError:
+      return .errorNotification
+    default:
+      return nil
+    }
+  }
+
+  var previewErrorNotificationMessage: String? {
+    switch self {
+    case .addDownloadError:
+      return "预览：添加下载失败，站点返回错误"
+    case .reorganizeError:
+      return "预览：重新整理失败，请检查规则和目标目录"
+    default:
+      return nil
     }
   }
 }
 
 private enum UIPreviewComponentCase: String, UIPreviewCase {
   case mediaCards
+  case mediaCardsContextMenu
+  case mediaCardsLimitedPermissions
   case torrentCards
+  case torrentCardsNoSearchPermission
+  case torrentDownloadSheet
+  case sheetPickerSelection
+  case subscriptionAlert
   case pickers
+  case mediaActionLoading
+  case mediaActionNotFound
   case notification
 
   var title: String {
     switch self {
     case .mediaCards: return "组件 · 媒体卡片"
+    case .mediaCardsContextMenu: return "组件 · 媒体卡片完整菜单"
+    case .mediaCardsLimitedPermissions: return "组件 · 媒体卡片低权限菜单"
     case .torrentCards: return "组件 · 种子卡片"
+    case .torrentCardsNoSearchPermission: return "组件 · 种子卡片无搜索权限"
+    case .torrentDownloadSheet: return "组件 · 种子卡片下载弹窗"
+    case .sheetPickerSelection: return "组件 · 单选弹窗"
+    case .subscriptionAlert: return "组件 · 订阅结果提示"
     case .pickers: return "组件 · 选择器 / 输入框"
+    case .mediaActionLoading: return "组件 · TMDB 识别中"
+    case .mediaActionNotFound: return "组件 · TMDB 未识别提示"
     case .notification: return "组件 · 通知"
     }
   }
@@ -1343,9 +2530,29 @@ private enum UIPreviewComponentCase: String, UIPreviewCase {
   var note: String {
     switch self {
     case .mediaCards: return "普通媒体、无图、合集、订阅分享、加载更多组合。"
+    case .mediaCardsContextMenu: return "全权限媒体卡片菜单，覆盖 TMDB 跳转、已订阅、分季订阅、搜索资源和订阅分享复用入口。"
+    case .mediaCardsLimitedPermissions: return "缺少订阅和搜索权限时，媒体卡片菜单只保留允许的详情入口。"
     case .torrentCards: return "免费、促销、软过滤、低做种等种子卡片组合。"
+    case .torrentCardsNoSearchPermission: return "缺少搜索权限时，种子卡片不能打开添加下载弹窗，菜单不显示下载入口。"
+    case .torrentDownloadSheet: return "从种子卡片入口进入添加下载 Sheet。"
+    case .sheetPickerSelection: return "SheetPicker 单选列表 Sheet。"
+    case .subscriptionAlert: return "全局订阅动作 Alert，覆盖重复订阅/复用结果提示样式。"
     case .pickers: return "Segmented Picker、ShelfPicker、SheetPicker、SheetTextField。"
+    case .mediaActionLoading: return "全局媒体动作遮罩，检查识别中 ProgressView。"
+    case .mediaActionNotFound: return "全局媒体动作 Alert，检查 TMDB 未识别提示。"
     case .notification: return "信息/成功/警告/错误四类通知和悬浮提示。"
+    }
+  }
+
+  var permissions: Set<UserPermissionKey> {
+    switch self {
+    case .mediaCardsLimitedPermissions:
+      return [.discovery, .manage]
+    case .torrentCardsNoSearchPermission:
+      return [.discovery, .subscribe, .manage]
+    case .mediaCards, .mediaCardsContextMenu, .torrentCards, .torrentDownloadSheet, .sheetPickerSelection, .subscriptionAlert,
+      .pickers, .mediaActionLoading, .mediaActionNotFound, .notification:
+      return .allPreviewPermissions
     }
   }
 }
@@ -1370,6 +2577,34 @@ private enum UIPreviewFixtures {
     APIService.shared.uiPreviewCanRequestSuperUserEndpoints = canRequestSuperUserEndpoints
   }
 
+  static func loginViewModel(_ previewCase: UIPreviewAppCase) -> LoginViewModel {
+    let viewModel = LoginViewModel()
+    let filledServerURL = "http://moviepilot.local:3000"
+    switch previewCase {
+    case .login:
+      viewModel.serverURL = ""
+      viewModel.username = ""
+      viewModel.password = ""
+    case .loginReady:
+      viewModel.serverURL = filledServerURL
+      viewModel.username = "preview-user"
+      viewModel.password = "preview-password"
+    case .loginLoading:
+      viewModel.serverURL = filledServerURL
+      viewModel.username = "preview-user"
+      viewModel.password = "preview-password"
+      viewModel.isLoading = true
+    case .loginFailed:
+      viewModel.serverURL = filledServerURL
+      viewModel.username = "preview-user"
+      viewModel.password = "wrong-password"
+      viewModel.errorMessage = "登录失败: 用户名或密码错误"
+    case .loggedIn, .startupPreparing, .loggedInLimitedTabs, .backendVersionWarning, .accountPermissionWarning:
+      break
+    }
+    return viewModel
+  }
+
   @discardableResult
   static func installDetail(_ detailCase: UIPreviewDetailCase) -> MediaInfo {
     applyPermissions(
@@ -1381,24 +2616,46 @@ private enum UIPreviewFixtures {
     let media = detailMedia(detailCase)
     let task = MediaPreloadTask(partialMedia: media)
 
-    if detailCase != .loading {
+    if detailCase == .detailLoadFailed {
+      task.isDetailFailed = true
+    } else if detailCase != .loading {
       task.fullDetail = media
       task.isDetailReady = true
       task.tmdbId = media.tmdb_id
-      task.isSubscribed = false
+      task.isSubscribed = detailCase.isSubscribed
     }
 
     switch detailCase {
-    case .tvWithSeasons, .noArtwork, .noSearchPermission:
+    case .tvWithSeasons, .tvWithSeasonsNoSubscribePermission, .noArtwork, .noSearchPermission, .contentPage,
+      .contentPageRowsLoadingMore, .contentPageNoSearchAndNoSubscribePermission, .siteSelection:
       task.seasonViewModel = seasonViewModel(mediaInfo: media, initialSeason: nil, mode: .mixedSubscription)
       task.isSeasonDataLoaded = true
-    case .tvWithoutSeasons:
+    case .contentPageSingleEpisodeGroup:
+      task.seasonViewModel = seasonViewModel(
+        mediaInfo: media,
+        initialSeason: nil,
+        mode: .seasons,
+        episodeGroups: []
+      )
+      task.isSeasonDataLoaded = true
+    case .contentPageManySeasons:
+      task.seasonViewModel = seasonViewModel(
+        mediaInfo: media,
+        initialSeason: nil,
+        mode: .mixedSubscription,
+        seasons: previewManySeasons,
+        episodeGroups: previewEpisodeGroups
+      )
+      task.isSeasonDataLoaded = true
+    case .tvWithoutSeasons, .tvWithoutSeasonsNoSubscribePermission, .tvWithoutSeasonsNoSearchPermission:
       task.seasonViewModel = seasonViewModel(mediaInfo: media, initialSeason: nil, mode: .empty)
       task.isSeasonDataLoaded = true
     case .seasonLoadFailed:
       task.seasonViewModel = seasonViewModel(mediaInfo: media, initialSeason: nil, mode: .failed)
       task.isSeasonDataLoaded = true
-    case .loading, .noSubscribePermission:
+    case .loading, .detailLoadFailed, .movieUnsubscribed, .movieSubscribed, .tmdbJumpLoading, .subscribeSheet,
+      .unsubscribeConfirmation, .unsubscribing, .noSubscribePermission,
+      .noSearchAndNoSubscribePermission:
       break
     }
 
@@ -1451,6 +2708,44 @@ private enum UIPreviewFixtures {
         ],
         isLoading: false
       )
+    case .latestEmptyServer:
+      viewModel.installUIPreviewData(
+        latestMediaByServer: [
+          "Emby": [],
+          "Plex": mediaServerItems(prefix: "plex"),
+        ],
+        selectedServer: "Emby",
+        movieSubscriptions: [
+          subscribe(id: 31_201, name: "荒原长路", type: "电影", state: "R", lack: nil),
+        ],
+        tvSubscriptions: [
+          subscribe(id: 31_202, name: "边境信号", type: "电视剧", state: "N", lack: 4),
+        ],
+        isLoading: false
+      )
+    case .subscriptionsOnly:
+      viewModel.installUIPreviewData(
+        latestMediaByServer: [:],
+        selectedServer: "",
+        movieSubscriptions: [
+          subscribe(id: 31_301, name: "荒原长路", type: "电影", state: "R", lack: nil),
+        ],
+        tvSubscriptions: [
+          subscribe(id: 31_302, name: "边境信号", type: "电视剧", state: "S", lack: 6),
+        ],
+        isLoading: false
+      )
+    case .noSubscribePermission:
+      viewModel.installUIPreviewData(
+        latestMediaByServer: [
+          "Emby": mediaServerItems(prefix: "emby"),
+          "Plex": mediaServerItems(prefix: "plex"),
+        ],
+        selectedServer: "Emby",
+        movieSubscriptions: [],
+        tvSubscriptions: [],
+        isLoading: false
+      )
     }
     return viewModel
   }
@@ -1460,6 +2755,8 @@ private enum UIPreviewFixtures {
     viewModel.selectedCategory = .movie
     viewModel.selectedShelf = RecommendViewModel.allShelves.first { $0.category == .movie }
     switch mode {
+    case .initial:
+      viewModel.installUIPreviewPaginator(nil)
     case .loading:
       viewModel.installUIPreviewPaginator(.uiPreview(isFirstLoading: true))
     case .empty:
@@ -1473,11 +2770,42 @@ private enum UIPreviewFixtures {
   static func exploreViewModel(_ mode: UIPreviewExploreMode) -> ExploreViewModel {
     let viewModel = ExploreViewModel(loadsAutomatically: false)
     switch mode {
+    case .initial:
+      viewModel.selectedSource = .themoviedb
+      viewModel.selectedType = .movies
+      viewModel.installUIPreviewPaginator(nil)
+    case .loading:
+      viewModel.selectedSource = .themoviedb
+      viewModel.selectedType = .movies
+      viewModel.tmdbGenre = "878"
+      viewModel.installUIPreviewPaginator(.uiPreview(isFirstLoading: true))
     case .tmdb:
       viewModel.selectedSource = .themoviedb
       viewModel.selectedType = .movies
       viewModel.tmdbGenre = "878"
       viewModel.tmdbLanguage = "ja"
+      viewModel.installUIPreviewPaginator(.uiPreview(items: previewMediaGrid, isLoadingMore: true))
+    case .douban:
+      viewModel.selectedSource = .douban
+      viewModel.selectedType = .movies
+      viewModel.doubanSort = "S"
+      viewModel.doubanCategory = "悬疑"
+      viewModel.doubanZone = "日本"
+      viewModel.doubanYear = "2020年代"
+      viewModel.installUIPreviewPaginator(.uiPreview(items: previewMediaGrid))
+    case .bangumi:
+      viewModel.selectedSource = .bangumi
+      viewModel.selectedType = .tvs
+      viewModel.bangumiCat = "1"
+      viewModel.bangumiSort = "rank"
+      viewModel.bangumiYear = "2026"
+      viewModel.installUIPreviewPaginator(.uiPreview(items: previewMediaGrid))
+    case .popular:
+      viewModel.selectedSource = .popular
+      viewModel.selectedType = .tvs
+      viewModel.popularSortBy = "rating"
+      viewModel.popularGenre = "10765"
+      viewModel.popularMinRating = 8
       viewModel.installUIPreviewPaginator(.uiPreview(items: previewMediaGrid, isLoadingMore: true))
     case .share:
       viewModel.selectedSource = .subscriptionShare
@@ -1487,6 +2815,17 @@ private enum UIPreviewFixtures {
         shareMedia(id: 33_001, title: "高质量订阅分享 · 边境信号"),
         shareMedia(id: 33_002, title: "整季打包分享 · 海岸档案"),
       ]))
+    case .noSubscribePermission:
+      viewModel.selectedSource = .themoviedb
+      viewModel.selectedType = .tvs
+      viewModel.tmdbGenre = "10765"
+      viewModel.installUIPreviewPaginator(.uiPreview(items: previewMediaGridWithoutShares, isLoadingMore: true))
+    case .empty:
+      viewModel.selectedSource = .themoviedb
+      viewModel.selectedType = .movies
+      viewModel.tmdbGenre = "878"
+      viewModel.tmdbVoteAverage = 9
+      viewModel.installUIPreviewPaginator(.uiPreview(items: []))
     }
     return viewModel
   }
@@ -1496,12 +2835,30 @@ private enum UIPreviewFixtures {
     viewModel.siteFilter.availableSites = sites
     viewModel.siteFilter.selectedSites = [1, 3]
     switch searchCase {
-    case .unifiedResults:
+    case .notSearched:
+      viewModel.query = ""
+      viewModel.submittedQuery = ""
+      viewModel.searchType = .unified
+      viewModel.hasSearched = false
+      viewModel.isLoading = false
+    case .unifiedLoading:
+      viewModel.query = "边境信号"
+      viewModel.submittedQuery = "边境信号"
+      viewModel.searchType = .unified
+      viewModel.hasSearched = true
+      viewModel.isLoading = true
+    case .unifiedResults, .unifiedLoadingMore, .unifiedShareSheet, .unifiedResultsNoSubscribePermission:
       let movies = [movieMedia(id: 34_001, title: "边境信号：序章")]
       let tvShows = [baseTVMedia(id: 34_101, title: "边境信号")]
       let collections = [collectionMedia(id: 34_201, title: "边境信号系列")]
       let people = [person(id: 34_301, name: "林原真", character: "导演")]
-      let shares = [shareMedia(id: 34_401, title: "边境信号 订阅分享")]
+      let shares = searchCase == .unifiedResultsNoSubscribePermission
+        ? []
+        : [shareMedia(id: 34_401, title: "边境信号 订阅分享")]
+      var bestResults: [BestResultItem] = [.media(tvShows[0]), .person(people[0])]
+      if let share = shares.first {
+        bestResults.append(.media(share))
+      }
       viewModel.installUIPreviewUnifiedResults(
         query: "边境信号",
         movies: movies,
@@ -1509,10 +2866,13 @@ private enum UIPreviewFixtures {
         collections: collections,
         persons: people,
         shares: shares,
-        bestResults: [.media(tvShows[0]), .person(people[0]), .media(shares[0])]
+        bestResults: bestResults,
+        isLoadingMore: searchCase == .unifiedLoadingMore
       )
     case .unifiedEmpty:
       viewModel.installUIPreviewUnifiedEmpty(query: "没有结果的关键词")
+    case .siteSelection:
+      viewModel.installUIPreviewResourceResults(query: "边境信号", results: contexts)
     case .resourceLoading:
       viewModel.installUIPreviewResourceResults(
         query: "边境信号",
@@ -1525,7 +2885,7 @@ private enum UIPreviewFixtures {
       viewModel.installUIPreviewResourceResults(query: "边境信号", results: contexts)
     case .resourceEmpty:
       viewModel.installUIPreviewResourceResults(query: "没有资源的关键词", results: [])
-    case .resourcePageLoading, .resourcePageResults:
+    case .resourcePageLoading, .resourcePageEmpty, .resourcePageResults, .resourcePageFilterSelection:
       break
     }
     return viewModel
@@ -1535,8 +2895,12 @@ private enum UIPreviewFixtures {
     switch mode {
     case .loading:
       return CollectionDetailViewModel(previewPaginator: .uiPreview(isFirstLoading: true))
+    case .empty:
+      return CollectionDetailViewModel(previewPaginator: .uiPreview(items: []))
     case .full:
       return CollectionDetailViewModel(previewPaginator: .uiPreview(items: previewMediaGrid))
+    case .loadingMore:
+      return CollectionDetailViewModel(previewPaginator: .uiPreview(items: previewMediaGrid, isLoadingMore: true))
     }
   }
 
@@ -1545,7 +2909,7 @@ private enum UIPreviewFixtures {
       id: 35_001,
       name: "林原真",
       character: nil,
-      biography: mode == .loading ? nil : "长期活跃于科幻与悬疑题材的导演，作品以冷静的工业质感和细密的人物关系见长。这段长简介用于检查可聚焦简介卡片、Sheet 展开和多行文本。"
+      biography: (mode == .full || mode == .biographySheet) ? "长期活跃于科幻与悬疑题材的导演，作品以冷静的工业质感和细密的人物关系见长。这段长简介用于检查可聚焦简介卡片、Sheet 展开和多行文本。" : nil
     )
     switch mode {
     case .loading:
@@ -1554,10 +2918,22 @@ private enum UIPreviewFixtures {
         previewPaginator: .uiPreview(isFirstLoading: true),
         isLoadingDetails: true
       )
-    case .full:
+    case .noBiography:
       return PersonDetailViewModel(
         person: previewPerson,
         previewPaginator: .uiPreview(items: previewMediaGrid),
+        isLoadingDetails: false
+      )
+    case .full, .biographySheet:
+      return PersonDetailViewModel(
+        person: previewPerson,
+        previewPaginator: .uiPreview(items: previewMediaGrid),
+        isLoadingDetails: false
+      )
+    case .loadingMore:
+      return PersonDetailViewModel(
+        person: previewPerson,
+        previewPaginator: .uiPreview(items: previewMediaGrid, isLoadingMore: true),
         isLoadingDetails: false
       )
     }
@@ -1567,7 +2943,7 @@ private enum UIPreviewFixtures {
     ResourceResultViewModel(
       previewTitle: "边境信号",
       mediaInfo: baseTVMedia(id: 36_001, title: "边境信号"),
-      results: mode == .loading ? [] : contexts,
+      results: mode == .results ? contexts : [],
       isLoading: mode == .loading,
       progressText: "正在搜索默认站点...",
       progress: 60
@@ -1610,6 +2986,12 @@ private enum UIPreviewFixtures {
     switch mode {
     case .loading:
       viewModel.installUIPreviewData(items: [], isFirstLoading: true)
+    case .loadingMore:
+      viewModel.installUIPreviewData(
+        items: transferHistory,
+        storageDict: ["local": "本地存储", "nas": "NAS"],
+        isLoadingMore: true
+      )
     case .empty:
       viewModel.installUIPreviewData(items: [], storageDict: ["local": "本地存储"])
     case .aiRedoing:
@@ -1632,19 +3014,29 @@ private enum UIPreviewFixtures {
       serverURL: "http://moviepilot.local:3000",
       username: "preview-user",
       backendVersion: "v2.14.1",
-      availableSites: settingsCase == .noSearch ? [] : sites,
-      customFilterRules: settingsCase == .fullAccess ? customRules : [],
-      isRefreshing: false,
-      refreshMessage: "上次刷新成功"
+      availableSites: settingsCase.hasEmptySites ? [] : sites,
+      customFilterRules: settingsCase.hasEmptyFilterRules ? [] : customRules,
+      isRefreshing: settingsCase == .connectionRefreshing,
+      refreshMessage: settingsCase == .connectionRefreshing ? "正在刷新登录凭据" : "上次刷新成功",
+      isLoadingSites: settingsCase == .siteLoading,
+      isLoadingRules: settingsCase.isLoadingFilterRules
     )
     return viewModel
   }
 
-  static func subscribeSheetViewModel() -> SubscribeSheetViewModel {
+  static func subscribeSheetViewModel(
+    type: String = "电视剧",
+    isLoading: Bool = false,
+    isSaving: Bool = false
+  ) -> SubscribeSheetViewModel {
     let viewModel = SubscribeSheetViewModel(
-      subscribe: subscribe(id: 45_001, name: "边境信号", type: "电视剧", state: "S", lack: 6),
+      subscribe: subscribe(id: 45_001, name: type == "电视剧" ? "边境信号" : "边境信号：序章", type: type, state: "S", lack: type == "电视剧" ? 6 : nil),
       isNewSubscription: true
     )
+    guard !isLoading else {
+      viewModel.isLoading = true
+      return viewModel
+    }
     viewModel.installUIPreviewOptions(
       sites: sites,
       downloaders: downloaders,
@@ -1655,14 +3047,22 @@ private enum UIPreviewFixtures {
         episodeGroup(id: "preview-alt", name: "播出顺序"),
       ]
     )
+    viewModel.isSaving = isSaving
     return viewModel
   }
 
-  static func addDownloadViewModel() -> AddDownloadViewModel {
+  static func addDownloadViewModel(
+    isLoading: Bool = false,
+    isSubmitting: Bool = false
+  ) -> AddDownloadViewModel {
     let viewModel = AddDownloadViewModel(
       torrent: contexts[0].torrent_info!,
       media: baseTVMedia(id: 45_101, title: "边境信号")
     )
+    guard !isLoading else {
+      viewModel.isLoading = true
+      return viewModel
+    }
     viewModel.installUIPreviewOptions(
       downloaders: downloaders,
       directories: directories,
@@ -1670,15 +3070,23 @@ private enum UIPreviewFixtures {
       selectedDirectory: "/downloads/tv",
       tmdbId: "90101"
     )
+    viewModel.isSubmitting = isSubmitting
     return viewModel
   }
 
-  static func reorganizeViewModel() -> ReorganizeViewModel {
+  static func reorganizeViewModel(
+    isLoading: Bool = false,
+    isSubmitting: Bool = false
+  ) -> ReorganizeViewModel {
     let viewModel = ReorganizeViewModel(
       logIds: [44_001],
       fileItem: fileItem(name: "Frontier.Signal.S01E01.mkv", path: "/downloads/Frontier.Signal.S01E01.mkv"),
       targetStorage: "local"
     )
+    guard !isLoading else {
+      viewModel.isLoading = true
+      return viewModel
+    }
     viewModel.form.type_name = "电视剧"
     viewModel.form.tmdbid = 90_101
     viewModel.form.season = 1
@@ -1692,6 +3100,7 @@ private enum UIPreviewFixtures {
         PickerOption(title: "/media/Movies", value: "/media/Movies"),
       ]
     )
+    viewModel.isSubmitting = isSubmitting
     return viewModel
   }
 
@@ -1714,7 +3123,7 @@ private enum UIPreviewFixtures {
 
   static func seasonViewModel(_ seasonCase: UIPreviewSeasonCase) -> SubscribeSeasonViewModel {
     applyPermissions(seasonCase.permissions)
-    return seasonViewModel(mediaInfo: baseTVMedia(id: 91_100, title: "分季预览剧集"), initialSeason: nil, mode: seasonCase)
+    return seasonViewModel(mediaInfo: baseTVMedia(id: 91_100, title: "分季预览剧集"), initialSeason: nil, mode: seasonCase.dataMode)
   }
 
   static func seasonViewModel(
@@ -1727,16 +3136,20 @@ private enum UIPreviewFixtures {
   private static func seasonViewModel(
     mediaInfo: MediaInfo,
     initialSeason: Int?,
-    mode: UIPreviewSeasonCase
+    mode: UIPreviewSeasonCase,
+    seasons: [TmdbSeason]? = nil,
+    episodeGroups: [EpisodeGroup]? = nil
   ) -> SubscribeSeasonViewModel {
     let viewModel = SubscribeSeasonViewModel(mediaInfo: mediaInfo, initialSeason: initialSeason)
+    let seasonInfos = seasons ?? previewSeasons
+    let groups = episodeGroups ?? previewEpisodeGroups
 
     switch mode {
     case .loading:
       viewModel.isLoading = true
-    case .seasons:
-      viewModel.episodeGroups = [episodeGroup(id: "preview-main", name: "官方顺序")]
-      viewModel.seasonInfos = previewSeasons
+    case .seasons, .noSubscribePermission:
+      viewModel.episodeGroups = groups
+      viewModel.seasonInfos = seasonInfos
       viewModel.seasonsNotExisted = [:]
       viewModel.isSeasonAvailabilityLoaded = true
     case .empty:
@@ -1746,12 +3159,9 @@ private enum UIPreviewFixtures {
       viewModel.hasSeasonLoadError = true
       viewModel.errorMessage = "预览：分季接口加载失败"
       viewModel.isSeasonAvailabilityLoaded = true
-    case .mixedSubscription:
-      viewModel.episodeGroups = [
-        episodeGroup(id: "preview-main", name: "官方顺序"),
-        episodeGroup(id: "preview-alt", name: "播出顺序"),
-      ]
-      viewModel.seasonInfos = previewSeasons
+    case .mixedSubscription, .seasonDetail, .subscribeSheet, .unsubscribeConfirmation:
+      viewModel.episodeGroups = groups
+      viewModel.seasonInfos = seasonInfos
       viewModel.seasonsNotExisted = [1: 0, 2: 1, 3: 2]
       viewModel.isSeasonAvailabilityLoaded = true
       viewModel.seasonSubscriptions = [
@@ -1763,22 +3173,82 @@ private enum UIPreviewFixtures {
     return viewModel
   }
 
+  static func detailRows(for detailCase: UIPreviewDetailCase) -> MediaDetailUIPreviewRows? {
+    switch detailCase {
+    case .contentPage, .contentPageNoSearchAndNoSubscribePermission, .contentPageSingleEpisodeGroup,
+      .contentPageManySeasons:
+      return previewDetailRows
+    case .contentPageRowsLoadingMore:
+      return previewDetailRowsLoadingMore
+    default:
+      return nil
+    }
+  }
+
   private static func detailMedia(_ detailCase: UIPreviewDetailCase) -> MediaInfo {
     switch detailCase {
     case .loading:
       return baseTVMedia(id: 90_001, title: "边境信号 · 加载中")
+    case .detailLoadFailed:
+      return baseTVMedia(id: 90_021, title: "边境信号 · 详情失败")
+    case .movieUnsubscribed:
+      return movieMedia(id: 90_101, title: "荒原长路 · 未订阅")
+    case .movieSubscribed:
+      return movieMedia(id: 90_102, title: "荒原长路 · 已订阅")
     case .tvWithSeasons:
       return baseTVMedia(id: 90_002, title: "边境信号")
+    case .tvWithSeasonsNoSubscribePermission:
+      return baseTVMedia(id: 90_015, title: "边境信号 · 有分季无订阅权限")
     case .tvWithoutSeasons:
       return baseTVMedia(id: 90_003, title: "边境信号 · 无分季")
     case .seasonLoadFailed:
       return baseTVMedia(id: 90_004, title: "边境信号 · 分季失败")
     case .noArtwork:
       return baseTVMedia(id: 90_005, title: "边境信号 · 无图", hasArtwork: false)
+    case .contentPage:
+      return baseTVMedia(id: 90_010, title: "边境信号 · 第二页")
+    case .contentPageRowsLoadingMore:
+      return baseTVMedia(id: 90_019, title: "边境信号 · 第二页加载更多")
+    case .contentPageNoSearchAndNoSubscribePermission:
+      return baseTVMedia(id: 90_016, title: "边境信号 · 第二页无操作权限")
+    case .contentPageSingleEpisodeGroup:
+      return baseTVMedia(id: 90_017, title: "边境信号 · 单剧集组")
+    case .contentPageManySeasons:
+      return baseTVMedia(id: 90_018, title: "边境信号 · 多分季")
+    case .tmdbJumpLoading:
+      return MediaInfo(
+        tmdb_id: nil,
+        douban_id: "36789012",
+        source: "douban",
+        title: "荒原长路 · 识别中",
+        original_title: "Long Road",
+        type: "电影",
+        year: "2025",
+        poster_path: "https://image.tmdb.org/t/p/w500/8cdWjvZQUExUUTzyp4t6EDMubfO.jpg",
+        backdrop_path: "https://image.tmdb.org/t/p/original/3V4kLQg0kSqPLctI5ziYWabAZYF.jpg",
+        overview: "外部来源详情缺少 TMDB ID，用于检查跳转按钮的识别中状态。",
+        vote_average: 7.7,
+        popularity: 88,
+        genres: [genre("剧情")]
+      )
+    case .siteSelection:
+      return baseTVMedia(id: 90_011, title: "边境信号 · 站点选择")
+    case .subscribeSheet:
+      return movieMedia(id: 90_012, title: "荒原长路 · 订阅弹窗")
+    case .unsubscribeConfirmation:
+      return movieMedia(id: 90_013, title: "荒原长路 · 取消订阅")
+    case .unsubscribing:
+      return movieMedia(id: 90_020, title: "荒原长路 · 取消订阅中")
     case .noSubscribePermission:
       return baseTVMedia(id: 90_006, title: "边境信号 · 无订阅权限")
     case .noSearchPermission:
       return baseTVMedia(id: 90_007, title: "边境信号 · 无搜索权限")
+    case .tvWithoutSeasonsNoSubscribePermission:
+      return baseTVMedia(id: 90_008, title: "边境信号 · 无分季无订阅权限")
+    case .tvWithoutSeasonsNoSearchPermission:
+      return baseTVMedia(id: 90_014, title: "边境信号 · 无分季无搜索权限")
+    case .noSearchAndNoSubscribePermission:
+      return baseTVMedia(id: 90_009, title: "边境信号 · 无操作权限")
     }
   }
 
@@ -1830,6 +3300,24 @@ private enum UIPreviewFixtures {
     )
   }
 
+  static func externalSourceMedia(id: Int, title: String) -> MediaInfo {
+    MediaInfo(
+      tmdb_id: nil,
+      douban_id: "\(id)",
+      source: "douban",
+      title: title,
+      original_title: "Frontier Signal",
+      type: "电影",
+      year: "2026",
+      poster_path: "https://image.tmdb.org/t/p/w500/8cdWjvZQUExUUTzyp4t6EDMubfO.jpg",
+      backdrop_path: "https://image.tmdb.org/t/p/original/3V4kLQg0kSqPLctI5ziYWabAZYF.jpg",
+      overview: "外部来源媒体，预览媒体卡片菜单中的 TMDB 详情页入口。",
+      vote_average: 8.1,
+      popularity: 76,
+      genres: [genre("科幻")]
+    )
+  }
+
   static func collectionMedia(id: Int, title: String) -> MediaInfo {
     MediaInfo(
       tmdb_id: id,
@@ -1872,6 +3360,34 @@ private enum UIPreviewFixtures {
     ]
   }
 
+  private static var previewMediaGridWithoutShares: [MediaInfo] {
+    previewMediaGrid.filter { $0.subscribeShare == nil }
+  }
+
+  private static var previewDetailRows: MediaDetailUIPreviewRows {
+    MediaDetailUIPreviewRows(
+      actors: [
+        person(id: 70_101, name: "高桥遥", character: "领航员"),
+        person(id: 70_102, name: "陈述", character: "工程师"),
+        person(id: 70_103, name: "周念", character: "通讯官"),
+        person(id: 70_104, name: "森田葵", character: "医疗官"),
+      ],
+      recommendations: Array(previewMediaGridWithoutShares.prefix(4)),
+      similar: [
+        baseTVMedia(id: 80_201, title: "星门回声"),
+        movieMedia(id: 80_202, title: "荒原长路"),
+        baseTVMedia(id: 80_203, title: "轨道边界"),
+        collectionMedia(id: 80_204, title: "深空信号系列"),
+      ]
+    )
+  }
+
+  private static var previewDetailRowsLoadingMore: MediaDetailUIPreviewRows {
+    var rows = previewDetailRows
+    rows.isLoadingMore = true
+    return rows
+  }
+
   private static func mediaServerItems(prefix: String) -> [MediaServerPlayItem] {
     [
       MediaServerPlayItem(
@@ -1900,6 +3416,24 @@ private enum UIPreviewFixtures {
       season(number: 1, name: "第 1 季", episodes: 12, vote: 8.5),
       season(number: 2, name: "第 2 季", episodes: 10, vote: 8.1),
       season(number: 3, name: "特别篇", episodes: 0, vote: 0),
+    ]
+  }
+
+  private static var previewManySeasons: [TmdbSeason] {
+    var seasons: [TmdbSeason] = []
+    for number in 1...12 {
+      let name = number == 12 ? "特别篇合集" : "第 \(number) 季"
+      let episodeCount = number == 12 ? 4 : 8 + (number % 5)
+      let vote = number == 12 ? 7.6 : 8.0 + Double(number % 4) * 0.2
+      seasons.append(season(number: number, name: name, episodes: episodeCount, vote: vote))
+    }
+    return seasons
+  }
+
+  private static var previewEpisodeGroups: [EpisodeGroup] {
+    [
+      episodeGroup(id: "preview-main", name: "官方顺序"),
+      episodeGroup(id: "preview-alt", name: "播出顺序"),
     ]
   }
 
@@ -1981,6 +3515,10 @@ private enum UIPreviewFixtures {
       downloading(hash: "hash-2", title: "Long.Road.2025.1080p", state: "paused", progress: 35, dlspeed: "0 B", left: "暂停"),
       downloading(hash: "hash-3", title: "Coast.Archive.S02E04.1080p", state: "error", progress: 91, dlspeed: "0 B", left: "错误"),
       downloading(hash: "hash-4", title: "Checking.File.S01E02", state: "checking", progress: 8, dlspeed: "0 B", left: "校验中"),
+      downloading(hash: "hash-5", title: "Stalled.File.S01E03", state: "stalledDL", progress: 18, dlspeed: "0 B", left: "等待连接"),
+      downloading(hash: "hash-6", title: "Uploading.File.S01E04", state: "uploading", progress: 100, dlspeed: "0 B", left: "做种中"),
+      downloading(hash: "hash-7", title: "Missing.File.S01E05", state: "missingFiles", progress: 64, dlspeed: "0 B", left: "文件丢失"),
+      downloading(hash: "hash-8", title: "Queued.File.S01E06", state: "queuedDL", progress: 0, dlspeed: "0 B", left: "等待中"),
     ]
   }
 

--- a/MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift
+++ b/MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift
@@ -568,6 +568,12 @@ private struct UIPreviewComponentSceneView: View {
   let componentCase: UIPreviewComponentCase
   @Binding var navigationPath: NavigationPath
 
+  init(componentCase: UIPreviewComponentCase, navigationPath: Binding<NavigationPath>) {
+    self.componentCase = componentCase
+    _navigationPath = navigationPath
+    UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true)
+  }
+
   var body: some View {
     switch componentCase {
     case .mediaCards:
@@ -578,7 +584,6 @@ private struct UIPreviewComponentSceneView: View {
     case .torrentCards:
       UIPreviewTorrentCards()
         .previewRoot(componentCase.title)
-        .onAppear { UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true) }
     case .pickers:
       UIPreviewPickerComponents()
         .previewRoot(componentCase.title)
@@ -718,7 +723,11 @@ private extension View {
         PersonDetailView(person: person, navigationPath: path)
       }
       .navigationDestination(for: ResourceSearchRequest.self) { request in
-        ResourceResultView(request: request)
+        ResourceResultView(
+          title: request.title ?? "资源搜索",
+          mediaInfo: request.mediaInfo,
+          previewViewModel: UIPreviewFixtures.resourceResultViewModel(.results)
+        )
       }
       .navigationDestination(for: SubscribeSeasonRequest.self) { request in
         SubscribeSeasonView(

--- a/MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift
+++ b/MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift
@@ -194,6 +194,10 @@ private struct UIPreviewLoggedInRootView: View {
     searchInitialPath: NavigationPath = NavigationPath(),
     searchPreviewDestinations: SearchViewUIPreviewDestinations? = nil
   ) {
+    UIPreviewFixtures.applyPermissions(
+      permissions,
+      canRequestSuperUserEndpoints: canRequestSuperUserEndpoints
+    )
     _homeViewModel = StateObject(wrappedValue: UIPreviewFixtures.homeViewModel(homeMode))
     _recommendViewModel = StateObject(wrappedValue: UIPreviewFixtures.recommendViewModel(recommendMode))
     _exploreViewModel = StateObject(wrappedValue: UIPreviewFixtures.exploreViewModel(exploreMode))

--- a/MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift
+++ b/MoviePilot-TV/PreviewSupport/PreviewCatalogView.swift
@@ -505,27 +505,28 @@ private struct UIPreviewSettingsSceneView: View {
 private struct UIPreviewSheetSceneView: View {
   let sheetCase: UIPreviewSheetCase
 
+  init(sheetCase: UIPreviewSheetCase) {
+    self.sheetCase = sheetCase
+    UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true)
+  }
+
   var body: some View {
     switch sheetCase {
     case .subscribe:
       SubscribeSheet(previewViewModel: UIPreviewFixtures.subscribeSheetViewModel())
         .previewRoot(sheetCase.title)
-        .onAppear { UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true) }
     case .addDownload:
       AddDownloadSheet(previewViewModel: UIPreviewFixtures.addDownloadViewModel())
         .environmentObject(NotificationManager())
         .previewRoot(sheetCase.title)
-        .onAppear { UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true) }
     case .reorganize:
       ReorganizeSheet(previewViewModel: UIPreviewFixtures.reorganizeViewModel()) {}
         .environmentObject(NotificationManager())
         .previewRoot(sheetCase.title)
-        .onAppear { UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true) }
     case .reorganizeBatch:
       ReorganizeSheet(previewViewModel: UIPreviewFixtures.reorganizeBatchViewModel()) {}
         .environmentObject(NotificationManager())
         .previewRoot(sheetCase.title)
-        .onAppear { UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true) }
     case .forkSubscribe:
       ForkSubscribeSheet(
         share: UIPreviewFixtures.previewSubscribeShare,
@@ -533,18 +534,15 @@ private struct UIPreviewSheetSceneView: View {
         subscriptionHandler: SubscriptionHandler()
       )
       .previewRoot(sheetCase.title)
-      .onAppear { UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true) }
     case .seasonDetail:
       SeasonDetailSheet(
         season: UIPreviewFixtures.previewSeasonDetail,
         mediaInfo: UIPreviewFixtures.baseTVMedia(id: 45_301, title: "边境信号")
       )
       .previewRoot(sheetCase.title)
-      .onAppear { UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true) }
     case .multiSelection:
       UIPreviewMultiSelectionSheet()
         .previewRoot(sheetCase.title)
-        .onAppear { UIPreviewFixtures.applyPermissions(.allPreviewPermissions, canRequestSuperUserEndpoints: true) }
     }
   }
 }

--- a/MoviePilot-TV/PreviewSupport/UIPreviewMode.swift
+++ b/MoviePilot-TV/PreviewSupport/UIPreviewMode.swift
@@ -3,9 +3,18 @@ import Foundation
 
 enum UIPreviewMode {
   nonisolated static let launchArgument = "-uiPreviewMode"
+  nonisolated static let sceneLaunchArgument = "-uiPreviewScene"
 
   nonisolated static func isEnabled(arguments: [String] = ProcessInfo.processInfo.arguments) -> Bool {
     arguments.contains(launchArgument)
+  }
+
+  nonisolated static func sceneID(arguments: [String] = ProcessInfo.processInfo.arguments) -> String? {
+    guard let index = arguments.firstIndex(of: sceneLaunchArgument) else { return nil }
+    let valueIndex = arguments.index(after: index)
+    guard arguments.indices.contains(valueIndex) else { return nil }
+    let value = arguments[valueIndex]
+    return value.hasPrefix("-") ? nil : value
   }
 }
 #endif

--- a/MoviePilot-TV/PreviewSupport/UIPreviewMode.swift
+++ b/MoviePilot-TV/PreviewSupport/UIPreviewMode.swift
@@ -1,0 +1,11 @@
+#if DEBUG
+import Foundation
+
+enum UIPreviewMode {
+  nonisolated static let launchArgument = "-uiPreviewMode"
+
+  nonisolated static func isEnabled(arguments: [String] = ProcessInfo.processInfo.arguments) -> Bool {
+    arguments.contains(launchArgument)
+  }
+}
+#endif

--- a/MoviePilot-TV/Services/APIService.swift
+++ b/MoviePilot-TV/Services/APIService.swift
@@ -393,6 +393,8 @@ class APIService: ObservableObject {
   #if DEBUG
   var subscriptionCacheTestHooks = SubscriptionCacheTestHooks()
   private var subscriptionDebugRequestCount = 0
+  var uiPreviewPermissions: Set<UserPermissionKey>?
+  var uiPreviewCanRequestSuperUserEndpoints: Bool?
   #endif
 
   private func invalidateSubscriptionCaches() async {
@@ -596,11 +598,21 @@ class APIService: ObservableObject {
   }
 
   var canRequestSuperUserEndpoints: Bool {
-    currentOrStoredUser?.canRequestSuperUserEndpoints == true
+    #if DEBUG
+    if UIPreviewMode.isEnabled(), let uiPreviewCanRequestSuperUserEndpoints {
+      return uiPreviewCanRequestSuperUserEndpoints
+    }
+    #endif
+    return currentOrStoredUser?.canRequestSuperUserEndpoints == true
   }
 
   func canAccess(_ permission: UserPermissionKey) -> Bool {
-    currentOrStoredUser?.canAccess(permission) == true
+    #if DEBUG
+    if UIPreviewMode.isEnabled(), let uiPreviewPermissions {
+      return uiPreviewPermissions.contains(permission)
+    }
+    #endif
+    return currentOrStoredUser?.canAccess(permission) == true
   }
 
   func sessionSnapshot() -> APIServiceSessionSnapshot {

--- a/MoviePilot-TV/Services/APIService.swift
+++ b/MoviePilot-TV/Services/APIService.swift
@@ -599,8 +599,8 @@ class APIService: ObservableObject {
 
   var canRequestSuperUserEndpoints: Bool {
     #if DEBUG
-    if UIPreviewMode.isEnabled(), let uiPreviewCanRequestSuperUserEndpoints {
-      return uiPreviewCanRequestSuperUserEndpoints
+    if UIPreviewMode.isEnabled() {
+      return uiPreviewCanRequestSuperUserEndpoints ?? false
     }
     #endif
     return currentOrStoredUser?.canRequestSuperUserEndpoints == true
@@ -608,8 +608,8 @@ class APIService: ObservableObject {
 
   func canAccess(_ permission: UserPermissionKey) -> Bool {
     #if DEBUG
-    if UIPreviewMode.isEnabled(), let uiPreviewPermissions {
-      return uiPreviewPermissions.contains(permission)
+    if UIPreviewMode.isEnabled() {
+      return uiPreviewPermissions?.contains(permission) ?? false
     }
     #endif
     return currentOrStoredUser?.canAccess(permission) == true

--- a/MoviePilot-TV/Services/Paginator.swift
+++ b/MoviePilot-TV/Services/Paginator.swift
@@ -337,6 +337,20 @@ public class Paginator<ItemType: Identifiable>: ObservableObject {
 
 #if DEBUG
 extension Paginator {
+  func installUIPreviewItems(
+    _ items: [ItemType],
+    isFirstLoading: Bool = false,
+    isLoadingMore: Bool = false,
+    hasError: Bool = false
+  ) {
+    self.items = items
+    self.isFirstLoading = isFirstLoading
+    self.isLoading = isFirstLoading || isLoadingMore
+    self.isLoadingMore = isLoadingMore
+    self.hasError = hasError
+    self.hasMore = isLoadingMore
+  }
+
   static func uiPreview(
     items: [ItemType] = [],
     isFirstLoading: Bool = false,

--- a/MoviePilot-TV/Services/Paginator.swift
+++ b/MoviePilot-TV/Services/Paginator.swift
@@ -334,3 +334,27 @@ public class Paginator<ItemType: Identifiable>: ObservableObject {
     onReset?()
   }
 }
+
+#if DEBUG
+extension Paginator {
+  static func uiPreview(
+    items: [ItemType] = [],
+    isFirstLoading: Bool = false,
+    isLoadingMore: Bool = false,
+    hasError: Bool = false
+  ) -> Paginator<ItemType> {
+    let paginator = Paginator<ItemType>(
+      threshold: 24,
+      fetcher: { _ in [] },
+      processor: { _, _ in false }
+    )
+    paginator.items = items
+    paginator.isFirstLoading = isFirstLoading
+    paginator.isLoading = isFirstLoading || isLoadingMore
+    paginator.isLoadingMore = isLoadingMore
+    paginator.hasError = hasError
+    paginator.hasMore = isLoadingMore
+    return paginator
+  }
+}
+#endif

--- a/MoviePilot-TV/ViewModels/AddDownloadViewModel.swift
+++ b/MoviePilot-TV/ViewModels/AddDownloadViewModel.swift
@@ -24,6 +24,23 @@ class AddDownloadViewModel: ObservableObject {
     self.onSuccess = onSuccess
   }
 
+  #if DEBUG
+  func installUIPreviewOptions(
+    downloaders: [DownloaderConf],
+    directories: [TransferDirectoryConf],
+    selectedDownloader: String?,
+    selectedDirectory: String?,
+    tmdbId: String = ""
+  ) {
+    self.downloaders = downloaders
+    self.directories = directories
+    self.selectedDownloader = selectedDownloader
+    self.selectedDirectory = selectedDirectory
+    self.tmdbId = tmdbId
+    isLoading = false
+  }
+  #endif
+
   // 目标目录的计算属性（URI 格式）
   var targetDirectories: [String] {
     let uris = directories.compactMap { item -> String? in
@@ -37,6 +54,10 @@ class AddDownloadViewModel: ObservableObject {
   }
 
   func loadData() async {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
+
     guard APIService.shared.canAccess(.search) else {
       clearLoadedOptions()
       return
@@ -80,6 +101,13 @@ class AddDownloadViewModel: ObservableObject {
   }
 
   func addDownload() async {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() {
+      onSuccess?()
+      return
+    }
+    #endif
+
     isSubmitting = true
     defer { isSubmitting = false }
 

--- a/MoviePilot-TV/ViewModels/CollectionDetailViewModel.swift
+++ b/MoviePilot-TV/ViewModels/CollectionDetailViewModel.swift
@@ -39,6 +39,17 @@ class CollectionDetailViewModel: ObservableObject {
       .store(in: &cancellables)
   }
 
+  #if DEBUG
+  init(previewPaginator: Paginator<MediaInfo>) {
+    self.paginator = previewPaginator
+    self.paginator.objectWillChange
+      .sink { [weak self] _ in
+        self?.objectWillChange.send()
+      }
+      .store(in: &cancellables)
+  }
+  #endif
+
   private var hasLoaded = false
 
   func loadInitialData() async {

--- a/MoviePilot-TV/ViewModels/ContentViewModel.swift
+++ b/MoviePilot-TV/ViewModels/ContentViewModel.swift
@@ -30,6 +30,10 @@ class ContentViewModel: ObservableObject {
     isLoggedIn = apiService.isLoggedIn
     currentUser = apiService.currentUser
 
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
+
     // 监听令牌变化 -> 在登录或令牌更新时触发设置获取
     apiService.$token
       .receive(on: RunLoop.main)

--- a/MoviePilot-TV/ViewModels/DownloadTaskViewModel.swift
+++ b/MoviePilot-TV/ViewModels/DownloadTaskViewModel.swift
@@ -11,7 +11,23 @@ class DownloadTaskViewModel: ObservableObject {
   private let apiService = APIService.shared
   private var downloadLoadGeneration = 0
 
+  #if DEBUG
+  func installUIPreviewData(
+    clients: [DownloaderConf],
+    selectedClient: String,
+    downloads: [DownloadingInfo]
+  ) {
+    self.clients = clients
+    self.selectedClient = selectedClient
+    self.downloads = downloads
+  }
+  #endif
+
   func initialLoad() async {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
+
     guard apiService.canAccess(.manage) else {
       clearForRestrictedUser()
       return
@@ -30,6 +46,10 @@ class DownloadTaskViewModel: ObservableObject {
   }
 
   func loadDownloads() async {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
+
     guard apiService.canAccess(.manage) else {
       clearForRestrictedUser()
       return
@@ -75,6 +95,10 @@ class DownloadTaskViewModel: ObservableObject {
   }
 
   func stopDownload(hash: String) async -> Bool {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return true }
+    #endif
+
     guard apiService.canAccess(.manage) else { return false }
     guard !selectedClient.isEmpty else { return false }
     do {
@@ -91,6 +115,10 @@ class DownloadTaskViewModel: ObservableObject {
   }
 
   func startDownload(hash: String) async -> Bool {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return true }
+    #endif
+
     guard apiService.canAccess(.manage) else { return false }
     guard !selectedClient.isEmpty else { return false }
     do {
@@ -108,6 +136,10 @@ class DownloadTaskViewModel: ObservableObject {
 
   @MainActor
   func deleteDownload(hash: String) async {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
+
     guard apiService.canAccess(.manage) else { return }
     let clientName = selectedClient
     guard !clientName.isEmpty else { return }

--- a/MoviePilot-TV/ViewModels/ExploreViewModel.swift
+++ b/MoviePilot-TV/ViewModels/ExploreViewModel.swift
@@ -78,6 +78,17 @@ class ExploreViewModel: ObservableObject {
   private var paginatorCancellable: AnyCancellable?
 
   init() {
+    configureAutomaticLoading()
+  }
+
+  #if DEBUG
+  init(loadsAutomatically: Bool) {
+    guard loadsAutomatically else { return }
+    configureAutomaticLoading()
+  }
+  #endif
+
+  private func configureAutomaticLoading() {
     // 将所有筛选器的 Publisher 转换为 AnyPublisher<Void, Never>
     let filterPublishers: [AnyPublisher<Void, Never>] = [
       $selectedSource.map { _ in }.eraseToAnyPublisher(),
@@ -116,6 +127,18 @@ class ExploreViewModel: ObservableObject {
       }
       .store(in: &cancellables)
   }
+
+  #if DEBUG
+  func installUIPreviewPaginator(_ previewPaginator: Paginator<MediaInfo>?) {
+    paginator?.cancel()
+    paginatorCancellable?.cancel()
+    paginator = previewPaginator
+    paginatorCancellable = previewPaginator?.objectWillChange
+      .sink { [weak self] _ in
+        self?.objectWillChange.send()
+      }
+  }
+  #endif
 
   // MARK: - TheMovieDb 字典
 

--- a/MoviePilot-TV/ViewModels/HomeViewModel.swift
+++ b/MoviePilot-TV/ViewModels/HomeViewModel.swift
@@ -172,6 +172,10 @@ class HomeViewModel: ObservableObject {
   }
 
   private func persistSelectedLatestMediaServer() {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
+
     UserDefaults.standard.set(selectedLatestMediaServer, forKey: latestMediaSelectedServerKey)
   }
 

--- a/MoviePilot-TV/ViewModels/HomeViewModel.swift
+++ b/MoviePilot-TV/ViewModels/HomeViewModel.swift
@@ -46,6 +46,25 @@ class HomeViewModel: ObservableObject {
       .store(in: &cancellables)
   }
 
+  #if DEBUG
+  func installUIPreviewData(
+    latestMediaByServer: [String: [MediaServerPlayItem]],
+    selectedServer: String,
+    movieSubscriptions: [Subscribe],
+    tvSubscriptions: [Subscribe],
+    isLoading: Bool = false
+  ) {
+    self.latestMediaByServer = latestMediaByServer
+    self.latestMediaServers = Array(latestMediaByServer.keys).sorted()
+    self.selectedLatestMediaServer = selectedServer
+    self.latestMedia = latestMediaByServer[selectedServer] ?? []
+    self.movieSubscriptions = movieSubscriptions
+    self.tvSubscriptions = tvSubscriptions
+    self.isLoading = isLoading
+    self.hasLoaded = true
+  }
+  #endif
+
   private var hasLoaded = false
 
   /// 初始或刷新加载数据
@@ -191,6 +210,10 @@ class HomeViewModel: ObservableObject {
 
   /// 切换订阅状态（运行/停止）
   func toggleSubscribeStatus(subscribe: Subscribe) async -> Bool {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return true }
+    #endif
+
     guard apiService.canAccess(.subscribe) else { return false }
     guard let id = subscribe.id else { return false }
     // 前端逻辑：如果是 'S' (已停止) -> 切换到 'R' (运行)，否则 -> 'S' (停止)
@@ -209,6 +232,10 @@ class HomeViewModel: ObservableObject {
 
   /// 重置订阅历史
   func resetSubscribe(subscribe: Subscribe) async -> Bool {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return true }
+    #endif
+
     guard apiService.canAccess(.subscribe) else { return false }
     guard let id = subscribe.id else { return false }
     do {
@@ -225,6 +252,10 @@ class HomeViewModel: ObservableObject {
 
   /// 立即触发订阅搜索
   func searchSubscribe(subscribe: Subscribe) async -> Bool {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return true }
+    #endif
+
     guard apiService.canAccess(.subscribe) else { return false }
     guard let id = subscribe.id else { return false }
     do {
@@ -243,6 +274,10 @@ class HomeViewModel: ObservableObject {
 
   /// 删除订阅
   func deleteSubscribe(subscribe: Subscribe) async -> Bool {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return true }
+    #endif
+
     guard apiService.canAccess(.subscribe) else { return false }
     guard let id = subscribe.id else { return false }
     do {

--- a/MoviePilot-TV/ViewModels/MediaActionHandler.swift
+++ b/MoviePilot-TV/ViewModels/MediaActionHandler.swift
@@ -22,6 +22,12 @@ class MediaActionHandler: ObservableObject {
   }
 
   func searchResourcesTargetUsingDefaultSites(for item: MediaInfo) async -> ResourceSearchRequest {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() {
+      return searchResourcesTarget(for: item)
+    }
+    #endif
+
     let sites = await SystemViewModel.normalizedDefaultSearchSitesString()
     return searchResourcesTarget(for: item, sites: sites)
   }
@@ -30,6 +36,12 @@ class MediaActionHandler: ObservableObject {
     for item: MediaInfo, targetTmdbId: Int? = nil
   ) async -> MediaInfo? {
     var tmdbIdToUse: Int? = targetTmdbId ?? item.tmdb_id
+
+    #if DEBUG
+    if UIPreviewMode.isEnabled(), tmdbIdToUse == nil {
+      tmdbIdToUse = 900_000 + Int(UInt(bitPattern: item.id.hashValue) % 100_000)
+    }
+    #endif
 
     if tmdbIdToUse == nil {
       isRecognizingTmdb = true

--- a/MoviePilot-TV/ViewModels/MediaActionHandler.swift
+++ b/MoviePilot-TV/ViewModels/MediaActionHandler.swift
@@ -39,7 +39,7 @@ class MediaActionHandler: ObservableObject {
 
     #if DEBUG
     if UIPreviewMode.isEnabled(), tmdbIdToUse == nil {
-      tmdbIdToUse = 900_000 + Int(UInt(bitPattern: item.id.hashValue) % 100_000)
+      tmdbIdToUse = deterministicUIPreviewTMDBId(for: item.id)
     }
     #endif
 
@@ -96,4 +96,13 @@ class MediaActionHandler: ObservableObject {
       category: item.category
     )
   }
+
+  #if DEBUG
+  private func deterministicUIPreviewTMDBId(for id: String) -> Int {
+    let seed = id.unicodeScalars.reduce(0) { partial, scalar in
+      (partial * 31 + Int(scalar.value)) % 100_000
+    }
+    return 900_000 + seed
+  }
+  #endif
 }

--- a/MoviePilot-TV/ViewModels/MediaDetailViewModel.swift
+++ b/MoviePilot-TV/ViewModels/MediaDetailViewModel.swift
@@ -165,6 +165,15 @@ class MediaDetailViewModel: ObservableObject {
       // 否则：View 层通过 onChange(of: preloadTask.isSeasonDataLoaded) 设置
     }
 
+    #if DEBUG
+    if UIPreviewMode.isEnabled() {
+      if !isSeasonFirst {
+        isFirstRowReady = true
+      }
+      return
+    }
+    #endif
+
     // 异步加载网络数据（不阻塞调用方返回，数据到达后渐进显示）
     Task {
       // 1. 并发启动演职员、推荐和相似内容加载
@@ -279,6 +288,13 @@ class MediaDetailViewModel: ObservableObject {
     isUnsubscribing = true
     defer { isUnsubscribing = false }
 
+    #if DEBUG
+    if UIPreviewMode.isEnabled() {
+      preloadTask?.isSubscribed = false
+      return
+    }
+    #endif
+
     let didCancel = await deleteResolvedSubscription()
 
     // 刷新所有订阅状态（包括全局和分季）
@@ -297,6 +313,12 @@ class MediaDetailViewModel: ObservableObject {
       preloadTask?.isSubscribed = false
       return true
     }
+
+    #if DEBUG
+    if UIPreviewMode.isEnabled() {
+      return true
+    }
+    #endif
 
     // 使用 TaskGroup 或并发 Task 同时刷新全局和分季订阅
     var resultCount = 0
@@ -350,6 +372,10 @@ class MediaDetailViewModel: ObservableObject {
   }
 
   private func deleteResolvedSubscription() async -> Bool {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return true }
+    #endif
+
     var fallbackSubscriptionId: Int?
     for media in subscriptionLookupCandidates() {
       do {
@@ -378,6 +404,9 @@ class MediaDetailViewModel: ObservableObject {
 
   func headerUnsubscribeConfirmationMessage() async -> String {
     let baseMessage = SubscriptionCancelConfirmation.headerMessage(for: detail)
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return baseMessage }
+    #endif
     guard let warning = await resolvedTMDBMultiSeasonCancellationWarning() else {
       return baseMessage
     }

--- a/MoviePilot-TV/ViewModels/MediaDetailViewModel.swift
+++ b/MoviePilot-TV/ViewModels/MediaDetailViewModel.swift
@@ -131,6 +131,26 @@ class MediaDetailViewModel: ObservableObject {
       .store(in: &cancellables)
   }
 
+  #if DEBUG
+  func installUIPreviewRows(
+    actors: [Person],
+    recommendations: [MediaInfo],
+    similar: [MediaInfo],
+    isLoadingMore: Bool = false
+  ) {
+    actorsPaginator.installUIPreviewItems(actors, isLoadingMore: isLoadingMore)
+    recommendPaginator.installUIPreviewItems(recommendations, isLoadingMore: isLoadingMore)
+    similarPaginator.installUIPreviewItems(similar, isLoadingMore: isLoadingMore)
+
+    if heroTopActors.isEmpty {
+      heroTopActors = Array(actors.prefix(4))
+    }
+    if !actors.isEmpty || !uniqueDirectors.isEmpty || !recommendations.isEmpty || !similar.isEmpty {
+      isFirstRowReady = true
+    }
+  }
+  #endif
+
   private var hasAppliedFullDetail = false
 
   /// 应用完整的媒体详情数据并加载辅助内容。

--- a/MoviePilot-TV/ViewModels/MediaPreloader.swift
+++ b/MoviePilot-TV/ViewModels/MediaPreloader.swift
@@ -386,6 +386,7 @@ class MediaPreloader: ObservableObject {
     task.isDetailReady = true
     task.tmdbId = media.tmdb_id
     task.isSubscribed = false
+    task.isSeasonDataLoaded = media.type == "电视剧"
     cache[key] = task
     accessOrder.append(key)
     evictIfNeeded()

--- a/MoviePilot-TV/ViewModels/MediaPreloader.swift
+++ b/MoviePilot-TV/ViewModels/MediaPreloader.swift
@@ -340,6 +340,12 @@ class MediaPreloader: ObservableObject {
   /// 获取已有预加载任务，或创建并启动新任务
   @discardableResult
   func preload(for media: MediaInfo) -> MediaPreloadTask {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() {
+      return uiPreviewTask(for: media)
+    }
+    #endif
+
     let key = media.id
     if let existing = cache[key] {
       // 失败的任务不缓存：移除后重新创建，允许自动重试
@@ -366,6 +372,34 @@ class MediaPreloader: ObservableObject {
 
     return task
   }
+
+  #if DEBUG
+  private func uiPreviewTask(for media: MediaInfo) -> MediaPreloadTask {
+    let key = media.id
+    if let existing = cache[key] {
+      touchLRU(key: key)
+      return existing
+    }
+
+    let task = MediaPreloadTask(partialMedia: media)
+    task.fullDetail = media
+    task.isDetailReady = true
+    task.tmdbId = media.tmdb_id
+    task.isSubscribed = false
+    cache[key] = task
+    accessOrder.append(key)
+    evictIfNeeded()
+    return task
+  }
+
+  func installPreviewTask(_ task: MediaPreloadTask, for media: MediaInfo) {
+    let key = media.id
+    cache[key]?.cancel()
+    cache[key] = task
+    accessOrder.removeAll { $0 == key }
+    accessOrder.append(key)
+  }
+  #endif
 
   /// 仅获取已有的预加载任务（不创建新的），并更新 LRU 顺序。
   /// ⚠️ 不要在 SwiftUI body 中使用此方法（会修改状态），请用 peekTask。

--- a/MoviePilot-TV/ViewModels/PersonDetailViewModel.swift
+++ b/MoviePilot-TV/ViewModels/PersonDetailViewModel.swift
@@ -52,6 +52,19 @@ class PersonDetailViewModel: ObservableObject {
       .store(in: &cancellables)
   }
 
+  #if DEBUG
+  init(person: Person, previewPaginator: Paginator<MediaInfo>, isLoadingDetails: Bool) {
+    self.person = person
+    self.isLoadingDetails = isLoadingDetails
+    self.paginator = previewPaginator
+    self.paginator.objectWillChange
+      .sink { [weak self] _ in
+        self?.objectWillChange.send()
+      }
+      .store(in: &cancellables)
+  }
+  #endif
+
   func loadDetails() async {
     // 如果缺少 raw_id，则不获取详情数据。
     guard let personId = person.raw_id, !personId.isEmpty else {

--- a/MoviePilot-TV/ViewModels/RecommendViewModel.swift
+++ b/MoviePilot-TV/ViewModels/RecommendViewModel.swift
@@ -89,6 +89,17 @@ class RecommendViewModel: ObservableObject {
   }
 
   init() {
+    configureAutomaticLoading()
+  }
+
+  #if DEBUG
+  init(loadsAutomatically: Bool) {
+    guard loadsAutomatically else { return }
+    configureAutomaticLoading()
+  }
+  #endif
+
+  private func configureAutomaticLoading() {
     // 默认选中流行趋势
     // 当 selectedShelf 改变时，自动创建一个新的 Paginator 实例
     // sink 会因为 selectedShelf 的初始值而立即触发，所以无需手动调用 setupPaginator
@@ -104,6 +115,18 @@ class RecommendViewModel: ObservableObject {
     // 设置初始货架，这将触发上面的 sink
     onCategoryChanged()
   }
+
+  #if DEBUG
+  func installUIPreviewPaginator(_ previewPaginator: Paginator<MediaInfo>?) {
+    paginator?.cancel()
+    paginatorCancellable?.cancel()
+    paginator = previewPaginator
+    paginatorCancellable = previewPaginator?.objectWillChange
+      .sink { [weak self] _ in
+        self?.objectWillChange.send()
+      }
+  }
+  #endif
 
   private func setupPaginator(for shelf: RecommendShelf) {
     paginator?.cancel()

--- a/MoviePilot-TV/ViewModels/ReorganizeViewModel.swift
+++ b/MoviePilot-TV/ViewModels/ReorganizeViewModel.swift
@@ -82,7 +82,10 @@ class ReorganizeViewModel: ObservableObject {
 
   func loadConfig() async {
     #if DEBUG
-    if UIPreviewMode.isEnabled() { return }
+    if UIPreviewMode.isEnabled() {
+      isLoading = false
+      return
+    }
     #endif
 
     guard apiService.canAccess(.manage) else {

--- a/MoviePilot-TV/ViewModels/ReorganizeViewModel.swift
+++ b/MoviePilot-TV/ViewModels/ReorganizeViewModel.swift
@@ -66,7 +66,25 @@ class ReorganizeViewModel: ObservableObject {
     updateEpisodeDetailDisabledState()
   }
 
+  #if DEBUG
+  func installUIPreviewConfig(
+    directories: [TransferDirectoryConf],
+    storages: [StorageConf],
+    targetDirectoryOptions: [PickerOption<String>],
+    isLoading: Bool = false
+  ) {
+    self.directories = directories
+    self.storages = storages
+    self.targetDirectoryOptions = targetDirectoryOptions
+    self.isLoading = isLoading
+  }
+  #endif
+
   func loadConfig() async {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
+
     guard apiService.canAccess(.manage) else {
       clearLoadedConfig()
       isLoading = false
@@ -110,6 +128,10 @@ class ReorganizeViewModel: ObservableObject {
   }
 
   func submit(background: Bool) async -> Bool {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return true }
+    #endif
+
     guard apiService.canAccess(.manage) else { return false }
     isSubmitting = true
     defer { isSubmitting = false }

--- a/MoviePilot-TV/ViewModels/ResourceResultViewModel.swift
+++ b/MoviePilot-TV/ViewModels/ResourceResultViewModel.swift
@@ -37,6 +37,24 @@ class ResourceResultViewModel: ObservableObject {
     self.sites = sites
   }
 
+  #if DEBUG
+  convenience init(
+    previewTitle: String,
+    mediaInfo _: MediaInfo?,
+    results: [Context],
+    isLoading: Bool,
+    progressText: String = "",
+    progress: Double = 0
+  ) {
+    self.init(keyword: previewTitle, title: previewTitle)
+    self.results = results
+    self.isLoading = isLoading
+    self.hasSearched = true
+    self.searchProgressText = progressText
+    self.searchProgress = progress
+  }
+  #endif
+
   deinit {
     searchStreamTask?.cancel()
   }

--- a/MoviePilot-TV/ViewModels/SearchViewModel.swift
+++ b/MoviePilot-TV/ViewModels/SearchViewModel.swift
@@ -600,6 +600,63 @@ class SearchViewModel: ObservableObject {
       return contexts
     }
   }
+
+  #if DEBUG
+  func installUIPreviewUnifiedResults(
+    query: String,
+    movies: [MediaInfo],
+    tvShows: [MediaInfo],
+    collections: [MediaInfo],
+    persons: [Person],
+    shares: [MediaInfo],
+    bestResults: [BestResultItem]
+  ) {
+    searchStreamTask?.cancel()
+    searchStreamTask = nil
+    self.query = query
+    submittedQuery = query
+    searchType = .unified
+    hasSearched = true
+    isLoading = false
+    moviePaginator = .uiPreview(items: movies)
+    tvPaginator = .uiPreview(items: tvShows)
+    collectionPaginator = .uiPreview(items: collections)
+    personPaginator = .uiPreview(items: persons)
+    subscriptionSharePaginator = .uiPreview(items: shares)
+    self.bestResults = bestResults
+  }
+
+  func installUIPreviewUnifiedEmpty(query: String) {
+    installUIPreviewUnifiedResults(
+      query: query,
+      movies: [],
+      tvShows: [],
+      collections: [],
+      persons: [],
+      shares: [],
+      bestResults: []
+    )
+  }
+
+  func installUIPreviewResourceResults(
+    query: String,
+    results: [Context],
+    isLoading: Bool = false,
+    progressText: String = "",
+    progress: Double = 0
+  ) {
+    searchStreamTask?.cancel()
+    searchStreamTask = nil
+    self.query = query
+    submittedQuery = query
+    searchType = .resource
+    hasSearched = !isLoading
+    self.isLoading = isLoading
+    resourceResults = results
+    searchProgressText = progressText
+    searchProgress = progress
+  }
+  #endif
 }
 
 // MARK: - 共享分页抓取代理

--- a/MoviePilot-TV/ViewModels/SearchViewModel.swift
+++ b/MoviePilot-TV/ViewModels/SearchViewModel.swift
@@ -612,7 +612,8 @@ class SearchViewModel: ObservableObject {
     collections: [MediaInfo],
     persons: [Person],
     shares: [MediaInfo],
-    bestResults: [BestResultItem]
+    bestResults: [BestResultItem],
+    isLoadingMore: Bool = false
   ) {
     searchStreamTask?.cancel()
     searchStreamTask = nil
@@ -621,11 +622,11 @@ class SearchViewModel: ObservableObject {
     searchType = .unified
     hasSearched = true
     isLoading = false
-    moviePaginator = .uiPreview(items: movies)
-    tvPaginator = .uiPreview(items: tvShows)
-    collectionPaginator = .uiPreview(items: collections)
-    personPaginator = .uiPreview(items: persons)
-    subscriptionSharePaginator = .uiPreview(items: shares)
+    moviePaginator = .uiPreview(items: movies, isLoadingMore: isLoadingMore)
+    tvPaginator = .uiPreview(items: tvShows, isLoadingMore: isLoadingMore)
+    collectionPaginator = .uiPreview(items: collections, isLoadingMore: isLoadingMore)
+    personPaginator = .uiPreview(items: persons, isLoadingMore: isLoadingMore)
+    subscriptionSharePaginator = .uiPreview(items: shares, isLoadingMore: isLoadingMore)
     self.bestResults = bestResults
   }
 

--- a/MoviePilot-TV/ViewModels/SearchViewModel.swift
+++ b/MoviePilot-TV/ViewModels/SearchViewModel.swift
@@ -248,6 +248,9 @@ class SearchViewModel: ObservableObject {
   func autoSearch() async {
     guard !query.isEmpty else { return }
     guard apiService.canAccess(.search) else { return }
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
     searchGeneration += 1
     let currentSearchGeneration = searchGeneration
     let searchQuery = query

--- a/MoviePilot-TV/ViewModels/StatusViewModel.swift
+++ b/MoviePilot-TV/ViewModels/StatusViewModel.swift
@@ -10,6 +10,14 @@ class StatusViewModel: ObservableObject {
 
   private let apiService = APIService.shared
 
+  #if DEBUG
+  func installUIPreviewData(statistic: Statistic?, storage: Storage?, downloader: DownloaderInfo?) {
+    self.statistic = statistic
+    self.storage = storage
+    self.downloader = downloader
+  }
+  #endif
+
   func refreshAllData() async {
     guard apiService.canRequestSuperUserEndpoints else {
       statistic = nil

--- a/MoviePilot-TV/ViewModels/SubscribeSeasonViewModel.swift
+++ b/MoviePilot-TV/ViewModels/SubscribeSeasonViewModel.swift
@@ -129,6 +129,10 @@ class SubscribeSeasonViewModel: ObservableObject {
 
   /// 当用户在界面切换剧集组时触发重新加载
   func fetchSeasons() async {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
+
     isLoading = true
     hasSeasonLoadError = false
     defer { isLoading = false }
@@ -166,6 +170,10 @@ class SubscribeSeasonViewModel: ObservableObject {
 
   /// 调用后端接口，比对媒体库中已有的集数，确定每一季的完整性
   func checkSeasonsStatus() async {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
+
     isSeasonAvailabilityLoaded = false
     guard APIService.shared.canAccess(.subscribe) else {
       seasonsNotExisted = [:]
@@ -246,6 +254,10 @@ class SubscribeSeasonViewModel: ObservableObject {
   /// 查询当前媒体所有分季订阅摘要，填充 seasonSubscriptions 和 subscribedSeasons
   @discardableResult
   func checkSubscriptionStatus(forceRefresh: Bool = false) async -> Bool {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return true }
+    #endif
+
     guard APIService.shared.canAccess(.subscribe) else {
       seasonSubscriptions = [:]
       subscribedSeasons = []
@@ -304,6 +316,13 @@ class SubscribeSeasonViewModel: ObservableObject {
   }
 
   func unsubscribeSeason(_ seasonNumber: Int) async {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() {
+      showUnsubscribeConfirm = nil
+      return
+    }
+    #endif
+
     subscribingSeasons.insert(seasonNumber)
     defer { subscribingSeasons.remove(seasonNumber) }
 

--- a/MoviePilot-TV/ViewModels/SubscribeSheetViewModel.swift
+++ b/MoviePilot-TV/ViewModels/SubscribeSheetViewModel.swift
@@ -56,7 +56,28 @@ class SubscribeSheetViewModel: ObservableObject {
     self.isNewSubscription = isNewSubscription
   }
 
+  #if DEBUG
+  func installUIPreviewOptions(
+    sites: [Site],
+    downloaders: [DownloaderConf],
+    directories: [TransferDirectoryConf],
+    filterGroups: [FilterRuleGroup],
+    episodeGroups: [EpisodeGroup]
+  ) {
+    self.sites = sites
+    self.downloaders = downloaders
+    self.directories = directories
+    self.filterGroups = filterGroups
+    self.episodeGroups = episodeGroups
+    isLoading = false
+  }
+  #endif
+
   func loadData() async {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
+
     guard apiService.canAccess(.subscribe) else {
       clearLoadedOptions()
       return
@@ -164,6 +185,13 @@ class SubscribeSheetViewModel: ObservableObject {
   }
 
   func save() async -> Bool {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() {
+      isSaved = true
+      return true
+    }
+    #endif
+
     isSaving = true
     defer { isSaving = false }
     do {
@@ -191,6 +219,10 @@ class SubscribeSheetViewModel: ObservableObject {
   }
 
   func cancel() async {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
+
     // 如果我们创建了一个新订阅但用户取消了，我们必须回滚（删除）它
     if isNewSubscription, let id = subscribe.id {
       do {

--- a/MoviePilot-TV/ViewModels/SubscriptionHandler.swift
+++ b/MoviePilot-TV/ViewModels/SubscriptionHandler.swift
@@ -17,6 +17,17 @@ class SubscriptionHandler: ObservableObject {
   func handleSubscribe(_ item: MediaInfo) {
     guard apiService.canAccess(.subscribe) else { return }
 
+    #if DEBUG
+    if UIPreviewMode.isEnabled() {
+      if item.canDirectlySubscribe {
+        sheetSubscribe = mediaInfoToSubscribeRequest(item)
+      } else {
+        tvSubscribeRequest = SubscribeSeasonRequest(mediaInfo: item, initialSeason: nil)
+      }
+      return
+    }
+    #endif
+
     if item.canDirectlySubscribe {
       Task {
         var isSubscribed = try? await apiService.checkSubscription(media: item)
@@ -43,6 +54,13 @@ class SubscriptionHandler: ObservableObject {
   func fork(share: SubscribeShare) async -> Int? {
     guard apiService.canAccess(.subscribe) else { return nil }
 
+    #if DEBUG
+    if UIPreviewMode.isEnabled() {
+      showAlert(title: share.share_title ?? "", message: "复用订阅成功！")
+      return 1
+    }
+    #endif
+
     do {
       guard let newSubId = try await apiService.forkSubscription(share: share) else {
         return nil
@@ -57,6 +75,10 @@ class SubscriptionHandler: ObservableObject {
 
   func fetchSubscriptionAndShowEditor(subId: Int) async {
     guard apiService.canAccess(.subscribe) else { return }
+
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
 
     do {
       let subscription = try await apiService.fetchSubscription(id: subId)

--- a/MoviePilot-TV/ViewModels/SystemViewModel.swift
+++ b/MoviePilot-TV/ViewModels/SystemViewModel.swift
@@ -146,6 +146,32 @@ class SystemViewModel: ObservableObject {
     checkKeychainStatus()
   }
 
+  #if DEBUG
+  func installUIPreviewData(
+    storageDescription: String,
+    serverURL: String,
+    username: String,
+    backendVersion: String?,
+    availableSites: [Site],
+    customFilterRules: [CustomRule],
+    isRefreshing: Bool = false,
+    refreshMessage: String? = nil,
+    isLoadingSites: Bool = false,
+    isLoadingRules: Bool = false
+  ) {
+    self.storageDescription = storageDescription
+    self.serverURL = serverURL
+    self.username = username
+    self.backendVersion = backendVersion
+    self.availableSites = availableSites
+    self.customFilterRules = customFilterRules
+    self.isRefreshing = isRefreshing
+    self.refreshMessage = refreshMessage
+    self.isLoadingSites = isLoadingSites
+    self.isLoadingRules = isLoadingRules
+  }
+  #endif
+
   /// 手动刷新登录凭据（解决服务器重启或 Token 失效问题）
   func relogin() async {
     guard !isRefreshing else { return }

--- a/MoviePilot-TV/ViewModels/SystemViewModel.swift
+++ b/MoviePilot-TV/ViewModels/SystemViewModel.swift
@@ -36,9 +36,22 @@ class SystemViewModel: ObservableObject {
   private static let waitMediaDetailBackgroundImageKey = "waitMediaDetailBackgroundImage"
   private static let autoSearchNewSubscriptionsKey = "autoSearchNewSubscriptions"
 
+  #if DEBUG
+  private static var isUIPreviewMode: Bool {
+    UIPreviewMode.isEnabled()
+  }
+
+  private var uiPreviewDefaultSearchSites: Set<Int> = []
+  private var uiPreviewHardFilterRuleId: String?
+  private var uiPreviewSoftFilterRuleId: String?
+  #endif
+
   /// 是否在 MediaDetail 首屏等待背景/海报预加载完成。默认开启。
   @Published var waitMediaDetailBackgroundImage: Bool = true {
     didSet {
+      #if DEBUG
+      guard !Self.isUIPreviewMode else { return }
+      #endif
       UserDefaults.standard.set(waitMediaDetailBackgroundImage, forKey: Self.waitMediaDetailBackgroundImageKey)
     }
   }
@@ -46,6 +59,9 @@ class SystemViewModel: ObservableObject {
   /// 新增订阅保存后是否立即触发一次手动搜索。默认开启，保持现有 TV 行为。
   @Published var autoSearchNewSubscriptions: Bool = true {
     didSet {
+      #if DEBUG
+      guard !Self.isUIPreviewMode else { return }
+      #endif
       UserDefaults.standard.set(autoSearchNewSubscriptions, forKey: Self.autoSearchNewSubscriptionsKey)
     }
   }
@@ -57,11 +73,21 @@ class SystemViewModel: ObservableObject {
   /// 默认搜索站点（绑定 URL + 用户名）
   var defaultSearchSites: Set<Int> {
     get {
+      #if DEBUG
+      if Self.isUIPreviewMode { return uiPreviewDefaultSearchSites }
+      #endif
       let array = UserDefaults.standard.array(forKey: defaultSearchSitesUserDefaultsKey) as? [Int] ?? []
       return Set(array)
     }
     set {
       let normalizedSites = normalizeDefaultSearchSites(newValue)
+      #if DEBUG
+      if Self.isUIPreviewMode {
+        uiPreviewDefaultSearchSites = normalizedSites
+        objectWillChange.send()
+        return
+      }
+      #endif
       let array = normalizedSites.sorted()
       if array.isEmpty {
         UserDefaults.standard.removeObject(forKey: defaultSearchSitesUserDefaultsKey)
@@ -79,9 +105,19 @@ class SystemViewModel: ObservableObject {
   /// 当前选中的硬过滤规则 ID（绑定 URL + 用户名）
   var selectedHardFilterRuleId: String? {
     get {
-      UserDefaults.standard.string(forKey: hardFilterRuleUserDefaultsKey)
+      #if DEBUG
+      if Self.isUIPreviewMode { return uiPreviewHardFilterRuleId }
+      #endif
+      return UserDefaults.standard.string(forKey: hardFilterRuleUserDefaultsKey)
     }
     set {
+      #if DEBUG
+      if Self.isUIPreviewMode {
+        uiPreviewHardFilterRuleId = newValue
+        objectWillChange.send()
+        return
+      }
+      #endif
       if let value = newValue {
         UserDefaults.standard.set(value, forKey: hardFilterRuleUserDefaultsKey)
       } else {
@@ -94,9 +130,19 @@ class SystemViewModel: ObservableObject {
   /// 当前选中的软过滤规则 ID（绑定 URL + 用户名）
   var selectedSoftFilterRuleId: String? {
     get {
-      UserDefaults.standard.string(forKey: softFilterRuleUserDefaultsKey)
+      #if DEBUG
+      if Self.isUIPreviewMode { return uiPreviewSoftFilterRuleId }
+      #endif
+      return UserDefaults.standard.string(forKey: softFilterRuleUserDefaultsKey)
     }
     set {
+      #if DEBUG
+      if Self.isUIPreviewMode {
+        uiPreviewSoftFilterRuleId = newValue
+        objectWillChange.send()
+        return
+      }
+      #endif
       if let value = newValue {
         UserDefaults.standard.set(value, forKey: softFilterRuleUserDefaultsKey)
       } else {
@@ -169,12 +215,23 @@ class SystemViewModel: ObservableObject {
     self.refreshMessage = refreshMessage
     self.isLoadingSites = isLoadingSites
     self.isLoadingRules = isLoadingRules
+    uiPreviewDefaultSearchSites = []
+    uiPreviewHardFilterRuleId = customFilterRules.first?.id
+    uiPreviewSoftFilterRuleId = customFilterRules.dropFirst().first?.id ?? customFilterRules.first?.id
   }
   #endif
 
   /// 手动刷新登录凭据（解决服务器重启或 Token 失效问题）
   func relogin() async {
     guard !isRefreshing else { return }
+
+    #if DEBUG
+    if Self.isUIPreviewMode {
+      refreshMessage = "刷新成功"
+      storageDescription = "已登录 (安全存储)"
+      return
+    }
+    #endif
 
     isRefreshing = true
     refreshMessage = nil
@@ -205,6 +262,14 @@ class SystemViewModel: ObservableObject {
   }
 
   func logout() {
+    #if DEBUG
+    if Self.isUIPreviewMode {
+      storageMechanism = .none
+      storageDescription = "未登录"
+      refreshMessage = nil
+      return
+    }
+    #endif
     APIService.shared.logout()
     checkKeychainStatus()
   }

--- a/MoviePilot-TV/ViewModels/TransferHistoryViewModel.swift
+++ b/MoviePilot-TV/ViewModels/TransferHistoryViewModel.swift
@@ -58,6 +58,29 @@ class TransferHistoryViewModel: ObservableObject {
     configurePaginator()
   }
 
+  #if DEBUG
+  func installUIPreviewData(
+    items: [TransferHistory],
+    storageDict: [String: String] = [:],
+    selectedIds: Set<Int> = [],
+    isFirstLoading: Bool = false,
+    isLoadingMore: Bool = false,
+    isAiRedoing: Bool = false,
+    aiRedoingIds: Set<Int> = [],
+    aiRedoProgressText: String = ""
+  ) {
+    paginator.cancel()
+    self.items = items
+    self.storageDict = storageDict
+    self.selectedIds = selectedIds
+    self.isFirstLoading = isFirstLoading
+    self.isLoadingMore = isLoadingMore
+    self.isAiRedoing = isAiRedoing
+    self.aiRedoingIds = aiRedoingIds
+    self.aiRedoProgressText = aiRedoProgressText
+  }
+  #endif
+
   private func configurePaginator() {
     paginator?.cancel()
 
@@ -131,6 +154,10 @@ class TransferHistoryViewModel: ObservableObject {
   }
 
   func refresh() async {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
+
     errorMessage = nil
     isLoadingMore = false
     guard apiService.canAccess(.manage) else {
@@ -176,6 +203,10 @@ class TransferHistoryViewModel: ObservableObject {
   }
 
   func loadMore(currentItemId: TransferHistory.ID) async {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
+
     errorMessage = nil
     guard apiService.canAccess(.manage) else { return }
     guard !isLoadingMore else { return }
@@ -195,6 +226,10 @@ class TransferHistoryViewModel: ObservableObject {
   }
 
   func deleteHistory(item: TransferHistory, deleteSource: Bool, deleteDest: Bool) async {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
+
     errorMessage = nil
     guard apiService.canAccess(.manage) else { return }
     do {
@@ -233,6 +268,10 @@ class TransferHistoryViewModel: ObservableObject {
   }
 
   func deleteSelected(deleteSource: Bool, deleteDest: Bool) async {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
+
     errorMessage = nil
     guard apiService.canAccess(.manage) else { return }
     let idsToDelete = Array(selectedIds)
@@ -272,6 +311,10 @@ class TransferHistoryViewModel: ObservableObject {
   // MARK: - Polling Helpers
 
   func fetchLatest() async {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
+
     guard apiService.canAccess(.manage) else { return }
     do {
       var allNewItems: [TransferHistory] = []
@@ -441,6 +484,10 @@ class TransferHistoryViewModel: ObservableObject {
   // MARK: - AI Reorganize
 
   func triggerAiRedo(for ids: [Int]) async {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() { return }
+    #endif
+
     guard apiService.canAccess(.manage) else { return }
     let pendingIds = ids.filter { !aiRedoingIds.contains($0) }
     guard !pendingIds.isEmpty else { return }

--- a/MoviePilot-TV/ViewModels/TransferHistoryViewModel.swift
+++ b/MoviePilot-TV/ViewModels/TransferHistoryViewModel.swift
@@ -70,6 +70,11 @@ class TransferHistoryViewModel: ObservableObject {
     aiRedoProgressText: String = ""
   ) {
     paginator.cancel()
+    paginatorItems = items
+    prependedItems.removeAll()
+    deletedIds.removeAll()
+    pendingInsertionShiftCount = 0
+    pendingDeletionShiftCount = 0
     self.items = items
     self.storageDict = storageDict
     self.selectedIds = selectedIds

--- a/MoviePilot-TV/Views/Components/SheetPicker.swift
+++ b/MoviePilot-TV/Views/Components/SheetPicker.swift
@@ -1,6 +1,12 @@
 import Combine
 import SwiftUI
 
+#if DEBUG
+enum SheetPickerUIPreviewPresentation {
+  case options
+}
+#endif
+
 struct PickerOption<Value: Hashable>: Identifiable {
   let id: Value
   let title: String
@@ -17,8 +23,38 @@ struct SheetPicker<Value: Hashable>: View {
   let title: String
   @Binding var selection: Value
   let options: [PickerOption<Value>]
+  #if DEBUG
+  private let presentsPickerOnAppear: Bool
+  #endif
 
   @State private var showingPicker = false
+
+  init(
+    title: String,
+    selection: Binding<Value>,
+    options: [PickerOption<Value>]
+  ) {
+    self.title = title
+    _selection = selection
+    self.options = options
+    #if DEBUG
+    self.presentsPickerOnAppear = false
+    #endif
+  }
+
+  #if DEBUG
+  init(
+    title: String,
+    selection: Binding<Value>,
+    options: [PickerOption<Value>],
+    uiPreviewPresentation: SheetPickerUIPreviewPresentation?
+  ) {
+    self.title = title
+    _selection = selection
+    self.options = options
+    self.presentsPickerOnAppear = uiPreviewPresentation == .options
+  }
+  #endif
 
   var body: some View {
     // 所有版本都使用嵌套 Sheet 模式，避免 NavigationLink 导致的 dismiss 问题
@@ -42,6 +78,15 @@ struct SheetPicker<Value: Hashable>: View {
         isPresented: $showingPicker
       )
     }
+    #if DEBUG
+    .onAppear {
+      guard presentsPickerOnAppear else { return }
+      Task { @MainActor in
+        await Task.yield()
+        showingPicker = true
+      }
+    }
+    #endif
   }
 }
 
@@ -79,4 +124,3 @@ private struct SheetPickerDetailView<Value: Hashable>: View {
     }
   }
 }
-

--- a/MoviePilot-TV/Views/Components/TorrentsResultView.swift
+++ b/MoviePilot-TV/Views/Components/TorrentsResultView.swift
@@ -1,5 +1,11 @@
 import SwiftUI
 
+#if DEBUG
+enum TorrentsResultUIPreviewPresentation {
+  case filterSelection
+}
+#endif
+
 struct TorrentsResultView<Header: View>: View {
   let result: [Context]
   var overrideMediaInfo: MediaInfo? = nil
@@ -17,6 +23,10 @@ struct TorrentsResultView<Header: View>: View {
   // 计算/缓存状态
   @State private var filterOptions: [String: [String]] = [:]
   @State private var filteredResults: [Context] = []
+  #if DEBUG
+  @State private var didPresentPreviewFilter = false
+  private let uiPreviewPresentation: TorrentsResultUIPreviewPresentation?
+  #endif
 
   // 底部重定向器的焦点管理
   @FocusState private var focusedItemId: Context.ID?
@@ -32,7 +42,24 @@ struct TorrentsResultView<Header: View>: View {
     self.result = result
     self.overrideMediaInfo = overrideMediaInfo
     self.header = header()
+    #if DEBUG
+    self.uiPreviewPresentation = nil
+    #endif
   }
+
+  #if DEBUG
+  init(
+    result: [Context],
+    overrideMediaInfo: MediaInfo? = nil,
+    uiPreviewPresentation: TorrentsResultUIPreviewPresentation?,
+    @ViewBuilder header: () -> Header
+  ) {
+    self.result = result
+    self.overrideMediaInfo = overrideMediaInfo
+    self.header = header()
+    self.uiPreviewPresentation = uiPreviewPresentation
+  }
+  #endif
 
   var body: some View {
     ScrollView(.vertical) {
@@ -114,6 +141,9 @@ struct TorrentsResultView<Header: View>: View {
     .onAppear {
       updateFilterOptions()
       updateFilteredResults()
+      #if DEBUG
+      presentUIPreviewFilterIfNeeded()
+      #endif
     }
   }
 
@@ -304,6 +334,23 @@ struct TorrentsResultView<Header: View>: View {
     return "Normal"
   }
 
+  #if DEBUG
+  private func presentUIPreviewFilterIfNeeded() {
+    guard uiPreviewPresentation == .filterSelection, !didPresentPreviewFilter else { return }
+    didPresentPreviewFilter = true
+
+    Task { @MainActor in
+      await Task.yield()
+      let key = "site"
+      activeFilter = FilterConfig(
+        id: key,
+        title: "站点",
+        options: filterOptions[key] ?? [],
+        disabledOptions: computeDisabledOptions(for: key)
+      )
+    }
+  }
+  #endif
 }
 
 extension TorrentsResultView where Header == EmptyView {

--- a/MoviePilot-TV/Views/ContentView.swift
+++ b/MoviePilot-TV/Views/ContentView.swift
@@ -4,7 +4,7 @@ struct ContentView: View {
   var body: some View {
     #if DEBUG
     if UIPreviewMode.isEnabled() {
-      PreviewCatalogView()
+      PreviewCatalogView(initialSceneID: UIPreviewMode.sceneID())
     } else {
       RealAppContentView()
     }

--- a/MoviePilot-TV/Views/ContentView.swift
+++ b/MoviePilot-TV/Views/ContentView.swift
@@ -8,6 +8,18 @@ struct ContentView: View {
   @Environment(\.scenePhase) private var scenePhase
 
   var body: some View {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() {
+      PreviewCatalogView()
+    } else {
+      appContent
+    }
+    #else
+    appContent
+    #endif
+  }
+
+  private var appContent: some View {
     Group {
       if viewModel.isPreparingStartupSession {
         ProgressView("正在准备会话...")

--- a/MoviePilot-TV/Views/ContentView.swift
+++ b/MoviePilot-TV/Views/ContentView.swift
@@ -1,6 +1,20 @@
 import SwiftUI
 
 struct ContentView: View {
+  var body: some View {
+    #if DEBUG
+    if UIPreviewMode.isEnabled() {
+      PreviewCatalogView()
+    } else {
+      RealAppContentView()
+    }
+    #else
+    RealAppContentView()
+    #endif
+  }
+}
+
+private struct RealAppContentView: View {
   @StateObject private var viewModel = ContentViewModel()
   @StateObject private var mediaActionHandler = MediaActionHandler()
   @State private var selectedTab = ContentViewModel.Tab.home
@@ -8,18 +22,6 @@ struct ContentView: View {
   @Environment(\.scenePhase) private var scenePhase
 
   var body: some View {
-    #if DEBUG
-    if UIPreviewMode.isEnabled() {
-      PreviewCatalogView()
-    } else {
-      appContent
-    }
-    #else
-    appContent
-    #endif
-  }
-
-  private var appContent: some View {
     Group {
       if viewModel.isPreparingStartupSession {
         ProgressView("正在准备会话...")

--- a/MoviePilot-TV/Views/Pages/CollectionDetailView.swift
+++ b/MoviePilot-TV/Views/Pages/CollectionDetailView.swift
@@ -17,6 +17,20 @@ struct CollectionDetailView: View {
       wrappedValue: CollectionDetailViewModel(collectionId: collectionId, title: title))
   }
 
+  #if DEBUG
+  init(
+    title: String,
+    collectionId: Int,
+    navigationPath: Binding<NavigationPath>,
+    previewViewModel: CollectionDetailViewModel
+  ) {
+    self.title = title
+    self.collectionId = collectionId
+    self._navigationPath = navigationPath
+    self._viewModel = StateObject(wrappedValue: previewViewModel)
+  }
+  #endif
+
   var body: some View {
     MediaGridView(
       items: viewModel.paginator.items,
@@ -43,6 +57,9 @@ struct CollectionDetailView: View {
     )
     .mediaSubscriptionAlerts(using: subscriptionHandler, navigationPath: $navigationPath)
     .task {
+      #if DEBUG
+      if UIPreviewMode.isEnabled() { return }
+      #endif
       await viewModel.loadInitialData()
     }
   }

--- a/MoviePilot-TV/Views/Pages/DownloadTaskView.swift
+++ b/MoviePilot-TV/Views/Pages/DownloadTaskView.swift
@@ -2,8 +2,26 @@ import Kingfisher
 import SwiftUI
 
 struct DownloadTaskView: View {
-  @StateObject private var viewModel = DownloadTaskViewModel()
+  @StateObject private var viewModel: DownloadTaskViewModel
+
+  #if DEBUG
+  private let refreshesOnAppear: Bool
+  #endif
   @State private var isExpanded = true
+
+  init() {
+    _viewModel = StateObject(wrappedValue: DownloadTaskViewModel())
+    #if DEBUG
+    refreshesOnAppear = true
+    #endif
+  }
+
+  #if DEBUG
+  init(viewModel: DownloadTaskViewModel, refreshesOnAppear: Bool) {
+    _viewModel = StateObject(wrappedValue: viewModel)
+    self.refreshesOnAppear = refreshesOnAppear
+  }
+  #endif
 
   var body: some View {
     VStack(alignment: .leading, spacing: 20) {
@@ -53,6 +71,9 @@ struct DownloadTaskView: View {
       }
     }
     .task {
+      #if DEBUG
+      guard refreshesOnAppear else { return }
+      #endif
       await DownloadTaskView.runAutoRefresh(
         initialLoad: { await viewModel.initialLoad() },
         loadDownloads: { await viewModel.loadDownloads() }

--- a/MoviePilot-TV/Views/Pages/DownloadTaskView.swift
+++ b/MoviePilot-TV/Views/Pages/DownloadTaskView.swift
@@ -1,11 +1,19 @@
 import Kingfisher
 import SwiftUI
 
+#if DEBUG
+enum DownloadTaskUIPreviewPresentation {
+  case collapsed
+  case deleteConfirmation
+}
+#endif
+
 struct DownloadTaskView: View {
   @StateObject private var viewModel: DownloadTaskViewModel
 
   #if DEBUG
   private let refreshesOnAppear: Bool
+  private let uiPreviewPresentation: DownloadTaskUIPreviewPresentation?
   #endif
   @State private var isExpanded = true
 
@@ -13,13 +21,20 @@ struct DownloadTaskView: View {
     _viewModel = StateObject(wrappedValue: DownloadTaskViewModel())
     #if DEBUG
     refreshesOnAppear = true
+    uiPreviewPresentation = nil
     #endif
   }
 
   #if DEBUG
-  init(viewModel: DownloadTaskViewModel, refreshesOnAppear: Bool) {
+  init(
+    viewModel: DownloadTaskViewModel,
+    refreshesOnAppear: Bool,
+    uiPreviewPresentation: DownloadTaskUIPreviewPresentation? = nil
+  ) {
     _viewModel = StateObject(wrappedValue: viewModel)
     self.refreshesOnAppear = refreshesOnAppear
+    self.uiPreviewPresentation = uiPreviewPresentation
+    _isExpanded = State(initialValue: uiPreviewPresentation != .collapsed)
   }
   #endif
 
@@ -64,7 +79,15 @@ struct DownloadTaskView: View {
         } else {
           LazyVStack(spacing: 15) {
             ForEach(viewModel.downloads) { item in
+              #if DEBUG
+              DownloadTaskRow(
+                item: item,
+                viewModel: viewModel,
+                showsDeleteConfirmation: uiPreviewPresentation == .deleteConfirmation && item.id == viewModel.downloads.first?.id
+              )
+              #else
               DownloadTaskRow(item: item, viewModel: viewModel)
+              #endif
             }
           }
         }
@@ -102,6 +125,7 @@ struct DownloadTaskView: View {
 private struct DownloadTaskRow: View {
   @ObservedObject var item: DownloadingInfo
   let viewModel: DownloadTaskViewModel
+  let presentsDeleteConfirmationOnAppear: Bool
 
   @State private var showingDeleteConfirm = false
 
@@ -109,9 +133,15 @@ private struct DownloadTaskRow: View {
   // 仅当 state 为 "downloading" 时为 true，用于控制“暂停/继续”按钮的状态。
   @State private var isDownloading: Bool
 
-  init(item: DownloadingInfo, viewModel: DownloadTaskViewModel) {
+  init(
+    item: DownloadingInfo,
+    viewModel: DownloadTaskViewModel,
+    showsDeleteConfirmation: Bool = false
+  ) {
     self.item = item
     self.viewModel = viewModel
+    self.presentsDeleteConfirmationOnAppear = showsDeleteConfirmation
+    _showingDeleteConfirm = State(initialValue: false)
     _isDownloading = State(initialValue: item.state?.lowercased() == "downloading")
   }
 
@@ -223,6 +253,13 @@ private struct DownloadTaskRow: View {
         }
       }
       Button("取消", role: .cancel) {}
+    }
+    .onAppear {
+      guard presentsDeleteConfirmationOnAppear else { return }
+      Task { @MainActor in
+        await Task.yield()
+        showingDeleteConfirm = true
+      }
     }
     .onChange(of: item.state) { _, newState in
       // 实时同步来自服务器的状态变更

--- a/MoviePilot-TV/Views/Pages/ExploreView.swift
+++ b/MoviePilot-TV/Views/Pages/ExploreView.swift
@@ -6,14 +6,21 @@ struct ExploreView: View {
   @State private var path = NavigationPath()
   @StateObject private var subscriptionHandler = SubscriptionHandler()
   @EnvironmentObject private var mediaActionHandler: MediaActionHandler
+  #if DEBUG
+  private let uiPreviewForkShare: SubscribeShare?
+  #endif
 
   init() {
     _viewModel = StateObject(wrappedValue: ExploreViewModel())
+    #if DEBUG
+    uiPreviewForkShare = nil
+    #endif
   }
 
   #if DEBUG
-  init(viewModel: ExploreViewModel) {
+  init(viewModel: ExploreViewModel, uiPreviewForkShare: SubscribeShare? = nil) {
     _viewModel = StateObject(wrappedValue: viewModel)
+    self.uiPreviewForkShare = uiPreviewForkShare
   }
   #endif
 
@@ -74,6 +81,15 @@ struct ExploreView: View {
         subscriptionHandler: subscriptionHandler
       )
     }
+    #if DEBUG
+    .onAppear {
+      guard let uiPreviewForkShare else { return }
+      Task { @MainActor in
+        await Task.yield()
+        subscriptionHandler.forkSheetRequest = uiPreviewForkShare
+      }
+    }
+    #endif
   }
 
   private var headerView: some View {

--- a/MoviePilot-TV/Views/Pages/ExploreView.swift
+++ b/MoviePilot-TV/Views/Pages/ExploreView.swift
@@ -2,10 +2,20 @@ import Combine
 import SwiftUI
 
 struct ExploreView: View {
-  @StateObject private var viewModel = ExploreViewModel()
+  @StateObject private var viewModel: ExploreViewModel
   @State private var path = NavigationPath()
   @StateObject private var subscriptionHandler = SubscriptionHandler()
   @EnvironmentObject private var mediaActionHandler: MediaActionHandler
+
+  init() {
+    _viewModel = StateObject(wrappedValue: ExploreViewModel())
+  }
+
+  #if DEBUG
+  init(viewModel: ExploreViewModel) {
+    _viewModel = StateObject(wrappedValue: viewModel)
+  }
+  #endif
 
   var body: some View {
     NavigationStack(path: $path) {

--- a/MoviePilot-TV/Views/Pages/HomeView.swift
+++ b/MoviePilot-TV/Views/Pages/HomeView.swift
@@ -4,6 +4,10 @@ import SwiftUI
 struct HomeView: View {
   @StateObject private var viewModel: HomeViewModel
 
+  #if DEBUG
+  private let loadsDataOnAppear: Bool
+  #endif
+
   // Sheet 状态
   @State private var selectedSubscribe: Subscribe?
 
@@ -12,7 +16,22 @@ struct HomeView: View {
 
   init(viewModel: HomeViewModel? = nil) {
     _viewModel = StateObject(wrappedValue: viewModel ?? HomeViewModel())
+    #if DEBUG
+    loadsDataOnAppear = true
+    #endif
   }
+
+  #if DEBUG
+  init(
+    viewModel: HomeViewModel,
+    loadsDataOnAppear: Bool,
+    initialPath: NavigationPath = NavigationPath()
+  ) {
+    _viewModel = StateObject(wrappedValue: viewModel)
+    self.loadsDataOnAppear = loadsDataOnAppear
+    _path = State(initialValue: initialPath)
+  }
+  #endif
 
   var body: some View {
     NavigationStack(path: $path) {
@@ -73,6 +92,9 @@ struct HomeView: View {
         }
       }
       .task {
+        #if DEBUG
+        guard loadsDataOnAppear else { return }
+        #endif
         // 每次页面出现时都会先加载一次（内部有 hasLoaded 控制全屏 Loading）
         await viewModel.loadData()
 

--- a/MoviePilot-TV/Views/Pages/HomeView.swift
+++ b/MoviePilot-TV/Views/Pages/HomeView.swift
@@ -1,11 +1,36 @@
 import SwiftUI
 
+#if DEBUG
+enum HomeViewUIPreviewPresentation {
+  case subscribeSheet
+  case unsubscribeConfirmation
+}
+
+struct HomeViewUIPreviewDestinations {
+  var mediaDetailPresentation: MediaDetailUIPreviewPresentation? = nil
+  var mediaDetailSites: [Site] = []
+  var mediaDetailRows: MediaDetailUIPreviewRows? = nil
+  var homePresentation: HomeViewUIPreviewPresentation? = nil
+}
+#endif
+
 @MainActor
 struct HomeView: View {
   @StateObject private var viewModel: HomeViewModel
 
   #if DEBUG
   private let loadsDataOnAppear: Bool
+  private let uiPreviewDestinations: HomeViewUIPreviewDestinations?
+  private var previewSubscriptionID: Int? {
+    switch uiPreviewDestinations?.homePresentation {
+    case .unsubscribeConfirmation:
+      return viewModel.movieSubscriptions.first?.id ?? viewModel.tvSubscriptions.first?.id
+    case .subscribeSheet, .none:
+      return nil
+    }
+  }
+  #else
+  private var previewSubscriptionID: Int? { nil }
   #endif
 
   // Sheet 状态
@@ -18,6 +43,7 @@ struct HomeView: View {
     _viewModel = StateObject(wrappedValue: viewModel ?? HomeViewModel())
     #if DEBUG
     loadsDataOnAppear = true
+    uiPreviewDestinations = nil
     #endif
   }
 
@@ -25,10 +51,12 @@ struct HomeView: View {
   init(
     viewModel: HomeViewModel,
     loadsDataOnAppear: Bool,
-    initialPath: NavigationPath = NavigationPath()
+    initialPath: NavigationPath = NavigationPath(),
+    uiPreviewDestinations: HomeViewUIPreviewDestinations? = nil
   ) {
     _viewModel = StateObject(wrappedValue: viewModel)
     self.loadsDataOnAppear = loadsDataOnAppear
+    self.uiPreviewDestinations = uiPreviewDestinations
     _path = State(initialValue: initialPath)
   }
   #endif
@@ -63,7 +91,8 @@ struct HomeView: View {
                 isFirstRow: viewModel.latestMediaServers.isEmpty,
                 viewModel: viewModel,
                 onEdit: presentEditSheet,
-                onViewDetail: navigateToDetail
+                onViewDetail: navigateToDetail,
+                previewUnsubscribeID: previewSubscriptionID
               )
             }
 
@@ -76,7 +105,8 @@ struct HomeView: View {
                   && viewModel.movieSubscriptions.isEmpty,
                 viewModel: viewModel,
                 onEdit: presentEditSheet,
-                onViewDetail: navigateToDetail
+                onViewDetail: navigateToDetail,
+                previewUnsubscribeID: previewSubscriptionID
               )
             }
 
@@ -109,9 +139,32 @@ struct HomeView: View {
       .sheet(item: $selectedSubscribe) { subscribe in
         SubscribeSheet(subscribe: subscribe)
       }
+      #if DEBUG
+      .onAppear {
+        guard uiPreviewDestinations?.homePresentation == .subscribeSheet else { return }
+        Task { @MainActor in
+          await Task.yield()
+          selectedSubscribe = viewModel.movieSubscriptions.first ?? viewModel.tvSubscriptions.first
+        }
+      }
+      #endif
       // 导航目的地
       .navigationDestination(for: MediaInfo.self) { mediaInfo in
+        #if DEBUG
+        if let presentation = uiPreviewDestinations?.mediaDetailPresentation {
+          MediaDetailContainerView(
+            media: mediaInfo,
+            navigationPath: $path,
+            uiPreviewPresentation: presentation,
+            uiPreviewSites: uiPreviewDestinations?.mediaDetailSites ?? [],
+            uiPreviewRows: uiPreviewDestinations?.mediaDetailRows
+          )
+        } else {
+          MediaDetailContainerView(media: mediaInfo, navigationPath: $path)
+        }
+        #else
         MediaDetailContainerView(media: mediaInfo, navigationPath: $path)
+        #endif
       }
       .navigationDestination(for: Person.self) { person in
         PersonDetailView(
@@ -286,6 +339,7 @@ private struct SubscribeSectionView: View {
   @ObservedObject var viewModel: HomeViewModel
   let onEdit: (Subscribe) -> Void
   let onViewDetail: (Subscribe) -> Void
+  var previewUnsubscribeID: Int? = nil
 
   @FocusState private var focusedItemId: String?
   @FocusState private var isTopRedirectorFocused: Bool
@@ -321,7 +375,8 @@ private struct SubscribeSectionView: View {
               item: item,
               viewModel: viewModel,
               onEdit: { onEdit(item) },
-              onViewDetail: { onViewDetail(item) }
+              onViewDetail: { onViewDetail(item) },
+              presentsUnsubscribeConfirmationOnAppear: item.id == previewUnsubscribeID
             )
             .focused($focusedItemId, equals: HomeSubscribeFocusID.value(for: item.id))
           }
@@ -340,6 +395,7 @@ private struct SubscribeItemView: View {
   @ObservedObject var viewModel: HomeViewModel
   let onEdit: () -> Void
   let onViewDetail: () -> Void
+  let presentsUnsubscribeConfirmationOnAppear: Bool
   @State private var showUnsubscribeConfirm = false
 
   var body: some View {
@@ -420,6 +476,13 @@ private struct SubscribeItemView: View {
       }
     } message: {
       Text(SubscriptionCancelConfirmation.message(for: item))
+    }
+    .onAppear {
+      guard presentsUnsubscribeConfirmationOnAppear else { return }
+      Task { @MainActor in
+        await Task.yield()
+        showUnsubscribeConfirm = true
+      }
     }
   }
 

--- a/MoviePilot-TV/Views/Pages/LoginView.swift
+++ b/MoviePilot-TV/Views/Pages/LoginView.swift
@@ -1,7 +1,17 @@
 import SwiftUI
 
 struct LoginView: View {
-  @StateObject private var viewModel = LoginViewModel()
+  @StateObject private var viewModel: LoginViewModel
+
+  init() {
+    _viewModel = StateObject(wrappedValue: LoginViewModel())
+  }
+
+  #if DEBUG
+  init(previewViewModel: LoginViewModel) {
+    _viewModel = StateObject(wrappedValue: previewViewModel)
+  }
+  #endif
 
   var body: some View {
     HStack {

--- a/MoviePilot-TV/Views/Pages/MediaDetailContainerView.swift
+++ b/MoviePilot-TV/Views/Pages/MediaDetailContainerView.swift
@@ -195,6 +195,11 @@ private struct MediaLoadingView: View {
 struct MediaDetailContainerView: View {
   let media: MediaInfo
   @Binding var navigationPath: NavigationPath
+  #if DEBUG
+  private let uiPreviewPresentation: MediaDetailUIPreviewPresentation?
+  private let uiPreviewSites: [Site]
+  private let uiPreviewRows: MediaDetailUIPreviewRows?
+  #endif
 
   /// 预加载任务：在 init 中立即获取/创建，确保首帧就有数据
   /// 非 Optional，消除 if let 条件分支导致的视图结构变化
@@ -203,17 +208,52 @@ struct MediaDetailContainerView: View {
   init(media: MediaInfo, navigationPath: Binding<NavigationPath>) {
     self.media = media
     _navigationPath = navigationPath
+    #if DEBUG
+    self.uiPreviewPresentation = nil
+    self.uiPreviewSites = []
+    self.uiPreviewRows = nil
+    #endif
     // 在 init 中立即获取预加载任务，避免首帧出现条件分支
     _preloadTask = State(wrappedValue: MediaPreloader.shared.preload(for: media))
   }
 
+  #if DEBUG
+  init(
+    media: MediaInfo,
+    navigationPath: Binding<NavigationPath>,
+    uiPreviewPresentation: MediaDetailUIPreviewPresentation?,
+    uiPreviewSites: [Site] = [],
+    uiPreviewRows: MediaDetailUIPreviewRows? = nil
+  ) {
+    self.media = media
+    _navigationPath = navigationPath
+    self.uiPreviewPresentation = uiPreviewPresentation
+    self.uiPreviewSites = uiPreviewSites
+    self.uiPreviewRows = uiPreviewRows
+    _preloadTask = State(wrappedValue: MediaPreloader.shared.preload(for: media))
+  }
+  #endif
+
   var body: some View {
     // 直接传入 preloadTask（非 Optional，无条件分支）
-    MediaDetailContainerContent(
-      media: media,
-      navigationPath: $navigationPath,
-      preloadTask: preloadTask
-    )
+    Group {
+      #if DEBUG
+      MediaDetailContainerContent(
+        media: media,
+        navigationPath: $navigationPath,
+        preloadTask: preloadTask,
+        uiPreviewPresentation: uiPreviewPresentation,
+        uiPreviewSites: uiPreviewSites,
+        uiPreviewRows: uiPreviewRows
+      )
+      #else
+      MediaDetailContainerContent(
+        media: media,
+        navigationPath: $navigationPath,
+        preloadTask: preloadTask
+      )
+      #endif
+    }
     .task(id: media.id) {
       // 确保当前任务被锁定，防止用户在子页面浏览时被最近最少使用算法 (LRU) 淘汰
       MediaPreloader.shared.pin(key: media.id)
@@ -230,6 +270,11 @@ private struct MediaDetailContainerContent: View {
   let media: MediaInfo
   @Binding var navigationPath: NavigationPath
   @ObservedObject var preloadTask: MediaPreloadTask
+  #if DEBUG
+  let uiPreviewPresentation: MediaDetailUIPreviewPresentation?
+  let uiPreviewSites: [Site]
+  let uiPreviewRows: MediaDetailUIPreviewRows?
+  #endif
 
   /// 第二页首行内容是否已就绪（由 MediaDetailView 回写）
   @State private var isContentReady = false
@@ -238,13 +283,41 @@ private struct MediaDetailContainerContent: View {
   /// 最短展示时间是否已过（防止加载太快导致动画闪烁）
   @State private var minTimeElapsed = false
 
-  init(media: MediaInfo, navigationPath: Binding<NavigationPath>, preloadTask: MediaPreloadTask) {
+  init(
+    media: MediaInfo,
+    navigationPath: Binding<NavigationPath>,
+    preloadTask: MediaPreloadTask
+  ) {
     self.media = media
     _navigationPath = navigationPath
     self.preloadTask = preloadTask
+    #if DEBUG
+    self.uiPreviewPresentation = nil
+    self.uiPreviewSites = []
+    self.uiPreviewRows = nil
+    #endif
     // 在 init 中判断，确保第一帧 isReady 就正确
     _wasPreloaded = State(initialValue: preloadTask.isDetailReady)
   }
+
+  #if DEBUG
+  init(
+    media: MediaInfo,
+    navigationPath: Binding<NavigationPath>,
+    preloadTask: MediaPreloadTask,
+    uiPreviewPresentation: MediaDetailUIPreviewPresentation? = nil,
+    uiPreviewSites: [Site] = [],
+    uiPreviewRows: MediaDetailUIPreviewRows? = nil
+  ) {
+    self.media = media
+    _navigationPath = navigationPath
+    self.preloadTask = preloadTask
+    self.uiPreviewPresentation = uiPreviewPresentation
+    self.uiPreviewSites = uiPreviewSites
+    self.uiPreviewRows = uiPreviewRows
+    _wasPreloaded = State(initialValue: preloadTask.isDetailReady)
+  }
+  #endif
 
   /// 数据是否就绪（加载成功或失败均算就绪，且首行内容已加载）
   /// 如果数据在进入时已预加载完毕，直接视为就绪
@@ -263,12 +336,26 @@ private struct MediaDetailContainerContent: View {
 
     ZStack {
       // Detail 层 — 无条件渲染，从第一帧就存在于视图树中
-      MediaDetailView(
-        detail: detail,
-        navigationPath: $navigationPath,
-        preloadTask: preloadTask,
-        isContentReady: $isContentReady
-      )
+      Group {
+        #if DEBUG
+        MediaDetailView(
+          detail: detail,
+          navigationPath: $navigationPath,
+          preloadTask: preloadTask,
+          isContentReady: $isContentReady,
+          uiPreviewPresentation: uiPreviewPresentation,
+          uiPreviewSites: uiPreviewSites,
+          uiPreviewRows: uiPreviewRows
+        )
+        #else
+        MediaDetailView(
+          detail: detail,
+          navigationPath: $navigationPath,
+          preloadTask: preloadTask,
+          isContentReady: $isContentReady
+        )
+        #endif
+      }
       // 加载未完成时隐藏详情，防止 NavigationStack 过渡动画透出内容
       .opacity(isReady ? 1 : 0)
 

--- a/MoviePilot-TV/Views/Pages/MediaDetailView.swift
+++ b/MoviePilot-TV/Views/Pages/MediaDetailView.swift
@@ -1,6 +1,24 @@
 import Kingfisher
 import SwiftUI
 
+#if DEBUG
+enum MediaDetailUIPreviewPresentation {
+  case contentPage
+  case tmdbJumpLoading
+  case siteSelection
+  case subscribeSheet
+  case unsubscribeConfirmation
+  case unsubscribing
+}
+
+struct MediaDetailUIPreviewRows {
+  var actors: [Person] = []
+  var recommendations: [MediaInfo] = []
+  var similar: [MediaInfo] = []
+  var isLoadingMore = false
+}
+#endif
+
 struct MediaDetailView: View {
   @StateObject private var viewModel: MediaDetailViewModel
   @Binding var navigationPath: NavigationPath
@@ -25,6 +43,11 @@ struct MediaDetailView: View {
   @State private var recommendPreloadDebounce: Task<Void, Never>?
   /// 相似区预加载防抖任务
   @State private var similarPreloadDebounce: Task<Void, Never>?
+
+  #if DEBUG
+  private let uiPreviewPresentation: MediaDetailUIPreviewPresentation?
+  @State private var didScrollToUIPreviewContentPage = false
+  #endif
 
   @FocusState private var focusedRecommendId: MediaInfo.ID?
   @FocusState private var focusedSimilarId: MediaInfo.ID?
@@ -129,7 +152,50 @@ struct MediaDetailView: View {
     _navigationPath = navigationPath
     self.preloadTask = preloadTask
     _isContentReady = isContentReady
+    #if DEBUG
+    uiPreviewPresentation = nil
+    #endif
   }
+
+  #if DEBUG
+  init(
+    detail: MediaInfo,
+    navigationPath: Binding<NavigationPath>,
+    preloadTask: MediaPreloadTask,
+    isContentReady: Binding<Bool>,
+    uiPreviewPresentation: MediaDetailUIPreviewPresentation?,
+    uiPreviewSites: [Site] = [],
+    uiPreviewRows: MediaDetailUIPreviewRows? = nil
+  ) {
+    let vm = MediaDetailViewModel(detail: detail)
+    vm.preloadTask = preloadTask
+    vm.siteFilter.availableSites = uiPreviewSites
+    vm.siteFilter.selectedSites = Set(uiPreviewSites.prefix(2).map(\.id))
+    vm.isUnsubscribing = uiPreviewPresentation == .unsubscribing
+    if let uiPreviewRows {
+      vm.installUIPreviewRows(
+        actors: uiPreviewRows.actors,
+        recommendations: uiPreviewRows.recommendations,
+        similar: uiPreviewRows.similar,
+        isLoadingMore: uiPreviewRows.isLoadingMore
+      )
+    }
+    _viewModel = StateObject(wrappedValue: vm)
+    _navigationPath = navigationPath
+    self.preloadTask = preloadTask
+    _isContentReady = isContentReady
+    self.uiPreviewPresentation = uiPreviewPresentation
+    _showContentPage = State(initialValue: uiPreviewPresentation == .contentPage)
+    _showSiteSelection = State(initialValue: false)
+    _sheetSubscribe = State(initialValue: nil)
+    _showUnsubscribeConfirm = State(initialValue: false)
+    _unsubscribeConfirmationMessage = State(
+      initialValue: uiPreviewPresentation == .unsubscribeConfirmation
+        ? SubscriptionCancelConfirmation.headerMessage(for: detail)
+        : ""
+    )
+  }
+  #endif
 
   var body: some View {
     ZStack {
@@ -260,6 +326,11 @@ struct MediaDetailView: View {
             }
           }
         }
+        #if DEBUG
+        .onAppear {
+          scrollToUIPreviewContentPage(proxy)
+        }
+        #endif
       }
     }
     .environmentObject(subscriptionHandler)
@@ -283,6 +354,9 @@ struct MediaDetailView: View {
         hasRefreshedSubscription: hasRefreshedSubscriptionAfterFullDetail
       )
       if canSearchResources {
+        #if DEBUG
+        guard !UIPreviewMode.isEnabled() else { return }
+        #endif
         await viewModel.siteFilter.loadSites()
       }
     }
@@ -376,12 +450,47 @@ struct MediaDetailView: View {
         label: { $0.name }
       )
     }
+    #if DEBUG
+    .onAppear {
+      guard let uiPreviewPresentation else { return }
+      Task { @MainActor in
+        await Task.yield()
+        switch uiPreviewPresentation {
+        case .siteSelection:
+          showSiteSelection = true
+        case .subscribeSheet:
+          sheetSubscribe = viewModel.buildSubscribeRequest()
+        case .unsubscribeConfirmation:
+          showUnsubscribeConfirm = true
+        case .contentPage, .tmdbJumpLoading, .unsubscribing:
+          break
+        }
+      }
+    }
+    #endif
     .onChange(of: focusedButton) { _, newValue in
       if let newValue = newValue {
         lastFocusedButton = newValue
       }
     }
   }
+
+  #if DEBUG
+  private func scrollToUIPreviewContentPage(_ proxy: ScrollViewProxy) {
+    guard uiPreviewPresentation == .contentPage, !didScrollToUIPreviewContentPage else { return }
+    didScrollToUIPreviewContentPage = true
+    showContentPage = true
+    Task { @MainActor in
+      await Task.yield()
+      try? await Task.sleep(for: .milliseconds(600))
+      showContentPage = true
+      isHeroFocused = false
+      withAnimation(.easeInOut(duration: 0.6)) {
+        proxy.scrollTo("contentTop", anchor: .top)
+      }
+    }
+  }
+  #endif
 
   // MARK: - 订阅 UI 操作（业务逻辑委托给 ViewModel）
 

--- a/MoviePilot-TV/Views/Pages/PersonDetailView.swift
+++ b/MoviePilot-TV/Views/Pages/PersonDetailView.swift
@@ -4,17 +4,29 @@ import SwiftUI
 struct PersonDetailView: View {
   @StateObject private var viewModel: PersonDetailViewModel
   @Binding var navigationPath: NavigationPath
+  #if DEBUG
+  private let presentsBiographySheetOnAppear: Bool
+  #endif
 
   init(person: Person, navigationPath: Binding<NavigationPath>) {
     _viewModel = StateObject(
       wrappedValue: PersonDetailViewModel(person: person))
     _navigationPath = navigationPath
+    #if DEBUG
+    presentsBiographySheetOnAppear = false
+    #endif
   }
 
   #if DEBUG
-  init(previewViewModel: PersonDetailViewModel, navigationPath: Binding<NavigationPath>) {
+  init(
+    previewViewModel: PersonDetailViewModel,
+    navigationPath: Binding<NavigationPath>,
+    showsBiographySheet: Bool = false
+  ) {
     _viewModel = StateObject(wrappedValue: previewViewModel)
     _navigationPath = navigationPath
+    presentsBiographySheetOnAppear = showsBiographySheet
+    _showFullBio = State(initialValue: false)
   }
   #endif
 
@@ -183,6 +195,15 @@ struct PersonDetailView: View {
         .frame(width: 1600)
       }
     }
+    #if DEBUG
+    .onAppear {
+      guard presentsBiographySheetOnAppear else { return }
+      Task { @MainActor in
+        await Task.yield()
+        showFullBio = true
+      }
+    }
+    #endif
     .mediaSubscriptionAlerts(using: subscriptionHandler, navigationPath: $navigationPath)
   }
 }

--- a/MoviePilot-TV/Views/Pages/PersonDetailView.swift
+++ b/MoviePilot-TV/Views/Pages/PersonDetailView.swift
@@ -11,6 +11,13 @@ struct PersonDetailView: View {
     _navigationPath = navigationPath
   }
 
+  #if DEBUG
+  init(previewViewModel: PersonDetailViewModel, navigationPath: Binding<NavigationPath>) {
+    _viewModel = StateObject(wrappedValue: previewViewModel)
+    _navigationPath = navigationPath
+  }
+  #endif
+
   @State private var showFullBio = false
   @State private var isImageFailed: Bool = false
   @StateObject private var subscriptionHandler = SubscriptionHandler()
@@ -156,6 +163,9 @@ struct PersonDetailView: View {
       }
     )
     .task {
+      #if DEBUG
+      if UIPreviewMode.isEnabled() { return }
+      #endif
       await viewModel.loadInitialData()
     }
     .defaultFocus($focusedElement, .biography)

--- a/MoviePilot-TV/Views/Pages/RecommendView.swift
+++ b/MoviePilot-TV/Views/Pages/RecommendView.swift
@@ -1,10 +1,20 @@
 import SwiftUI
 
 struct RecommendView: View {
-  @StateObject private var viewModel = RecommendViewModel()
+  @StateObject private var viewModel: RecommendViewModel
   @State private var path = NavigationPath()
   @StateObject private var subscriptionHandler = SubscriptionHandler()
   @EnvironmentObject private var mediaActionHandler: MediaActionHandler
+
+  init() {
+    _viewModel = StateObject(wrappedValue: RecommendViewModel())
+  }
+
+  #if DEBUG
+  init(viewModel: RecommendViewModel) {
+    _viewModel = StateObject(wrappedValue: viewModel)
+  }
+  #endif
 
   var body: some View {
     NavigationStack(path: $path) {

--- a/MoviePilot-TV/Views/Pages/ResourceResultView.swift
+++ b/MoviePilot-TV/Views/Pages/ResourceResultView.swift
@@ -7,9 +7,16 @@ struct ResourceResultView: View {
   let title: String
   let mediaInfo: MediaInfo?
 
+  #if DEBUG
+  private let searchesOnAppear: Bool
+  #endif
+
   init(request: ResourceSearchRequest) {
     self.title = request.title ?? "资源搜索"
     self.mediaInfo = request.mediaInfo
+    #if DEBUG
+    self.searchesOnAppear = true
+    #endif
     _viewModel = StateObject(
       wrappedValue: ResourceResultViewModel(
         keyword: request.keyword,
@@ -22,6 +29,15 @@ struct ResourceResultView: View {
       )
     )
   }
+
+  #if DEBUG
+  init(title: String, mediaInfo: MediaInfo?, previewViewModel: ResourceResultViewModel) {
+    self.title = title
+    self.mediaInfo = mediaInfo
+    self.searchesOnAppear = false
+    _viewModel = StateObject(wrappedValue: previewViewModel)
+  }
+  #endif
 
   var body: some View {
     Group {
@@ -72,6 +88,9 @@ struct ResourceResultView: View {
       }
     }
     .task {
+      #if DEBUG
+      guard searchesOnAppear else { return }
+      #endif
       await viewModel.search()
     }
     .onDisappear {

--- a/MoviePilot-TV/Views/Pages/ResourceResultView.swift
+++ b/MoviePilot-TV/Views/Pages/ResourceResultView.swift
@@ -9,6 +9,7 @@ struct ResourceResultView: View {
 
   #if DEBUG
   private let searchesOnAppear: Bool
+  private let torrentsPresentation: TorrentsResultUIPreviewPresentation?
   #endif
 
   init(request: ResourceSearchRequest) {
@@ -16,6 +17,7 @@ struct ResourceResultView: View {
     self.mediaInfo = request.mediaInfo
     #if DEBUG
     self.searchesOnAppear = true
+    self.torrentsPresentation = nil
     #endif
     _viewModel = StateObject(
       wrappedValue: ResourceResultViewModel(
@@ -31,10 +33,16 @@ struct ResourceResultView: View {
   }
 
   #if DEBUG
-  init(title: String, mediaInfo: MediaInfo?, previewViewModel: ResourceResultViewModel) {
+  init(
+    title: String,
+    mediaInfo: MediaInfo?,
+    previewViewModel: ResourceResultViewModel,
+    torrentsPresentation: TorrentsResultUIPreviewPresentation? = nil
+  ) {
     self.title = title
     self.mediaInfo = mediaInfo
     self.searchesOnAppear = false
+    self.torrentsPresentation = torrentsPresentation
     _viewModel = StateObject(wrappedValue: previewViewModel)
   }
   #endif
@@ -56,17 +64,20 @@ struct ResourceResultView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
       } else {
+        #if DEBUG
         TorrentsResultView(
           result: viewModel.results,
           overrideMediaInfo: mediaInfo,
-          header: {
-            if mediaInfo != nil {
-              Text(title)
-                .font(.largeTitle.bold())
-                .foregroundColor(.secondary)
-            }
-          }
+          uiPreviewPresentation: torrentsPresentation,
+          header: { resultHeader }
         )
+        #else
+        TorrentsResultView(
+          result: viewModel.results,
+          overrideMediaInfo: mediaInfo,
+          header: { resultHeader }
+        )
+        #endif
       }
     }
     .background {
@@ -98,6 +109,15 @@ struct ResourceResultView: View {
       guard searchesOnAppear else { return }
       #endif
       viewModel.cancelInFlightSearch()
+    }
+  }
+
+  @ViewBuilder
+  private var resultHeader: some View {
+    if mediaInfo != nil {
+      Text(title)
+        .font(.largeTitle.bold())
+        .foregroundColor(.secondary)
     }
   }
 }

--- a/MoviePilot-TV/Views/Pages/ResourceResultView.swift
+++ b/MoviePilot-TV/Views/Pages/ResourceResultView.swift
@@ -94,6 +94,9 @@ struct ResourceResultView: View {
       await viewModel.search()
     }
     .onDisappear {
+      #if DEBUG
+      guard searchesOnAppear else { return }
+      #endif
       viewModel.cancelInFlightSearch()
     }
   }

--- a/MoviePilot-TV/Views/Pages/SearchView.swift
+++ b/MoviePilot-TV/Views/Pages/SearchView.swift
@@ -317,6 +317,17 @@ struct SearchView: View {
         mediaInfo: request.mediaInfo,
         previewViewModel: previewViewModel
       )
+    } else if UIPreviewMode.isEnabled() {
+      ResourceResultView(
+        title: request.title ?? "资源搜索",
+        mediaInfo: request.mediaInfo,
+        previewViewModel: ResourceResultViewModel(
+          previewTitle: request.title ?? request.keyword,
+          mediaInfo: request.mediaInfo,
+          results: [],
+          isLoading: false
+        )
+      )
     } else {
       ResourceResultView(request: request)
     }

--- a/MoviePilot-TV/Views/Pages/SearchView.swift
+++ b/MoviePilot-TV/Views/Pages/SearchView.swift
@@ -4,8 +4,12 @@ import SwiftUI
 struct SearchViewUIPreviewDestinations {
   var collectionViewModel: CollectionDetailViewModel? = nil
   var personViewModel: PersonDetailViewModel? = nil
+  var personShowsBiographySheet = false
   var resourceResultViewModel: ResourceResultViewModel? = nil
+  var resourceTorrentsPresentation: TorrentsResultUIPreviewPresentation? = nil
   var seasonViewModel: SubscribeSeasonViewModel? = nil
+  var seasonPresentation: SubscribeSeasonUIPreviewPresentation? = nil
+  var forkShare: SubscribeShare? = nil
 }
 #endif
 
@@ -15,6 +19,7 @@ struct SearchView: View {
   #if DEBUG
   private let loadsSitesOnAppear: Bool
   private let uiPreviewDestinations: SearchViewUIPreviewDestinations?
+  private let presentsSiteSelectionOnAppear: Bool
   #endif
   @State private var path = NavigationPath()
   @StateObject private var subscriptionHandler = SubscriptionHandler()
@@ -38,6 +43,7 @@ struct SearchView: View {
     #if DEBUG
     loadsSitesOnAppear = true
     uiPreviewDestinations = nil
+    presentsSiteSelectionOnAppear = false
     #endif
   }
 
@@ -46,12 +52,15 @@ struct SearchView: View {
     viewModel: SearchViewModel,
     loadsSitesOnAppear: Bool,
     initialPath: NavigationPath = NavigationPath(),
-    uiPreviewDestinations: SearchViewUIPreviewDestinations? = nil
+    uiPreviewDestinations: SearchViewUIPreviewDestinations? = nil,
+    showsSiteSelection: Bool = false
   ) {
     _viewModel = StateObject(wrappedValue: viewModel)
     self.loadsSitesOnAppear = loadsSitesOnAppear
     self.uiPreviewDestinations = uiPreviewDestinations
+    presentsSiteSelectionOnAppear = showsSiteSelection
     _path = State(initialValue: initialPath)
+    _showSiteSelection = State(initialValue: false)
   }
   #endif
 
@@ -256,6 +265,22 @@ struct SearchView: View {
         // 当视图出现时加载站点
         await viewModel.siteFilter.loadSites()
       }
+      #if DEBUG
+      .onAppear {
+        guard presentsSiteSelectionOnAppear else { return }
+        Task { @MainActor in
+          await Task.yield()
+          showSiteSelection = true
+        }
+      }
+      .onAppear {
+        guard let forkShare = uiPreviewDestinations?.forkShare else { return }
+        Task { @MainActor in
+          await Task.yield()
+          subscriptionHandler.forkSheetRequest = forkShare
+        }
+      }
+      #endif
       .onChange(of: focusedField) { _, newValue in
         if let newValue = newValue {
           lastFocusedField = newValue
@@ -299,7 +324,11 @@ struct SearchView: View {
   private func personDestination(for person: Person) -> some View {
     #if DEBUG
     if let previewViewModel = uiPreviewDestinations?.personViewModel {
-      PersonDetailView(previewViewModel: previewViewModel, navigationPath: $path)
+      PersonDetailView(
+        previewViewModel: previewViewModel,
+        navigationPath: $path,
+        showsBiographySheet: uiPreviewDestinations?.personShowsBiographySheet == true
+      )
     } else {
       PersonDetailView(person: person, navigationPath: $path)
     }
@@ -315,7 +344,8 @@ struct SearchView: View {
       ResourceResultView(
         title: request.title ?? "资源搜索",
         mediaInfo: request.mediaInfo,
-        previewViewModel: previewViewModel
+        previewViewModel: previewViewModel,
+        torrentsPresentation: uiPreviewDestinations?.resourceTorrentsPresentation
       )
     } else if UIPreviewMode.isEnabled() {
       ResourceResultView(
@@ -340,7 +370,10 @@ struct SearchView: View {
   private func seasonDestination(for request: SubscribeSeasonRequest) -> some View {
     #if DEBUG
     if let previewViewModel = uiPreviewDestinations?.seasonViewModel {
-      SubscribeSeasonView(previewViewModel: previewViewModel)
+      SubscribeSeasonView(
+        previewViewModel: previewViewModel,
+        uiPreviewPresentation: uiPreviewDestinations?.seasonPresentation
+      )
     } else {
       SubscribeSeasonView(mediaInfo: request.mediaInfo, initialSeason: request.initialSeason)
     }

--- a/MoviePilot-TV/Views/Pages/SearchView.swift
+++ b/MoviePilot-TV/Views/Pages/SearchView.swift
@@ -1,7 +1,21 @@
 import SwiftUI
 
+#if DEBUG
+struct SearchViewUIPreviewDestinations {
+  var collectionViewModel: CollectionDetailViewModel? = nil
+  var personViewModel: PersonDetailViewModel? = nil
+  var resourceResultViewModel: ResourceResultViewModel? = nil
+  var seasonViewModel: SubscribeSeasonViewModel? = nil
+}
+#endif
+
 struct SearchView: View {
-  @StateObject private var viewModel = SearchViewModel()
+  @StateObject private var viewModel: SearchViewModel
+
+  #if DEBUG
+  private let loadsSitesOnAppear: Bool
+  private let uiPreviewDestinations: SearchViewUIPreviewDestinations?
+  #endif
   @State private var path = NavigationPath()
   @StateObject private var subscriptionHandler = SubscriptionHandler()
   @EnvironmentObject private var mediaActionHandler: MediaActionHandler
@@ -18,6 +32,28 @@ struct SearchView: View {
   // TV 端特有的焦点重定向器：用于在原生搜索栏和自定义内容之间平滑过渡焦点
   @FocusState private var isTopRedirectorFocused: Bool
   @FocusState private var isBottomRedirectorFocused: Bool
+
+  init() {
+    _viewModel = StateObject(wrappedValue: SearchViewModel())
+    #if DEBUG
+    loadsSitesOnAppear = true
+    uiPreviewDestinations = nil
+    #endif
+  }
+
+  #if DEBUG
+  init(
+    viewModel: SearchViewModel,
+    loadsSitesOnAppear: Bool,
+    initialPath: NavigationPath = NavigationPath(),
+    uiPreviewDestinations: SearchViewUIPreviewDestinations? = nil
+  ) {
+    _viewModel = StateObject(wrappedValue: viewModel)
+    self.loadsSitesOnAppear = loadsSitesOnAppear
+    self.uiPreviewDestinations = uiPreviewDestinations
+    _path = State(initialValue: initialPath)
+  }
+  #endif
 
   /// MARK: - 站点过滤器显示逻辑
   /// 此逻辑非常关键，用于处理 TV 端遥控器操作时的焦点“粘性”。
@@ -180,24 +216,16 @@ struct SearchView: View {
         }
       }
       .navigationDestination(for: MediaInfo.self) { detail in
-        if let collectionId = detail.collection_id {
-          CollectionDetailView(
-            title: detail.title ?? "合集详情",
-            collectionId: collectionId,
-            navigationPath: $path
-          )
-        } else {
-          MediaDetailContainerView(media: detail, navigationPath: $path)
-        }
+        mediaDestination(for: detail)
       }
       .navigationDestination(for: Person.self) { person in
-        PersonDetailView(person: person, navigationPath: $path)
+        personDestination(for: person)
       }
       .navigationDestination(for: ResourceSearchRequest.self) { request in
-        ResourceResultView(request: request)
+        resourceDestination(for: request)
       }
       .navigationDestination(for: SubscribeSeasonRequest.self) { request in
-        SubscribeSeasonView(mediaInfo: request.mediaInfo, initialSeason: request.initialSeason)
+        seasonDestination(for: request)
       }
       .mediaSubscriptionAlerts(using: subscriptionHandler, navigationPath: $path)
       .sheet(item: $subscriptionHandler.forkSheetRequest) { share in
@@ -222,6 +250,9 @@ struct SearchView: View {
       // 使用原生搜索栏
       .searchable(text: $viewModel.query, placement: .automatic, prompt: "电影、节目、演职人员等")
       .task {
+        #if DEBUG
+        guard loadsSitesOnAppear else { return }
+        #endif
         // 当视图出现时加载站点
         await viewModel.siteFilter.loadSites()
       }
@@ -232,6 +263,79 @@ struct SearchView: View {
       }
     }
     .environmentObject(subscriptionHandler)
+  }
+
+  @ViewBuilder
+  private func mediaDestination(for detail: MediaInfo) -> some View {
+    if let collectionId = detail.collection_id {
+      #if DEBUG
+      if let previewViewModel = uiPreviewDestinations?.collectionViewModel {
+        CollectionDetailView(
+          title: detail.title ?? "合集详情",
+          collectionId: collectionId,
+          navigationPath: $path,
+          previewViewModel: previewViewModel
+        )
+      } else {
+        CollectionDetailView(
+          title: detail.title ?? "合集详情",
+          collectionId: collectionId,
+          navigationPath: $path
+        )
+      }
+      #else
+      CollectionDetailView(
+        title: detail.title ?? "合集详情",
+        collectionId: collectionId,
+        navigationPath: $path
+      )
+      #endif
+    } else {
+      MediaDetailContainerView(media: detail, navigationPath: $path)
+    }
+  }
+
+  @ViewBuilder
+  private func personDestination(for person: Person) -> some View {
+    #if DEBUG
+    if let previewViewModel = uiPreviewDestinations?.personViewModel {
+      PersonDetailView(previewViewModel: previewViewModel, navigationPath: $path)
+    } else {
+      PersonDetailView(person: person, navigationPath: $path)
+    }
+    #else
+    PersonDetailView(person: person, navigationPath: $path)
+    #endif
+  }
+
+  @ViewBuilder
+  private func resourceDestination(for request: ResourceSearchRequest) -> some View {
+    #if DEBUG
+    if let previewViewModel = uiPreviewDestinations?.resourceResultViewModel {
+      ResourceResultView(
+        title: request.title ?? "资源搜索",
+        mediaInfo: request.mediaInfo,
+        previewViewModel: previewViewModel
+      )
+    } else {
+      ResourceResultView(request: request)
+    }
+    #else
+    ResourceResultView(request: request)
+    #endif
+  }
+
+  @ViewBuilder
+  private func seasonDestination(for request: SubscribeSeasonRequest) -> some View {
+    #if DEBUG
+    if let previewViewModel = uiPreviewDestinations?.seasonViewModel {
+      SubscribeSeasonView(previewViewModel: previewViewModel)
+    } else {
+      SubscribeSeasonView(mediaInfo: request.mediaInfo, initialSeason: request.initialSeason)
+    }
+    #else
+    SubscribeSeasonView(mediaInfo: request.mediaInfo, initialSeason: request.initialSeason)
+    #endif
   }
 }
 

--- a/MoviePilot-TV/Views/Pages/StatusView.swift
+++ b/MoviePilot-TV/Views/Pages/StatusView.swift
@@ -2,8 +2,40 @@ import SwiftUI
 
 /// 系统状态视图：展示媒体库统计、服务器存储空间以及实时下载器状态
 struct StatusView: View {
-  @StateObject private var viewModel = StatusViewModel()
-  @StateObject private var transferHistoryViewModel = TransferHistoryViewModel()
+  @StateObject private var viewModel: StatusViewModel
+  @StateObject private var transferHistoryViewModel: TransferHistoryViewModel
+
+  #if DEBUG
+  @StateObject private var downloadTaskViewModel: DownloadTaskViewModel
+  private let refreshesOnAppear: Bool
+  private let transferPresentation: TransferHistoryUIPreviewPresentation?
+  #endif
+
+  init() {
+    _viewModel = StateObject(wrappedValue: StatusViewModel())
+    _transferHistoryViewModel = StateObject(wrappedValue: TransferHistoryViewModel())
+    #if DEBUG
+    _downloadTaskViewModel = StateObject(wrappedValue: DownloadTaskViewModel())
+    refreshesOnAppear = true
+    transferPresentation = nil
+    #endif
+  }
+
+  #if DEBUG
+  init(
+    viewModel: StatusViewModel,
+    downloadTaskViewModel: DownloadTaskViewModel,
+    transferHistoryViewModel: TransferHistoryViewModel,
+    refreshesOnAppear: Bool,
+    transferPresentation: TransferHistoryUIPreviewPresentation? = nil
+  ) {
+    _viewModel = StateObject(wrappedValue: viewModel)
+    _downloadTaskViewModel = StateObject(wrappedValue: downloadTaskViewModel)
+    _transferHistoryViewModel = StateObject(wrappedValue: transferHistoryViewModel)
+    self.refreshesOnAppear = refreshesOnAppear
+    self.transferPresentation = transferPresentation
+  }
+  #endif
 
   var body: some View {
     ScrollView {
@@ -36,18 +68,35 @@ struct StatusView: View {
 
         Divider()
 
-        DownloadTaskView()
+        #if DEBUG
+        let downloadTaskView = DownloadTaskView(
+          viewModel: downloadTaskViewModel,
+          refreshesOnAppear: refreshesOnAppear
+        )
+        #else
+        let downloadTaskView = DownloadTaskView()
+        #endif
+
+        downloadTaskView
           .padding(.vertical, 20)
 
         Divider()
 
         // --- 4. 媒体整理历史 ---
+        #if DEBUG
+        transferHistoryContent
+          .padding(.vertical, 20)
+        #else
         TransferHistoryView(viewModel: transferHistoryViewModel)
           .padding(.vertical, 20)
+        #endif
 
       }
     }
     .task {
+      #if DEBUG
+      guard refreshesOnAppear else { return }
+      #endif
       /// 核心异步刷新逻辑：
       /// 1. 初始加载全部数据。
       /// 2. 进入 while 循环，每隔 3 秒调用一次后端接口刷新状态。
@@ -58,6 +107,23 @@ struct StatusView: View {
       }
     }
   }
+
+  #if DEBUG
+  @ViewBuilder
+  private var transferHistoryContent: some View {
+    if let transferPresentation {
+      TransferHistoryView(
+        viewModel: transferHistoryViewModel,
+        uiPreviewPresentation: transferPresentation
+      )
+    } else {
+      TransferHistoryView(
+        viewModel: transferHistoryViewModel,
+        refreshesOnAppear: refreshesOnAppear
+      )
+    }
+  }
+  #endif
 }
 
 private struct MiniStat: View {

--- a/MoviePilot-TV/Views/Pages/StatusView.swift
+++ b/MoviePilot-TV/Views/Pages/StatusView.swift
@@ -8,6 +8,7 @@ struct StatusView: View {
   #if DEBUG
   @StateObject private var downloadTaskViewModel: DownloadTaskViewModel
   private let refreshesOnAppear: Bool
+  private let downloadPresentation: DownloadTaskUIPreviewPresentation?
   private let transferPresentation: TransferHistoryUIPreviewPresentation?
   #endif
 
@@ -17,6 +18,7 @@ struct StatusView: View {
     #if DEBUG
     _downloadTaskViewModel = StateObject(wrappedValue: DownloadTaskViewModel())
     refreshesOnAppear = true
+    downloadPresentation = nil
     transferPresentation = nil
     #endif
   }
@@ -27,12 +29,14 @@ struct StatusView: View {
     downloadTaskViewModel: DownloadTaskViewModel,
     transferHistoryViewModel: TransferHistoryViewModel,
     refreshesOnAppear: Bool,
+    downloadPresentation: DownloadTaskUIPreviewPresentation? = nil,
     transferPresentation: TransferHistoryUIPreviewPresentation? = nil
   ) {
     _viewModel = StateObject(wrappedValue: viewModel)
     _downloadTaskViewModel = StateObject(wrappedValue: downloadTaskViewModel)
     _transferHistoryViewModel = StateObject(wrappedValue: transferHistoryViewModel)
     self.refreshesOnAppear = refreshesOnAppear
+    self.downloadPresentation = downloadPresentation
     self.transferPresentation = transferPresentation
   }
   #endif
@@ -71,7 +75,8 @@ struct StatusView: View {
         #if DEBUG
         let downloadTaskView = DownloadTaskView(
           viewModel: downloadTaskViewModel,
-          refreshesOnAppear: refreshesOnAppear
+          refreshesOnAppear: refreshesOnAppear,
+          uiPreviewPresentation: downloadPresentation
         )
         #else
         let downloadTaskView = DownloadTaskView()

--- a/MoviePilot-TV/Views/Pages/SubscribeSeasonView.swift
+++ b/MoviePilot-TV/Views/Pages/SubscribeSeasonView.swift
@@ -4,11 +4,25 @@ import SwiftUI
 struct SubscribeSeasonView: View {
   @StateObject private var viewModel: SubscribeSeasonViewModel
 
+  #if DEBUG
+  private let loadsDataOnAppear: Bool
+  #endif
+
   init(mediaInfo: MediaInfo, initialSeason: Int? = nil) {
     _viewModel = StateObject(
       wrappedValue: SubscribeSeasonViewModel(
         mediaInfo: mediaInfo, initialSeason: initialSeason))
+    #if DEBUG
+    loadsDataOnAppear = true
+    #endif
   }
+
+  #if DEBUG
+  init(previewViewModel: SubscribeSeasonViewModel) {
+    _viewModel = StateObject(wrappedValue: previewViewModel)
+    loadsDataOnAppear = false
+  }
+  #endif
 
   var body: some View {
     ScrollView {
@@ -16,6 +30,9 @@ struct SubscribeSeasonView: View {
     }
     .focusSection()
     .task {
+      #if DEBUG
+      guard loadsDataOnAppear else { return }
+      #endif
       await viewModel.loadData()
     }
   }

--- a/MoviePilot-TV/Views/Pages/SubscribeSeasonView.swift
+++ b/MoviePilot-TV/Views/Pages/SubscribeSeasonView.swift
@@ -1,11 +1,20 @@
 import Kingfisher
 import SwiftUI
 
+#if DEBUG
+enum SubscribeSeasonUIPreviewPresentation {
+  case seasonDetail
+  case subscribeSheet
+  case unsubscribeConfirmation
+}
+#endif
+
 struct SubscribeSeasonView: View {
   @StateObject private var viewModel: SubscribeSeasonViewModel
 
   #if DEBUG
   private let loadsDataOnAppear: Bool
+  private let uiPreviewPresentation: SubscribeSeasonUIPreviewPresentation?
   #endif
 
   init(mediaInfo: MediaInfo, initialSeason: Int? = nil) {
@@ -14,19 +23,32 @@ struct SubscribeSeasonView: View {
         mediaInfo: mediaInfo, initialSeason: initialSeason))
     #if DEBUG
     loadsDataOnAppear = true
+    uiPreviewPresentation = nil
     #endif
   }
 
   #if DEBUG
-  init(previewViewModel: SubscribeSeasonViewModel) {
+  init(
+    previewViewModel: SubscribeSeasonViewModel,
+    uiPreviewPresentation: SubscribeSeasonUIPreviewPresentation? = nil
+  ) {
     _viewModel = StateObject(wrappedValue: previewViewModel)
     loadsDataOnAppear = false
+    self.uiPreviewPresentation = uiPreviewPresentation
   }
   #endif
 
   var body: some View {
     ScrollView {
+      #if DEBUG
+      SubscribeSeasonContentView(
+        viewModel: viewModel,
+        layout: .grid,
+        uiPreviewPresentation: uiPreviewPresentation
+      )
+      #else
       SubscribeSeasonContentView(viewModel: viewModel, layout: .grid)
+      #endif
     }
     .focusSection()
     .task {
@@ -46,17 +68,62 @@ enum SeasonLayout {
 
 struct SubscribeSeasonContentView: View {
   @ObservedObject var viewModel: SubscribeSeasonViewModel
+  @ObservedObject private var apiService = APIService.shared
   var layout: SeasonLayout = .shelf
   var title: String? = nil
   var showBadges: Bool = true
   var onSeasonTap: ((TmdbSeason) -> Void)? = nil
   var onMoreTapped: (() -> Void)? = nil
+  #if DEBUG
+  var uiPreviewPresentation: SubscribeSeasonUIPreviewPresentation? = nil
+  #endif
 
   @Environment(\.scenePhase) private var scenePhase
   @State private var selectedSeasonDetail: TmdbSeason?
+  #if DEBUG
+  @State private var hasPresentedUIPreview = false
+  #endif
   @FocusState private var focusedSeasonId: Int?
   @FocusState private var isTopRedirectorFocused: Bool
   @FocusState private var isBottomRedirectorFocused: Bool
+
+  init(
+    viewModel: SubscribeSeasonViewModel,
+    layout: SeasonLayout = .shelf,
+    title: String? = nil,
+    showBadges: Bool = true,
+    onSeasonTap: ((TmdbSeason) -> Void)? = nil,
+    onMoreTapped: (() -> Void)? = nil
+  ) {
+    self.viewModel = viewModel
+    self.layout = layout
+    self.title = title
+    self.showBadges = showBadges
+    self.onSeasonTap = onSeasonTap
+    self.onMoreTapped = onMoreTapped
+    _selectedSeasonDetail = State(initialValue: nil)
+  }
+
+  #if DEBUG
+  init(
+    viewModel: SubscribeSeasonViewModel,
+    layout: SeasonLayout = .shelf,
+    title: String? = nil,
+    showBadges: Bool = true,
+    onSeasonTap: ((TmdbSeason) -> Void)? = nil,
+    onMoreTapped: (() -> Void)? = nil,
+    uiPreviewPresentation: SubscribeSeasonUIPreviewPresentation?
+  ) {
+    self.viewModel = viewModel
+    self.layout = layout
+    self.title = title
+    self.showBadges = showBadges
+    self.onSeasonTap = onSeasonTap
+    self.onMoreTapped = onMoreTapped
+    self.uiPreviewPresentation = uiPreviewPresentation
+    _selectedSeasonDetail = State(initialValue: nil)
+  }
+  #endif
 
   static func performSeasonPrimaryAction(
     season: TmdbSeason,
@@ -251,6 +318,25 @@ struct SubscribeSeasonContentView: View {
         await viewModel.checkSubscriptionStatus(forceRefresh: true)
       }
     }
+    #if DEBUG
+    .onAppear {
+      guard !hasPresentedUIPreview, let uiPreviewPresentation else { return }
+      hasPresentedUIPreview = true
+      Task { @MainActor in
+        await Task.yield()
+        switch uiPreviewPresentation {
+        case .seasonDetail:
+          selectedSeasonDetail = viewModel.seasonInfos.first
+        case .subscribeSheet:
+          viewModel.prepareSubscription(seasonNumber: viewModel.seasonInfos.first?.season_number ?? 1)
+        case .unsubscribeConfirmation:
+          viewModel.showUnsubscribeConfirm = viewModel.subscribedSeasons.first
+            ?? viewModel.seasonInfos.first?.season_number
+            ?? 1
+        }
+      }
+    }
+    #endif
   }
 
   @ViewBuilder
@@ -312,6 +398,7 @@ struct SubscribeSeasonContentView: View {
   private func seasonCard(_ season: TmdbSeason) -> some View {
     let seasonNumber = season.season_number ?? 0
     let isSubscribed = viewModel.isSeasonSubscribed(seasonNumber)
+    let canSubscribeSeason = apiService.canAccess(.subscribe)
 
     let seasonName =
       (seasonNumber == 0 && !(season.name?.isEmpty ?? true))
@@ -322,7 +409,9 @@ struct SubscribeSeasonContentView: View {
     let episodeCount = season.episode_count ?? 0
     let bottomLeft = statusText.map { "\(episodeCount) 集 · \($0)" }
     let footerText =
-      isSubscribed ? (viewModel.subscriptionStatusText(for: seasonNumber) ?? "已订阅") : "订阅"
+      isSubscribed
+      ? (viewModel.subscriptionStatusText(for: seasonNumber) ?? "已订阅")
+      : (canSubscribeSeason ? "订阅" : "无订阅权限")
 
     MediaCard(
       title: title,
@@ -338,10 +427,11 @@ struct SubscribeSeasonContentView: View {
       source: nil,
       showBadges: showBadges,
       footerLabel: (
-        icon: isSubscribed ? "minus.circle" : "plus.circle",
+        icon: isSubscribed ? "minus.circle" : (canSubscribeSeason ? "plus.circle" : "lock"),
         text: footerText
       ),
       action: {
+        guard apiService.canAccess(.subscribe) else { return }
         Task { @MainActor in
           await Self.performSeasonPrimaryAction(
             season: season,
@@ -359,41 +449,43 @@ struct SubscribeSeasonContentView: View {
     )
     .compositingGroup()
     .contextMenu {
-      if isSubscribed {
-        Button(role: .destructive) {
-          Task { @MainActor in
-            await Self.performSeasonPrimaryAction(
-              season: season,
-              isSubscribed: true,
-              refreshSubscribedState: { seasonNumber in
-                let didRefresh = await viewModel.checkSubscriptionStatus(forceRefresh: true)
-                guard didRefresh else { return nil }
-                return viewModel.isSeasonSubscribed(seasonNumber)
-              },
-              showUnsubscribeConfirm: { viewModel.showUnsubscribeConfirm = $0 },
-              prepareSubscription: { viewModel.prepareSubscription(seasonNumber: $0) }
-            )
+      if apiService.canAccess(.subscribe) {
+        if isSubscribed {
+          Button(role: .destructive) {
+            Task { @MainActor in
+              await Self.performSeasonPrimaryAction(
+                season: season,
+                isSubscribed: true,
+                refreshSubscribedState: { seasonNumber in
+                  let didRefresh = await viewModel.checkSubscriptionStatus(forceRefresh: true)
+                  guard didRefresh else { return nil }
+                  return viewModel.isSeasonSubscribed(seasonNumber)
+                },
+                showUnsubscribeConfirm: { viewModel.showUnsubscribeConfirm = $0 },
+                prepareSubscription: { viewModel.prepareSubscription(seasonNumber: $0) }
+              )
+            }
+          } label: {
+            Label("取消订阅", systemImage: "minus.circle")
           }
-        } label: {
-          Label("取消订阅", systemImage: "minus.circle")
-        }
-      } else {
-        Button {
-          Task { @MainActor in
-            await Self.performSeasonPrimaryAction(
-              season: season,
-              isSubscribed: false,
-              refreshSubscribedState: { seasonNumber in
-                let didRefresh = await viewModel.checkSubscriptionStatus(forceRefresh: true)
-                guard didRefresh else { return nil }
-                return viewModel.isSeasonSubscribed(seasonNumber)
-              },
-              showUnsubscribeConfirm: { viewModel.showUnsubscribeConfirm = $0 },
-              prepareSubscription: { viewModel.prepareSubscription(seasonNumber: $0) }
-            )
+        } else {
+          Button {
+            Task { @MainActor in
+              await Self.performSeasonPrimaryAction(
+                season: season,
+                isSubscribed: false,
+                refreshSubscribedState: { seasonNumber in
+                  let didRefresh = await viewModel.checkSubscriptionStatus(forceRefresh: true)
+                  guard didRefresh else { return nil }
+                  return viewModel.isSeasonSubscribed(seasonNumber)
+                },
+                showUnsubscribeConfirm: { viewModel.showUnsubscribeConfirm = $0 },
+                prepareSubscription: { viewModel.prepareSubscription(seasonNumber: $0) }
+              )
+            }
+          } label: {
+            Label("订阅", systemImage: "plus.circle")
           }
-        } label: {
-          Label("订阅", systemImage: "plus.circle")
         }
       }
 

--- a/MoviePilot-TV/Views/Pages/SystemView.swift
+++ b/MoviePilot-TV/Views/Pages/SystemView.swift
@@ -3,6 +3,10 @@ import UIKit
 
 #if DEBUG
 enum SystemViewUIPreviewPresentation {
+  case connection
+  case siteSelection
+  case hardFilter
+  case softFilter
   case appInfo
   case logoutConfirmation
 }
@@ -26,6 +30,7 @@ struct SystemView: View {
 
   #if DEBUG
   private let loadsDataOnAppear: Bool
+  private let uiPreviewPresentation: SystemViewUIPreviewPresentation?
   #endif
 
   @StateObject private var viewModel: SystemViewModel
@@ -42,6 +47,7 @@ struct SystemView: View {
     self.isSelected = isSelected
     #if DEBUG
     loadsDataOnAppear = true
+    uiPreviewPresentation = nil
     #endif
     _viewModel = StateObject(wrappedValue: SystemViewModel())
   }
@@ -50,19 +56,22 @@ struct SystemView: View {
   init(isSelected: Bool, viewModel: SystemViewModel, loadsDataOnAppear: Bool) {
     self.isSelected = isSelected
     self.loadsDataOnAppear = loadsDataOnAppear
+    self.uiPreviewPresentation = nil
     _viewModel = StateObject(wrappedValue: viewModel)
   }
 
   init(uiPreviewPresentation: SystemViewUIPreviewPresentation, viewModel: SystemViewModel? = nil) {
     self.isSelected = true
     self.loadsDataOnAppear = false
+    self.uiPreviewPresentation = uiPreviewPresentation
     _viewModel = StateObject(wrappedValue: viewModel ?? SystemViewModel())
-    _showAppInfo = State(initialValue: uiPreviewPresentation == .appInfo)
-    _showLogoutConfirmation = State(initialValue: uiPreviewPresentation == .logoutConfirmation)
-    if uiPreviewPresentation == .logoutConfirmation {
-      _route = State(initialValue: [.connection])
-      _displayedRoute = State(initialValue: [.connection])
-      _pageOffsetDepth = State(initialValue: 1)
+    _showAppInfo = State(initialValue: false)
+    _showLogoutConfirmation = State(initialValue: false)
+    let route = uiPreviewPresentation.initialRoute
+    if !route.isEmpty {
+      _route = State(initialValue: route)
+      _displayedRoute = State(initialValue: route)
+      _pageOffsetDepth = State(initialValue: route.count)
     }
   }
   #endif
@@ -149,6 +158,22 @@ struct SystemView: View {
     .sheet(isPresented: $showAppInfo) {
       appInfoSheet
     }
+    #if DEBUG
+    .onAppear {
+      guard let uiPreviewPresentation else { return }
+      Task { @MainActor in
+        await Task.yield()
+        switch uiPreviewPresentation {
+        case .appInfo:
+          showAppInfo = true
+        case .logoutConfirmation:
+          showLogoutConfirmation = true
+        case .connection, .siteSelection, .hardFilter, .softFilter:
+          break
+        }
+      }
+    }
+    #endif
   }
 
   private func preview(for page: SystemSettingsPage, focusedItem: SystemSettingsFocus?) -> some View {
@@ -424,13 +449,21 @@ struct SystemView: View {
       }
       .focused($focusedItem, equals: filterNoneFocusTarget)
 
-      ForEach(viewModel.customFilterRules, id: \.id) { rule in
-        Button {
-          onSelect(rule.id)
-        } label: {
-          row(rule.name, value: selectedRuleId == rule.id ? "已选择" : nil)
+      if viewModel.isLoadingRules {
+        row("规则状态", value: "正在加载")
+          .foregroundStyle(.secondary)
+      } else if viewModel.customFilterRules.isEmpty {
+        row("规则状态", value: "暂无自定义过滤规则")
+          .foregroundStyle(.secondary)
+      } else {
+        ForEach(viewModel.customFilterRules, id: \.id) { rule in
+          Button {
+            onSelect(rule.id)
+          } label: {
+            row(rule.name, value: selectedRuleId == rule.id ? "已选择" : nil)
+          }
+          .focused($focusedItem, equals: filterRuleFocusTarget(rule.id))
         }
-        .focused($focusedItem, equals: filterRuleFocusTarget(rule.id))
       }
     }
   }
@@ -722,6 +755,25 @@ private enum SystemSettingsPage: Hashable {
   case hardFilter
   case softFilter
 }
+
+#if DEBUG
+private extension SystemViewUIPreviewPresentation {
+  var initialRoute: [SystemSettingsPage] {
+    switch self {
+    case .connection, .logoutConfirmation:
+      return [.connection]
+    case .siteSelection:
+      return [.siteSelection]
+    case .hardFilter:
+      return [.hardFilter]
+    case .softFilter:
+      return [.softFilter]
+    case .appInfo:
+      return []
+    }
+  }
+}
+#endif
 
 private enum SystemSettingsFocus: Hashable {
   case connection

--- a/MoviePilot-TV/Views/Pages/SystemView.swift
+++ b/MoviePilot-TV/Views/Pages/SystemView.swift
@@ -1,6 +1,13 @@
 import SwiftUI
 import UIKit
 
+#if DEBUG
+enum SystemViewUIPreviewPresentation {
+  case appInfo
+  case logoutConfirmation
+}
+#endif
+
 struct SystemView: View {
   private static let pageAnimationDuration: TimeInterval = 0.42
   private static let topAnchorID = "SystemSettingsTopAnchor"
@@ -17,7 +24,11 @@ struct SystemView: View {
 
   private let isSelected: Bool
 
-  @StateObject private var viewModel = SystemViewModel()
+  #if DEBUG
+  private let loadsDataOnAppear: Bool
+  #endif
+
+  @StateObject private var viewModel: SystemViewModel
   @ObservedObject private var apiService = APIService.shared
   @State private var showAppInfo = false
   @State private var showLogoutConfirmation = false
@@ -29,7 +40,27 @@ struct SystemView: View {
 
   init(isSelected: Bool = true) {
     self.isSelected = isSelected
+    #if DEBUG
+    loadsDataOnAppear = true
+    #endif
+    _viewModel = StateObject(wrappedValue: SystemViewModel())
   }
+
+  #if DEBUG
+  init(isSelected: Bool, viewModel: SystemViewModel, loadsDataOnAppear: Bool) {
+    self.isSelected = isSelected
+    self.loadsDataOnAppear = loadsDataOnAppear
+    _viewModel = StateObject(wrappedValue: viewModel)
+  }
+
+  init(uiPreviewPresentation: SystemViewUIPreviewPresentation, viewModel: SystemViewModel? = nil) {
+    self.isSelected = true
+    self.loadsDataOnAppear = false
+    _viewModel = StateObject(wrappedValue: viewModel ?? SystemViewModel())
+    _showAppInfo = State(initialValue: uiPreviewPresentation == .appInfo)
+    _showLogoutConfirmation = State(initialValue: uiPreviewPresentation == .logoutConfirmation)
+  }
+  #endif
 
   private var canConfigureSubscriptions: Bool {
     apiService.canAccess(.subscribe)
@@ -90,14 +121,23 @@ struct SystemView: View {
     .onAppear {
       displayedRoute = route
       pageOffsetDepth = route.count
+      #if DEBUG
+      guard loadsDataOnAppear else { return }
+      #endif
       viewModel.checkKeychainStatus()
       refreshFilterRulesForEntryIfNeeded()
     }
     .onChange(of: isSelected) { _, selected in
       guard selected else { return }
+      #if DEBUG
+      guard loadsDataOnAppear else { return }
+      #endif
       refreshFilterRulesForEntryIfNeeded()
     }
     .task {
+      #if DEBUG
+      guard loadsDataOnAppear else { return }
+      #endif
       await viewModel.loadSystemInfo()
       await viewModel.loadSites()
     }

--- a/MoviePilot-TV/Views/Pages/SystemView.swift
+++ b/MoviePilot-TV/Views/Pages/SystemView.swift
@@ -59,6 +59,11 @@ struct SystemView: View {
     _viewModel = StateObject(wrappedValue: viewModel ?? SystemViewModel())
     _showAppInfo = State(initialValue: uiPreviewPresentation == .appInfo)
     _showLogoutConfirmation = State(initialValue: uiPreviewPresentation == .logoutConfirmation)
+    if uiPreviewPresentation == .logoutConfirmation {
+      _route = State(initialValue: [.connection])
+      _displayedRoute = State(initialValue: [.connection])
+      _pageOffsetDepth = State(initialValue: 1)
+    }
   }
   #endif
 

--- a/MoviePilot-TV/Views/Pages/TransferHistoryView.swift
+++ b/MoviePilot-TV/Views/Pages/TransferHistoryView.swift
@@ -1,7 +1,17 @@
 import SwiftUI
 
+#if DEBUG
+enum TransferHistoryUIPreviewPresentation {
+  case detail
+}
+#endif
+
 struct TransferHistoryView: View {
   @ObservedObject var viewModel: TransferHistoryViewModel
+
+  #if DEBUG
+  private let refreshesOnAppear: Bool
+  #endif
   @State private var itemToDelete: TransferHistory? = nil
   @State private var itemToReorganize: TransferHistory? = nil
   @State private var historyIdToRestoreFocus: Int? = nil
@@ -14,7 +24,26 @@ struct TransferHistoryView: View {
 
   init(viewModel: TransferHistoryViewModel) {
     self.viewModel = viewModel
+    #if DEBUG
+    refreshesOnAppear = true
+    #endif
   }
+
+  #if DEBUG
+  init(viewModel: TransferHistoryViewModel, refreshesOnAppear: Bool) {
+    self.viewModel = viewModel
+    self.refreshesOnAppear = refreshesOnAppear
+  }
+
+  init(viewModel: TransferHistoryViewModel, uiPreviewPresentation: TransferHistoryUIPreviewPresentation) {
+    self.viewModel = viewModel
+    self.refreshesOnAppear = false
+    switch uiPreviewPresentation {
+    case .detail:
+      _itemForInfoSheet = State(initialValue: viewModel.items.first)
+    }
+  }
+  #endif
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
@@ -105,6 +134,9 @@ struct TransferHistoryView: View {
       }
     }
     .task {
+      #if DEBUG
+      guard refreshesOnAppear else { return }
+      #endif
       // 仅在数据为空时执行首次加载, 避免视图切换时重载
       if viewModel.items.isEmpty {
         await viewModel.refresh()

--- a/MoviePilot-TV/Views/Pages/TransferHistoryView.swift
+++ b/MoviePilot-TV/Views/Pages/TransferHistoryView.swift
@@ -3,6 +3,9 @@ import SwiftUI
 #if DEBUG
 enum TransferHistoryUIPreviewPresentation {
   case detail
+  case singleDelete
+  case batchDelete
+  case batchReorganize
 }
 #endif
 
@@ -11,6 +14,7 @@ struct TransferHistoryView: View {
 
   #if DEBUG
   private let refreshesOnAppear: Bool
+  private let uiPreviewPresentation: TransferHistoryUIPreviewPresentation?
   #endif
   @State private var itemToDelete: TransferHistory? = nil
   @State private var itemToReorganize: TransferHistory? = nil
@@ -26,6 +30,7 @@ struct TransferHistoryView: View {
     self.viewModel = viewModel
     #if DEBUG
     refreshesOnAppear = true
+    uiPreviewPresentation = nil
     #endif
   }
 
@@ -33,15 +38,13 @@ struct TransferHistoryView: View {
   init(viewModel: TransferHistoryViewModel, refreshesOnAppear: Bool) {
     self.viewModel = viewModel
     self.refreshesOnAppear = refreshesOnAppear
+    self.uiPreviewPresentation = nil
   }
 
   init(viewModel: TransferHistoryViewModel, uiPreviewPresentation: TransferHistoryUIPreviewPresentation) {
     self.viewModel = viewModel
     self.refreshesOnAppear = false
-    switch uiPreviewPresentation {
-    case .detail:
-      _itemForInfoSheet = State(initialValue: viewModel.items.first)
-    }
+    self.uiPreviewPresentation = uiPreviewPresentation
   }
   #endif
 
@@ -250,6 +253,24 @@ struct TransferHistoryView: View {
       message: {
         Text("确定要删除选中的 \(viewModel.selectedIds.count) 条记录吗？此操作不可撤销。")
       })
+    #if DEBUG
+    .onAppear {
+      guard let uiPreviewPresentation else { return }
+      Task { @MainActor in
+        await Task.yield()
+        switch uiPreviewPresentation {
+        case .detail:
+          itemForInfoSheet = viewModel.items.first
+        case .singleDelete:
+          itemToDelete = viewModel.items.first
+        case .batchDelete:
+          showBatchDeleteAlert = true
+        case .batchReorganize:
+          showBatchRedoSheet = true
+        }
+      }
+    }
+    #endif
   }
 
   private func restoreHistoryFocus() {

--- a/MoviePilot-TV/Views/Sheets/AddDownloadSheet.swift
+++ b/MoviePilot-TV/Views/Sheets/AddDownloadSheet.swift
@@ -1,5 +1,12 @@
 import SwiftUI
 
+#if DEBUG
+enum AddDownloadSheetUIPreviewPresentation {
+  case advanced
+  case errorNotification
+}
+#endif
+
 struct AddDownloadSheet: View {
   @Environment(\.dismiss) var dismiss
   @EnvironmentObject var notificationManager: NotificationManager
@@ -8,6 +15,7 @@ struct AddDownloadSheet: View {
 
   #if DEBUG
   private let loadsDataOnAppear: Bool
+  private let previewErrorMessage: String?
   #endif
   @State private var showAdvanced = false
   @FocusState private var isInfoSectionFocused: Bool
@@ -19,13 +27,20 @@ struct AddDownloadSheet: View {
     )
     #if DEBUG
     self.loadsDataOnAppear = true
+    self.previewErrorMessage = nil
     #endif
   }
 
   #if DEBUG
-  init(previewViewModel: AddDownloadViewModel) {
+  init(
+    previewViewModel: AddDownloadViewModel,
+    presentation: AddDownloadSheetUIPreviewPresentation? = nil
+  ) {
     _viewModel = StateObject(wrappedValue: previewViewModel)
     self.loadsDataOnAppear = false
+    _showAdvanced = State(initialValue: presentation == .advanced)
+    self.previewErrorMessage =
+      presentation == .errorNotification ? "预览：添加下载失败，站点返回错误" : nil
   }
   #endif
 
@@ -163,17 +178,28 @@ struct AddDownloadSheet: View {
     }
     .task {
       #if DEBUG
+      if let previewErrorMessage {
+        await Task.yield()
+        presentError(previewErrorMessage)
+        return
+      }
       guard loadsDataOnAppear else { return }
       #endif
       await viewModel.loadData()
     }
     .onChange(of: viewModel.errorMessage) { _, newValue in
       if let message = newValue {
-        notificationManager.show(message: message, type: .error)
-        viewModel.errorMessage = nil
-        dismiss()
+        presentError(message)
       }
     }
     .frame(width: 1200)
+  }
+
+  private func presentError(_ message: String) {
+    viewModel.errorMessage = nil
+    dismiss()
+    DispatchQueue.main.async {
+      notificationManager.show(message: message, type: .error)
+    }
   }
 }

--- a/MoviePilot-TV/Views/Sheets/AddDownloadSheet.swift
+++ b/MoviePilot-TV/Views/Sheets/AddDownloadSheet.swift
@@ -5,6 +5,10 @@ struct AddDownloadSheet: View {
   @EnvironmentObject var notificationManager: NotificationManager
   @ObservedObject private var apiService = APIService.shared
   @StateObject private var viewModel: AddDownloadViewModel
+
+  #if DEBUG
+  private let loadsDataOnAppear: Bool
+  #endif
   @State private var showAdvanced = false
   @FocusState private var isInfoSectionFocused: Bool
   @FocusState private var isAdvancedButtonFocused: Bool
@@ -13,7 +17,17 @@ struct AddDownloadSheet: View {
     _viewModel = StateObject(
       wrappedValue: AddDownloadViewModel(torrent: torrent, media: media, onSuccess: onSuccess)
     )
+    #if DEBUG
+    self.loadsDataOnAppear = true
+    #endif
   }
+
+  #if DEBUG
+  init(previewViewModel: AddDownloadViewModel) {
+    _viewModel = StateObject(wrappedValue: previewViewModel)
+    self.loadsDataOnAppear = false
+  }
+  #endif
 
   var body: some View {
     Group {
@@ -148,6 +162,9 @@ struct AddDownloadSheet: View {
       }
     }
     .task {
+      #if DEBUG
+      guard loadsDataOnAppear else { return }
+      #endif
       await viewModel.loadData()
     }
     .onChange(of: viewModel.errorMessage) { _, newValue in

--- a/MoviePilot-TV/Views/Sheets/ReorganizeSheet.swift
+++ b/MoviePilot-TV/Views/Sheets/ReorganizeSheet.swift
@@ -1,20 +1,27 @@
 import SwiftUI
 
+#if DEBUG
+enum ReorganizeSheetUIPreviewPresentation {
+  case advanced
+  case doubanRecognition
+  case errorNotification
+}
+#endif
+
 struct ReorganizeSheet: View {
   @Environment(\.dismiss) var dismiss
   @EnvironmentObject var notificationManager: NotificationManager
   let onDone: () -> Void
 
   @StateObject private var viewModel: ReorganizeViewModel
+  private let recognizeSource: String
 
   #if DEBUG
   private let loadsConfigOnAppear: Bool
+  private let previewErrorMessage: String?
   #endif
   @State private var showAdvanced = false
   @FocusState private var isAdvancedButtonFocused: Bool
-
-  // 从 APIService 获取全局设置
-  private let recognizeSource = APIService.shared.settings?.RECOGNIZE_SOURCE ?? "themoviedb"
 
   init(
     logIds: [Int] = [],
@@ -30,16 +37,28 @@ struct ReorganizeSheet: View {
       )
     )
     self.onDone = onDone
+    self.recognizeSource = APIService.shared.settings?.RECOGNIZE_SOURCE ?? "themoviedb"
     #if DEBUG
     self.loadsConfigOnAppear = true
+    self.previewErrorMessage = nil
     #endif
   }
 
   #if DEBUG
-  init(previewViewModel: ReorganizeViewModel, onDone: @escaping () -> Void) {
+  init(
+    previewViewModel: ReorganizeViewModel,
+    presentation: ReorganizeSheetUIPreviewPresentation? = nil,
+    onDone: @escaping () -> Void
+  ) {
     _viewModel = StateObject(wrappedValue: previewViewModel)
     self.onDone = onDone
+    self.recognizeSource =
+      presentation == .doubanRecognition
+      ? "douban" : (APIService.shared.settings?.RECOGNIZE_SOURCE ?? "themoviedb")
     self.loadsConfigOnAppear = false
+    _showAdvanced = State(initialValue: presentation == .advanced)
+    self.previewErrorMessage =
+      presentation == .errorNotification ? "预览：重新整理失败，请检查规则和目标目录" : nil
   }
   #endif
 
@@ -55,17 +74,26 @@ struct ReorganizeSheet: View {
       }
       .task {
         #if DEBUG
+        if let previewErrorMessage {
+          await Task.yield()
+          presentError(previewErrorMessage)
+          return
+        }
         guard loadsConfigOnAppear else { return }
         #endif
         await viewModel.loadConfig()
       }
       .onChange(of: viewModel.errorMessage) { _, newValue in
         if let message = newValue {
-          notificationManager.show(message: message, type: .error)
-          viewModel.errorMessage = nil
+          presentError(message)
         }
       }
     }
+  }
+
+  private func presentError(_ message: String) {
+    notificationManager.show(message: message, type: .error)
+    viewModel.errorMessage = nil
   }
 
   private var manualFormView: some View {

--- a/MoviePilot-TV/Views/Sheets/ReorganizeSheet.swift
+++ b/MoviePilot-TV/Views/Sheets/ReorganizeSheet.swift
@@ -6,6 +6,10 @@ struct ReorganizeSheet: View {
   let onDone: () -> Void
 
   @StateObject private var viewModel: ReorganizeViewModel
+
+  #if DEBUG
+  private let loadsConfigOnAppear: Bool
+  #endif
   @State private var showAdvanced = false
   @FocusState private var isAdvancedButtonFocused: Bool
 
@@ -26,7 +30,18 @@ struct ReorganizeSheet: View {
       )
     )
     self.onDone = onDone
+    #if DEBUG
+    self.loadsConfigOnAppear = true
+    #endif
   }
+
+  #if DEBUG
+  init(previewViewModel: ReorganizeViewModel, onDone: @escaping () -> Void) {
+    _viewModel = StateObject(wrappedValue: previewViewModel)
+    self.onDone = onDone
+    self.loadsConfigOnAppear = false
+  }
+  #endif
 
   var body: some View {
     NavigationStack {
@@ -39,6 +54,9 @@ struct ReorganizeSheet: View {
         }
       }
       .task {
+        #if DEBUG
+        guard loadsConfigOnAppear else { return }
+        #endif
         await viewModel.loadConfig()
       }
       .onChange(of: viewModel.errorMessage) { _, newValue in

--- a/MoviePilot-TV/Views/Sheets/SubscribeSheet.swift
+++ b/MoviePilot-TV/Views/Sheets/SubscribeSheet.swift
@@ -11,12 +11,27 @@ struct SubscribeSheet: View {
 
   var onSave: (() -> Void)?
 
+  #if DEBUG
+  private let loadsDataOnAppear: Bool
+  #endif
+
   init(subscribe: Subscribe, isNewSubscription: Bool = false, onSave: (() -> Void)? = nil) {
     _viewModel = StateObject(
       wrappedValue: SubscribeSheetViewModel(
         subscribe: subscribe, isNewSubscription: isNewSubscription))
     self.onSave = onSave
+    #if DEBUG
+    self.loadsDataOnAppear = true
+    #endif
   }
+
+  #if DEBUG
+  init(previewViewModel: SubscribeSheetViewModel, onSave: (() -> Void)? = nil) {
+    _viewModel = StateObject(wrappedValue: previewViewModel)
+    self.onSave = onSave
+    self.loadsDataOnAppear = false
+  }
+  #endif
 
   var body: some View {
     NavigationStack {
@@ -285,6 +300,9 @@ struct SubscribeSheet: View {
             }
           }
           .onAppear {
+            #if DEBUG
+            guard loadsDataOnAppear else { return }
+            #endif
             guard !hasAppeared else { return }
             hasAppeared = true
             Task {
@@ -292,6 +310,9 @@ struct SubscribeSheet: View {
             }
           }
           .onDisappear {
+            #if DEBUG
+            guard loadsDataOnAppear else { return }
+            #endif
             if !viewModel.isSaved {
               Task {
                 await viewModel.cancel()

--- a/MoviePilot-TV/Views/Sheets/SubscribeSheet.swift
+++ b/MoviePilot-TV/Views/Sheets/SubscribeSheet.swift
@@ -1,5 +1,13 @@
 import SwiftUI
 
+#if DEBUG
+enum SubscribeSheetUIPreviewPresentation {
+  case advanced
+  case siteSelection
+  case filterGroupSelection
+}
+#endif
+
 struct SubscribeSheet: View {
   @Environment(\.dismiss) var dismiss
   @StateObject private var viewModel: SubscribeSheetViewModel
@@ -13,6 +21,8 @@ struct SubscribeSheet: View {
 
   #if DEBUG
   private let loadsDataOnAppear: Bool
+  private let presentsSiteSelectionOnAppear: Bool
+  private let presentsFilterGroupSelectionOnAppear: Bool
   #endif
 
   init(subscribe: Subscribe, isNewSubscription: Bool = false, onSave: (() -> Void)? = nil) {
@@ -22,14 +32,24 @@ struct SubscribeSheet: View {
     self.onSave = onSave
     #if DEBUG
     self.loadsDataOnAppear = true
+    self.presentsSiteSelectionOnAppear = false
+    self.presentsFilterGroupSelectionOnAppear = false
     #endif
   }
 
   #if DEBUG
-  init(previewViewModel: SubscribeSheetViewModel, onSave: (() -> Void)? = nil) {
+  init(
+    previewViewModel: SubscribeSheetViewModel,
+    presentation: SubscribeSheetUIPreviewPresentation? = nil,
+    onSave: (() -> Void)? = nil
+  ) {
     _viewModel = StateObject(wrappedValue: previewViewModel)
     self.onSave = onSave
     self.loadsDataOnAppear = false
+    self.presentsSiteSelectionOnAppear = presentation == .siteSelection
+    self.presentsFilterGroupSelectionOnAppear = presentation == .filterGroupSelection
+    _showAdvanced = State(initialValue: presentation == .advanced || presentation == .filterGroupSelection)
+    _showingSiteSelection = State(initialValue: false)
   }
   #endif
 
@@ -344,6 +364,22 @@ struct SubscribeSheet: View {
         label: { $0.name }
       )
     }
+    #if DEBUG
+    .onAppear {
+      guard presentsSiteSelectionOnAppear else { return }
+      Task { @MainActor in
+        await Task.yield()
+        showingSiteSelection = true
+      }
+    }
+    .onAppear {
+      guard presentsFilterGroupSelectionOnAppear else { return }
+      Task { @MainActor in
+        await Task.yield()
+        showingFilterGroupSelection = true
+      }
+    }
+    #endif
   }
 
   /// Site selection button label

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@
 
 如需使用自己的 MoviePilot 后端验证 TV 端接口、图片和功能兼容性，请先阅读 [后端兼容性测试文档](docs/backend-compatibility-tests.md)。真实后端测试可能包含副作用套件，运行前请确认测试范围。
 
+## UI 检查模式
+
+Debug 构建可通过启动参数 `-uiPreviewMode` 打开 UI 检查目录，用于检查主要页面、详情页、弹窗和常见状态。
+在 Xcode 的 **Run > Arguments** 添加该参数即可；模拟器也可用 `xcrun simctl launch booted <bundle-id> -uiPreviewMode`，该入口只在 Debug 生效，合并或发布时会检查 Release 产物不包含它。
+
 ## 反馈与贡献
 
 - **提交 Bug**：请务必提供 MoviePilot 版本号、相关截图和复现步骤。


### PR DESCRIPTION
## Summary
- 新增 Debug-only 的 `-uiPreviewMode` 手动 UI 预览目录，正常启动路径保持不变。
- 预览场景尽量走真实 TabView、NavigationStack 和页面容器路径，覆盖详情、推荐、探索、搜索、状态、设置和弹窗状态。
- 预览模式下短路页面内部可能触发后端写操作的动作，避免手动巡检误改真实数据。

## Test Plan
- `git diff --check`
- `xcodebuild clean build -project "MoviePilot-TV.xcodeproj" -scheme "MoviePilot-TV" -configuration Debug -destination "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.5" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipPackagePluginValidation`
- `xcodebuild clean build -project "MoviePilot-TV.xcodeproj" -scheme "MoviePilot-TV" -configuration Release -destination "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.5" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipPackagePluginValidation`
- Release app 产物扫描无 `PreviewCatalogView` / `UIPreviewMode` / `-uiPreviewMode` / `UI 预览` / `返回目录`
- Debug app 安装到 tvOS Simulator 并用 `-uiPreviewMode` 启动，截图确认进入预览目录
- `xcodebuild test -project "MoviePilot-TV.xcodeproj" -scheme "MoviePilot-TV" -configuration Debug -destination "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.5" -only-testing:MoviePilot-TV-Tests/UIPreviewModeTests -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipPackagePluginValidation`：16 tests, 0 failures

兼容测试按要求跳过。