### PR TITLE
[AI] chore/compatibility: 更新 MoviePilot v2.14.4 兼容基线

### DIFF
--- a/MoviePilot-TV-Tests/BackendCompatibilityTests.swift
+++ b/MoviePilot-TV-Tests/BackendCompatibilityTests.swift
@@ -1494,6 +1494,13 @@ final class BackendCompatibilityReadOnlyTests: XCTestCase {
       let subscriptions = try await service.fetchSubscriptions()
       collector.addSubscriptions(subscriptions, surface: "subscriptions list")
 
+      if let account = config.activeAccount, account.token.super_user?.value != true {
+        XCTAssertTrue(
+          subscriptions.allSatisfy { $0.username == account.account.username },
+          "Ordinary account subscription list must be owner-scoped for \(config.activeAccountDiagnostic)."
+        )
+      }
+
       for subscription in subscriptions {
         guard let id = subscription.id else { continue }
         do {

--- a/MoviePilot-TV-Tests/ContentViewModelBehaviorTests.swift
+++ b/MoviePilot-TV-Tests/ContentViewModelBehaviorTests.swift
@@ -71,7 +71,7 @@ final class ContentViewModelBehaviorTests: XCTestCase {
 
     await viewModel?.prepareStartupIfNeeded()
 
-    XCTAssertEqual(service.settings?.BACKEND_VERSION, "v2.13.14")
+    XCTAssertEqual(service.settings?.BACKEND_VERSION, "v2.14.4")
     XCTAssertNil(viewModel?.backendVersionWarning)
 
     service.baseURL = "https://old.content-view-model-tests.local"
@@ -79,11 +79,11 @@ final class ContentViewModelBehaviorTests: XCTestCase {
     service.currentUser = token("token-b", userName: "second-user")
 
     try await waitUntil("expected backend warning to reload from old backend") {
-      service.settings?.BACKEND_VERSION == "v2.13.13"
-        && viewModel?.backendVersionWarning?.backendVersion == "v2.13.13"
+      service.settings?.BACKEND_VERSION == "v2.14.3"
+        && viewModel?.backendVersionWarning?.backendVersion == "v2.14.3"
     }
 
-    XCTAssertEqual(viewModel?.backendVersionWarning?.backendVersion, "v2.13.13")
+    XCTAssertEqual(viewModel?.backendVersionWarning?.backendVersion, "v2.14.3")
     XCTAssertEqual(
       viewModel?.backendVersionWarning?.requiredVersion,
       AppVersionInfo.compatibleMoviePilotVersion
@@ -220,9 +220,9 @@ private actor ContentViewModelURLProtocolStub {
     let backendVersion: String
     switch url.host {
     case "old.content-view-model-tests.local":
-      backendVersion = "v2.13.13"
+      backendVersion = "v2.14.3"
     default:
-      backendVersion = "v2.13.14"
+      backendVersion = "v2.14.4"
     }
 
     let data: Data

--- a/MoviePilot-TV-Tests/SystemVersionInfoTests.swift
+++ b/MoviePilot-TV-Tests/SystemVersionInfoTests.swift
@@ -10,7 +10,7 @@ final class SystemVersionInfoTests: XCTestCase {
     XCTAssertEqual(AppVersionInfo.displayAppVersion(shortVersion: ""), "未知")
     XCTAssertEqual(AppVersionInfo.displayAppVersion(shortVersion: "   "), "未知")
     XCTAssertEqual(AppVersionInfo.displayAppVersion(shortVersion: nil), "未知")
-    XCTAssertEqual(AppVersionInfo.compatibleMoviePilotVersion, "v2.13.14")
+    XCTAssertEqual(AppVersionInfo.compatibleMoviePilotVersion, "v2.14.4")
   }
 
   func testMoviePilotVersionComparisonIgnoresPrefixAndReleaseSuffix() {

--- a/MoviePilot-TV/Models/AppVersionInfo.swift
+++ b/MoviePilot-TV/Models/AppVersionInfo.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum AppVersionInfo {
-  nonisolated static let compatibleMoviePilotVersion = "v2.13.14"
+  nonisolated static let compatibleMoviePilotVersion = "v2.14.4"
 
   nonisolated static func currentAppVersion(bundle: Bundle = .main) -> String {
     let shortVersion = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String

--- a/MoviePilot-TV/ViewModels/SubscribeSeasonViewModel.swift
+++ b/MoviePilot-TV/ViewModels/SubscribeSeasonViewModel.swift
@@ -314,12 +314,15 @@ class SubscribeSeasonViewModel: ObservableObject {
 
     do {
       try await refreshSubscriptionSummaries(forceRefresh: true)
-      guard let summary = seasonSubscriptions[seasonNumber] else {
+      guard seasonSubscriptions[seasonNumber] != nil else {
         showUnsubscribeConfirm = nil
         return
       }
 
-      let success = try await APIService.shared.deleteSubscription(id: summary.id)
+      let success = try await APIService.shared.deleteSubscription(
+        media: mediaInfo,
+        season: seasonNumber
+      )
       if success {
         try await refreshSubscriptionSummaries(forceRefresh: true)
         showUnsubscribeConfirm = nil

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/CHANTXU64/MoviePilot-TV/releases"><img src="https://img.shields.io/badge/Release-v0.3.3-blue?style=flat-square" alt="release"></a>
-  <a href="https://github.com/jxxghp/MoviePilot"><img src="https://img.shields.io/badge/MoviePilot-v2.14.0-darkviolet?style=flat-square" alt="MoviePilot Backend Version"></a>
+  <a href="https://github.com/jxxghp/MoviePilot"><img src="https://img.shields.io/badge/MoviePilot-v2.14.4-darkviolet?style=flat-square" alt="MoviePilot Backend Version"></a>
   <img src="https://img.shields.io/badge/platform-tvOS_18%2B-lightgrey.svg" alt="Platform">
   <img src="https://img.shields.io/badge/language-Swift-orange.svg?style=flat-square" alt="Language">
   <img src="https://img.shields.io/badge/UI-SwiftUI-blue.svg?style=flat-square" alt="UI Framework">
@@ -43,7 +43,7 @@
 ## ⚠️ 兼容性与已知问题
 
 - **tvOS 版本**: 支持 **tvOS 18.0+**。本项目主要在 **tvOS 26.0+** 环境下开发，建议使用最新的 tvOS 系统获得最佳体验。
-- **MoviePilot 版本**: 当前测试兼容的后端版本为 `v2.14.0`。低于该版本的后端可能出现严重功能异常、数据丢失或闪退；App 启动时会提示风险，但用户仍可选择继续使用。
+- **MoviePilot 版本**: 当前测试兼容的后端版本为 `v2.14.4`。低于该版本的后端可能出现严重功能异常、数据丢失或闪退；App 启动时会提示风险，但用户仍可选择继续使用。
 - **兼容原则**: TV 端以 MoviePilot Web 前端和 MoviePilot 后端当前行为为准；如果 Web 本来也不显示，或后端/第三方数据源同样异常，本项目通常不会在 TV 端额外兜底修复。
 - **更新节奏**: 本应用更新频率可能低于 MoviePilot 原版，不保证长期兼容旧版 API 或旧版后端已知问题。
 - **账号登录**: **不支持**已开启双因素认证 (MFA/2FA) 的账号，请在关闭双因素认证后再登录。

--- a/docs/backend-compatibility-tests.md
+++ b/docs/backend-compatibility-tests.md
@@ -40,6 +40,8 @@ GitHub CI 没有真实后端账号，`ci.yml` 会显式跳过 `BackendCompatibil
 
 `.env.compatibility` 只用于真实 MoviePilot 后端的只读兼容性检查。已配置时，测试会登录后端并按 TV 端真实页面入口巡检：系统配置、仪表盘、站点/下载器/目录配置、订阅读取、媒体服务器最近添加、下载中任务、推荐货架、发现页、搜索、详情页、演员/人物和分季数据。未配置时，这组测试会自动跳过。
 
+使用普通账号巡检订阅时，测试还会断言 `/subscribe/` 返回记录的 `username` 都属于当前账号，以覆盖 MoviePilot v2.14.2 起的订阅所有权隔离；超级用户仍按后端契约读取全局订阅。
+
 只读套件会把权限敏感接口拆成独立用例，避免一个管理员账号全通过后掩盖普通账号失败：
 
 - `testReadOnlySystemEnvCompatibility` 单独验证 `/system/env`；MoviePilot v2.13.14 起该接口只由超管账号巡检。

--- a/docs/frontend-update-todo.md
+++ b/docs/frontend-update-todo.md
@@ -16,16 +16,35 @@
 
 ### 字幕搜索与下载
 
-- 来源：MoviePilot Web / Backend `v2.13.6 -> v2.13.14` 新增字幕搜索、字幕结果展示和字幕下载相关能力。
+- 来源：MoviePilot Web / Backend `v2.13.6 -> v2.13.14` 新增字幕搜索、字幕结果展示和字幕下载相关能力；Backend `v2.14.0 -> v2.14.4` 要求字幕下载使用搜索结果返回的签名链接。
 - 当前判断：不是现有 TV 核心兼容必修项；TV 当前没有字幕搜索/下载入口。
 - 可评估方向：
   - 是否在媒体详情页提供字幕搜索入口。
   - 是否在资源搜索结果页增加“字幕”模式或筛选。
   - 是否需要支持字幕下载保存路径选择。
+  - 下载时必须原样保留搜索结果 `enclosure` 中的签名 fragment；后端重启或密钥轮换导致签名失效时，应重新搜索获取链接，不要由客户端自行拼接站点凭据或签名。
   - 字幕下载属于副作用操作，若实现必须加入显式副作用兼容测试开关。
 - 相关上游接口/路径：
   - Backend：`/search/subtitle/title`、`/search/subtitle/title/stream`、`/search/subtitle/media/{mediaid}`、`/download/subtitle`
   - Frontend：`SubtitleCard.vue`、`SubtitleItem.vue`、`AddSubtitleDownloadDialog.vue`
+
+### 后端扩展推荐源
+
+- 来源：MoviePilot Web 推荐页会读取 `/recommend/source`，把后端或插件提供的扩展推荐源与内置来源合并；`v2.14.4` 继续保留并整理了这套加载逻辑。
+- 当前判断：TV 推荐页已有内置分类、货架和分页浏览，但 `RecommendViewModel` 仍使用固定来源列表，不会显示后端扩展推荐源。
+- 可评估方向：
+  - 是否在现有推荐页加载扩展推荐源，并复用当前 `fetchRecommend(path:page:)` 和媒体网格。
+  - 按 `api_path` 去重，接口失败时继续显示内置推荐源。
+  - 评估后端 `type` 到 TV 推荐分类的映射，避免为扩展源新增独立页面或复杂配置界面。
+
+### 后端连接状态与自动重连
+
+- 来源：MoviePilot Web `v2.14.0 -> v2.14.4` 增加 `system/ping` 服务探测、在线/检查中/离线状态、退避重试和手动重试提示。
+- 当前判断：TV 已有服务器信息、登录凭据刷新和请求失败提示，但没有全局后端连接状态或统一重连入口。
+- 可评估方向：
+  - 是否在现有通知层增加非阻塞连接提示，而不是新增独立离线页面。
+  - 区分设备断网、请求超时、后端不可达和登录失效，避免把鉴权失败当成离线。
+  - 使用有限频率的 `system/ping` 与退避重试，并在应用进入后台或退出登录后停止探测。
 
 ### Agent Assistant / Web Agent
 

--- a/docs/subscription-compatibility-checklist.md
+++ b/docs/subscription-compatibility-checklist.md
@@ -30,9 +30,10 @@ MoviePilot 后端普通用户权限契约仍不稳定，后续版本可能有较
 - `episode_group` 是订阅配置，不是订阅身份的一部分。
 - 创建订阅时可以带 `episode_group`。
 - 查询某媒体某季是否已订阅时，只按媒体和季判断，不按 `episode_group` 判断。
-- 取消某媒体某季订阅时，后端媒体删除接口也是媒体和季语义，不按 `episode_group` 删除。
+- 取消某媒体某季订阅时，Web 统一按媒体标识调用删除接口并传入 `season`，不按 `episode_group` 删除；v2.14.4 后端只在 TMDB 分支使用该季号过滤。
 - TV 分季页展示的已订阅状态必须来自真实订阅记录上的 `episode_group`，不能来自当前 Picker 选择。
-- TV 分季页取消已订阅季时，应优先按订阅 `id` 删除当前匹配记录。
+- TV 分季页取消已订阅季时，与 Web v2.14.4 保持一致，调用 `DELETE /subscribe/media/{mediaid}` 并传入 `season`。
+- **已知上游风险（跟随 Web）**：超级用户可访问全局订阅，TMDB 删除会命中其可访问范围内同媒体、同季的全部记录；Douban 和其他 `mediaid` 分支还会忽略季号，可能跨季、跨用户删除。另外，若快照只能通过 `mediaid` fallback 匹配，但结构化 ID 为 `0` 或空，后端可能返回成功却未删除记录。TV 端不单独兜底；每次同步 Web 更新时复核该路径，Web 若修复，TV 同步跟进。
 - `/subscribe/` 快照是首页订阅列表、详情页订阅状态和分季订阅状态的共享数据源；普通用户由后端过滤为本人订阅，超级用户获得全局订阅，TV 不再重复按用户名过滤。几十或上百季电视剧不能退回逐季调用 `/subscribe/media/{mediaid}`。
 - `POST /subscribe/` 创建订阅时必须保留 `mediaid` fallback；当 `tmdbid`、`doubanid`、`bangumiid` 不足以标识媒体时，后端仍可用 `mediaid` 识别来源。
 - MoviePilot v2.14.0 起，`best_version` 和 `best_version_full` 的空值语义变为“使用后端默认订阅配置”。TV 端未明确选择普通/洗版/全集洗版时必须省略这两个字段，不能用 `0` 代替；显式发送 `0` 才表示普通订阅或关闭洗版。
@@ -80,7 +81,7 @@ MoviePilot Web v2.14.0 起，详情页订阅入口按媒体类型区分：
 - 电视剧详情页顶部按钮只作为“分季订阅”入口，不直接创建整条目订阅，也不因为存在 `douban_id` 或 `bangumi_id` 改走一键订阅。
 - 电视剧分季入口和预加载不能依赖 `tmdb_id != nil` 才显示或启动；Douban/Bangumi 详情也应能进入分季订阅流程。
 - 剧集组数据仍只能在有 TMDB ID 时加载；缺少 TMDB ID 时不应阻断分季订阅入口本身。
-- 分季页取消订阅仍优先按真实订阅 `id` 删除单条订阅，不把 Header 行为改造成媒体级批量删除。
+- 分季页取消订阅保持 Web 的请求形式：媒体级删除并传入季号，不单独改成按订阅 `id` 删除；后端是否按季过滤取决于媒体标识分支。
 
 如果以后 Web 或后端重新引入电视剧顶部直接订阅/取消，不能只改按钮文案；需要重新确认 TV 端是否应恢复媒体级删除、是否需要多季影响确认，以及分季页和 Header 的状态来源是否仍一致。
 
@@ -226,7 +227,7 @@ MoviePilot Web v2.14.0 起，详情页订阅入口按媒体类型区分：
   - 未明确选择洗版模式时是否省略 `best_version` / `best_version_full`；已完整入库季是否显式设置 `best_version: 1` 和 `best_version_full: 1`。
   - 已订阅状态显示是否来自订阅记录上的 `episode_group`。
   - 取消订阅前是否强制刷新订阅摘要。
-  - 取消订阅是否优先使用订阅 `id`。
+  - 取消订阅的请求形式是否仍与 Web 一致：使用媒体级删除并传入当前季号。
 - `MoviePilot-TV/Views/Pages/SubscribeSeasonView.swift`
   - 已订阅卡片是否显示真实订阅配置，例如 `已订阅 · 默认剧集组` 或 `已订阅 · 剧集组 A`。
   - 取消确认框是否明确剧名、季号和当前订阅使用的剧集组。
@@ -281,7 +282,7 @@ xcodebuild test \
 - 新建订阅未设置洗版模式时，payload 省略 `best_version` / `best_version_full`；显式 `0` 仍应保留。
 - 已完整入库季创建分季订阅时，payload 同时包含 `best_version: 1` 和 `best_version_full: 1`。
 - 部分缺失或未知入库状态的季创建订阅时，payload 省略洗版字段，由后端默认配置决定。
-- 订阅快照里 `tmdbid: 0 + mediaid: "tmdb:<有效 ID>"` 时，分季页仍显示已订阅并能按订阅 `id` 取消。
+- 订阅快照里 `tmdbid: 0 + mediaid: "tmdb:<有效 ID>"` 时，分季页仍显示已订阅；取消时保持 Web 请求形式，已知后端可能返回成功却不删除记录，TV 暂不兜底。
 - 订阅快照里 `bangumiid: 0 + mediaid: "tmdb:<有效 ID>"` 时，分季页仍能通过 fallback 匹配。
 - 订阅快照里空白 `doubanid + mediaid: "tmdb:<有效 ID>"` 时，分季页仍能通过 fallback 匹配。
 - 媒体详情 payload 里 `tmdb_id: 0` / 空白 `douban_id` / `bangumi_id: 0` 时，仍能 fallback 到 `mediaid_prefix + media_id`。

--- a/docs/subscription-compatibility-checklist.md
+++ b/docs/subscription-compatibility-checklist.md
@@ -26,14 +26,14 @@ MoviePilot 后端普通用户权限契约仍不稳定，后续版本可能有较
 
 ## 当前契约
 
-- 同一媒体同一季只有一条订阅。
+- MoviePilot v2.14.2 起，普通用户的订阅按 `username` 隔离；同一用户的同一媒体同一季只有一条订阅。超级用户仍可查看和管理全局订阅，因此快照中可能出现不同用户对同一媒体同一季的多条记录。
 - `episode_group` 是订阅配置，不是订阅身份的一部分。
 - 创建订阅时可以带 `episode_group`。
 - 查询某媒体某季是否已订阅时，只按媒体和季判断，不按 `episode_group` 判断。
 - 取消某媒体某季订阅时，后端媒体删除接口也是媒体和季语义，不按 `episode_group` 删除。
 - TV 分季页展示的已订阅状态必须来自真实订阅记录上的 `episode_group`，不能来自当前 Picker 选择。
-- TV 分季页取消已订阅季时，应优先按订阅 `id` 删除这条唯一订阅。
-- `/subscribe/` 快照是首页订阅列表、详情页订阅状态和分季订阅状态的共享数据源；几十或上百季电视剧不能退回逐季调用 `/subscribe/media/{mediaid}`。
+- TV 分季页取消已订阅季时，应优先按订阅 `id` 删除当前匹配记录。
+- `/subscribe/` 快照是首页订阅列表、详情页订阅状态和分季订阅状态的共享数据源；普通用户由后端过滤为本人订阅，超级用户获得全局订阅，TV 不再重复按用户名过滤。几十或上百季电视剧不能退回逐季调用 `/subscribe/media/{mediaid}`。
 - `POST /subscribe/` 创建订阅时必须保留 `mediaid` fallback；当 `tmdbid`、`doubanid`、`bangumiid` 不足以标识媒体时，后端仍可用 `mediaid` 识别来源。
 - MoviePilot v2.14.0 起，`best_version` 和 `best_version_full` 的空值语义变为“使用后端默认订阅配置”。TV 端未明确选择普通/洗版/全集洗版时必须省略这两个字段，不能用 `0` 代替；显式发送 `0` 才表示普通订阅或关闭洗版。
 - TV 分季页只有在已确认某季完整入库时，才显式发送 `best_version: 1` 和 `best_version_full: 1`，表示全集洗版；未知入库状态或仍有缺失集时应省略洗版字段，让后端应用默认配置。
@@ -113,11 +113,12 @@ MoviePilot Web v2.14.0 起，详情页订阅入口按媒体类型区分：
 - `app/api/endpoints/system.py`
   - `/system/env`、`GET /system/setting/{key}`、`POST /system/setting/{key}` 等端点实际依赖的是 active user 还是 active superuser；以 `Depends(...)` 为准，不能只看 summary 或注释里的“仅管理员”。
 - `app/db/subscribe_oper.py`
-  - `SubscribeOper.async_add` 是否仍用 `tmdbid` / `doubanid` + `season` 查重。
+  - `SubscribeOper.async_add` 是否仍用 `tmdbid` / `doubanid` + `season` 查重，并对普通用户同时限定 `username`。
   - 如果查重条件新增 `episode_group`，说明后端开始支持同一媒体同一季多剧集组订阅，TV 分季状态模型需要重做。
 - `app/db/models/subscribe.py`
   - `Subscribe.episode_group` 字段是否仍存在，类型和含义是否变化。
   - `Subscribe.async_exists` 是否仍不包含 `episode_group`。
+  - 普通用户的存在性查询和媒体查询是否仍限定当前 `username`，超级用户是否仍可查询全局订阅。
   - `Subscribe.async_get_by_tmdbid` 是否仍按 `tmdbid + season` 返回订阅。
   - `Subscribe.async_get_by_tmdbid` 在未传 `season` 时是否仍返回该 TMDB 下全部订阅。
 - `app/schemas/subscribe.py`
@@ -127,7 +128,9 @@ MoviePilot Web v2.14.0 起，详情页订阅入口按媒体类型区分：
   - `best_version` 和 `best_version_full` 是否仍是可空字段；如果后端再次改变空值和 `0` 的语义，TV 新建订阅 payload 必须重新评估。
   - 如果字段改名、嵌套、分页或拆分，需要同步更新 TV 解码和快照缓存。
 - `app/api/endpoints/subscribe.py`
-  - `GET /subscribe/` 是否仍返回当前用户完整订阅列表。
+  - `GET /subscribe/` 是否仍向普通用户返回本人完整订阅列表、向超级用户返回全局订阅列表。
+  - 普通用户的详情、更新、状态、重置、搜索和删除是否仍校验订阅归属；更新 payload 是否仍不能把订阅转移给其他用户。
+  - 无 `username` 的旧订阅是否仍只对超级用户可见。
   - `GET /subscribe/` 返回的订阅快照中，`tmdbid: 0` / `bangumiid: 0` / 空 `doubanid` 是否仍只代表缺失 ID，而不是有效 ID。
   - `POST /subscribe/` 是否仍用 `episode_group` 和 `mediaid` 创建或更新订阅配置。
   - `POST /subscribe/` 是否仍把省略 `best_version` / `best_version_full` 理解为使用后端默认配置，把显式 `0` 理解为普通订阅或关闭洗版。
@@ -284,6 +287,7 @@ xcodebuild test \
 - 媒体详情 payload 里 `tmdb_id: 0` / 空白 `douban_id` / `bangumi_id: 0` 时，仍能 fallback 到 `mediaid_prefix + media_id`。
 - 电视剧详情页和预加载不再因为原始 `tmdb_id == nil` 隐藏或跳过分季订阅入口；剧集组加载仍只在有 TMDB ID 时执行。
 - 订阅编辑保存时保留 `note`、`episode_priority`、`vote`、`filter`、`username`、`current_priority`、`date`，但不回传 `completed_episode`。
+- 普通用户执行真实后端只读巡检时，`/subscribe/` 返回的每条记录都属于当前登录用户名；超级用户仍可读取全局订阅。
 - 首页订阅卡片跳详情时，`Subscribe` 重建出的 `MediaInfo` 仍保留有效 fallback `mediaid`。
 - 取消前如果订阅已被其他设备删除，本机刷新为未订阅，不继续发起错误取消。
 - 首页订阅列表通知刷新、页面回前台刷新、手动搜索订阅后的刷新都能绕过缓存。


### PR DESCRIPTION
## 变更内容

- 将 App、README 和版本相关测试的 MoviePilot 兼容基线更新到 v2.14.4。
- 补充普通账号订阅按 `username` 隔离的真实后端只读断言与兼容契约。
- 在后续功能 TODO 中记录后端扩展推荐源、字幕签名下载链接和后端连接状态。

## 影响

- App 会对低于 v2.14.4 的后端继续显示兼容风险提示。
- 普通账号订阅巡检会验证后端所有权隔离，超级用户仍按契约读取全局订阅。
- 本次没有实现新的 TV 功能，新增项目仅作为后续评估项。

## 验证

- `xcodebuild -resolvePackageDependencies -project MoviePilot-TV.xcodeproj -scheme MoviePilot-TV -skipPackagePluginValidation`
- Apple TV / tvOS 26.5 Simulator 完整 clean build
- 串行执行 307 项测试，0 失败（包含真实后端兼容巡检）
- 独立子代理复审：无发现