### PR TITLE
[AI] 修复订阅刷新、冷启动权限与搜索状态

### DIFF
--- a/MoviePilot-TV-Tests/BackendCompatibilityTests.swift
+++ b/MoviePilot-TV-Tests/BackendCompatibilityTests.swift
@@ -2600,11 +2600,11 @@ final class BackendCompatibilityReadOnlyTests: XCTestCase {
 private enum SubscriptionStateRestoreResult: Equatable, Sendable {
   case restored(Bool)
   case failed(String)
-  case timedOut
+  case deadlineExceeded
 }
 
 private func restoreSubscriptionState(
-  timeoutNanoseconds: UInt64 = 15 * 1_000_000_000,
+  deadlineNanoseconds: UInt64 = 15 * 1_000_000_000,
   operation: @escaping @MainActor @Sendable () async throws -> Bool
 ) async -> SubscriptionStateRestoreResult {
   await Task.detached {
@@ -2618,8 +2618,8 @@ private func restoreSubscriptionState(
       }
 
       group.addTask {
-        try? await Task.sleep(nanoseconds: timeoutNanoseconds)
-        return .timedOut
+        try? await Task.sleep(nanoseconds: deadlineNanoseconds)
+        return .deadlineExceeded
       }
 
       let result = await group.next()
@@ -2647,7 +2647,7 @@ final class BackendCompatibilityCleanupTests: XCTestCase {
   func testSubscriptionStateRestoreDoesNotInheritCallerCancellation() async {
     let cleanupTask = Task {
       try? await Task.sleep(nanoseconds: 1_000_000)
-      return await restoreSubscriptionState(timeoutNanoseconds: 1_000_000_000) {
+      return await restoreSubscriptionState(deadlineNanoseconds: 1_000_000_000) {
         try Task.checkCancellation()
         return true
       }
@@ -2659,11 +2659,11 @@ final class BackendCompatibilityCleanupTests: XCTestCase {
   }
 
   @MainActor
-  func testSubscriptionStateRestoreWaitsForTimedOutOperationToFinish() async {
+  func testSubscriptionStateRestoreWaitsForOperationAfterDeadlineExceeded() async {
     let start = ContinuousClock.now
     var didFinishRestore = false
 
-    let result = await restoreSubscriptionState(timeoutNanoseconds: 20_000_000) {
+    let result = await restoreSubscriptionState(deadlineNanoseconds: 20_000_000) {
       await withCheckedContinuation { continuation in
         _ = Task.detached {
           try? await Task.sleep(nanoseconds: 300_000_000)
@@ -2674,7 +2674,7 @@ final class BackendCompatibilityCleanupTests: XCTestCase {
       return true
     }
 
-    XCTAssertEqual(result, .timedOut)
+    XCTAssertEqual(result, .deadlineExceeded)
     XCTAssertTrue(didFinishRestore)
     XCTAssertGreaterThanOrEqual(start.duration(to: .now), .milliseconds(250))
   }
@@ -3076,9 +3076,9 @@ final class BackendCompatibilitySideEffectTests: XCTestCase {
       XCTFail(
         "Failed to restore subscription \(target.id) to original state \(target.originalState): \(diagnostic)"
       )
-    case .timedOut:
+    case .deadlineExceeded:
       XCTFail(
-        "Timed out restoring subscription \(target.id) to original state \(target.originalState)."
+        "Restoring subscription \(target.id) to original state \(target.originalState) exceeded the 15-second cleanup deadline; cleanup finished before the suite continued."
       )
     }
   }

--- a/MoviePilot-TV-Tests/BackendCompatibilityTests.swift
+++ b/MoviePilot-TV-Tests/BackendCompatibilityTests.swift
@@ -2608,29 +2608,24 @@ private func restoreSubscriptionState(
   operation: @escaping @MainActor @Sendable () async throws -> Bool
 ) async -> SubscriptionStateRestoreResult {
   await Task.detached {
-    let (stream, continuation) = AsyncStream<SubscriptionStateRestoreResult>.makeStream()
-    let restoreTask = Task.detached {
-      do {
-        continuation.yield(.restored(try await operation()))
-      } catch {
-        continuation.yield(.failed(String(describing: error)))
+    await withTaskGroup(of: SubscriptionStateRestoreResult.self) { group in
+      group.addTask {
+        do {
+          return .restored(try await operation())
+        } catch {
+          return .failed(String(describing: error))
+        }
       }
-    }
-    let timeoutTask = Task.detached {
-      do {
-        try await Task.sleep(nanoseconds: timeoutNanoseconds)
-        continuation.yield(.timedOut)
-      } catch {
-        // The restore completed first.
-      }
-    }
 
-    var iterator = stream.makeAsyncIterator()
-    let result = await iterator.next()
-    restoreTask.cancel()
-    timeoutTask.cancel()
-    continuation.finish()
-    return result ?? .failed("Subscription state restore produced no result.")
+      group.addTask {
+        try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+        return .timedOut
+      }
+
+      let result = await group.next()
+      group.cancelAll()
+      return result ?? .failed("Subscription state restore produced no result.")
+    }
   }.value
 }
 
@@ -2664,8 +2659,9 @@ final class BackendCompatibilityCleanupTests: XCTestCase {
   }
 
   @MainActor
-  func testSubscriptionStateRestoreReturnsAtTimeoutWhenOperationIgnoresCancellation() async {
+  func testSubscriptionStateRestoreWaitsForTimedOutOperationToFinish() async {
     let start = ContinuousClock.now
+    var didFinishRestore = false
 
     let result = await restoreSubscriptionState(timeoutNanoseconds: 20_000_000) {
       await withCheckedContinuation { continuation in
@@ -2674,11 +2670,13 @@ final class BackendCompatibilityCleanupTests: XCTestCase {
           continuation.resume()
         }
       }
+      didFinishRestore = true
       return true
     }
 
     XCTAssertEqual(result, .timedOut)
-    XCTAssertLessThan(start.duration(to: .now), .milliseconds(150))
+    XCTAssertTrue(didFinishRestore)
+    XCTAssertGreaterThanOrEqual(start.duration(to: .now), .milliseconds(250))
   }
 }
 

--- a/MoviePilot-TV-Tests/BackendCompatibilityTests.swift
+++ b/MoviePilot-TV-Tests/BackendCompatibilityTests.swift
@@ -2597,7 +2597,44 @@ final class BackendCompatibilityReadOnlyTests: XCTestCase {
   }
 }
 
-private struct SubscriptionSideEffectTarget: Equatable {
+private enum SubscriptionStateRestoreResult: Equatable, Sendable {
+  case restored(Bool)
+  case failed(String)
+  case timedOut
+}
+
+private func restoreSubscriptionState(
+  timeoutNanoseconds: UInt64 = 15 * 1_000_000_000,
+  operation: @escaping @MainActor @Sendable () async throws -> Bool
+) async -> SubscriptionStateRestoreResult {
+  await Task.detached {
+    let (stream, continuation) = AsyncStream<SubscriptionStateRestoreResult>.makeStream()
+    let restoreTask = Task.detached {
+      do {
+        continuation.yield(.restored(try await operation()))
+      } catch {
+        continuation.yield(.failed(String(describing: error)))
+      }
+    }
+    let timeoutTask = Task.detached {
+      do {
+        try await Task.sleep(nanoseconds: timeoutNanoseconds)
+        continuation.yield(.timedOut)
+      } catch {
+        // The restore completed first.
+      }
+    }
+
+    var iterator = stream.makeAsyncIterator()
+    let result = await iterator.next()
+    restoreTask.cancel()
+    timeoutTask.cancel()
+    continuation.finish()
+    return result ?? .failed("Subscription state restore produced no result.")
+  }.value
+}
+
+private struct SubscriptionSideEffectTarget: Equatable, Sendable {
   let id: Int
   let originalState: String
 
@@ -2607,6 +2644,41 @@ private struct SubscriptionSideEffectTarget: Equatable {
 
   var isToggleable: Bool {
     originalState == "R" || originalState == "S"
+  }
+}
+
+final class BackendCompatibilityCleanupTests: XCTestCase {
+  @MainActor
+  func testSubscriptionStateRestoreDoesNotInheritCallerCancellation() async {
+    let cleanupTask = Task {
+      try? await Task.sleep(nanoseconds: 1_000_000)
+      return await restoreSubscriptionState(timeoutNanoseconds: 1_000_000_000) {
+        try Task.checkCancellation()
+        return true
+      }
+    }
+    cleanupTask.cancel()
+
+    let result = await cleanupTask.value
+    XCTAssertEqual(result, .restored(true))
+  }
+
+  @MainActor
+  func testSubscriptionStateRestoreReturnsAtTimeoutWhenOperationIgnoresCancellation() async {
+    let start = ContinuousClock.now
+
+    let result = await restoreSubscriptionState(timeoutNanoseconds: 20_000_000) {
+      await withCheckedContinuation { continuation in
+        _ = Task.detached {
+          try? await Task.sleep(nanoseconds: 300_000_000)
+          continuation.resume()
+        }
+      }
+      return true
+    }
+
+    XCTAssertEqual(result, .timedOut)
+    XCTAssertLessThan(start.duration(to: .now), .milliseconds(150))
   }
 }
 
@@ -2989,18 +3061,26 @@ final class BackendCompatibilitySideEffectTests: XCTestCase {
       XCTFail("Failed to \(operationDescription): \(error)")
     }
 
-    do {
-      let restored = try await service.updateSubscriptionStatus(
+    let restoreResult = await restoreSubscriptionState {
+      try await service.updateSubscriptionStatus(
         id: target.id,
         state: target.originalState
       )
-      XCTAssertTrue(
-        restored,
+    }
+    switch restoreResult {
+    case .restored(true):
+      break
+    case .restored(false):
+      XCTFail(
         "Subscription \(target.id) state restore to \(target.originalState) was rejected."
       )
-    } catch {
+    case .failed(let diagnostic):
       XCTFail(
-        "Failed to restore subscription \(target.id) to original state \(target.originalState): \(error)"
+        "Failed to restore subscription \(target.id) to original state \(target.originalState): \(diagnostic)"
+      )
+    case .timedOut:
+      XCTFail(
+        "Timed out restoring subscription \(target.id) to original state \(target.originalState)."
       )
     }
   }

--- a/MoviePilot-TV-Tests/ContentViewModelBehaviorTests.swift
+++ b/MoviePilot-TV-Tests/ContentViewModelBehaviorTests.swift
@@ -4,6 +4,101 @@ import XCTest
 
 @MainActor
 final class ContentViewModelBehaviorTests: XCTestCase {
+  func testAccountPermissionWarningUsesPersistedUserOnInitialization() async throws {
+    XCTAssertTrue(URLProtocol.registerClass(ContentViewModelURLProtocol.self))
+    defer { URLProtocol.unregisterClass(ContentViewModelURLProtocol.self) }
+
+    await ContentViewModelURLProtocol.stub.reset()
+    let service = APIService.shared
+    let snapshot = ContentViewModelServiceSnapshot.capture(service: service)
+    var viewModel: ContentViewModel?
+    defer {
+      viewModel = nil
+      snapshot.restore(to: service)
+    }
+
+    service.baseURL = "https://permission-warning.content-view-model-tests.local"
+    service.token = "limited-token"
+    service.currentUser = token(
+      "limited-token",
+      userName: "limited-user",
+      permissions: ["discovery": false, "search": false, "subscribe": false, "manage": true]
+    )
+
+    viewModel = ContentViewModel()
+
+    XCTAssertNotNil(viewModel?.accountPermissionWarning)
+  }
+
+  func testPrepareStartupRefreshesPersistedPermissionsOnSameAppVersion() async throws {
+    XCTAssertTrue(URLProtocol.registerClass(ContentViewModelURLProtocol.self))
+    defer { URLProtocol.unregisterClass(ContentViewModelURLProtocol.self) }
+
+    await ContentViewModelURLProtocol.stub.reset()
+    let service = APIService.shared
+    let snapshot = ContentViewModelServiceSnapshot.capture(service: service)
+    let markerKey = APIService.sessionRefreshAppVersionKey
+    let originalMarker = UserDefaults.standard.string(forKey: markerKey)
+    var viewModel: ContentViewModel?
+    defer {
+      viewModel = nil
+      snapshot.restore(to: service)
+      restoreUserDefaultsString(originalMarker, forKey: markerKey)
+    }
+
+    clearCredential(account: "username")
+    clearCredential(account: "password")
+    UserDefaults.standard.set(AppVersionInfo.currentAppVersion(), forKey: markerKey)
+    service.baseURL = "https://startup-permission.content-view-model-tests.local"
+    service.token = "persisted-token"
+    service.currentUser = token(
+      "persisted-token",
+      userName: "stale-user",
+      permissions: ["discovery": true, "search": false, "subscribe": false, "manage": false]
+    )
+
+    viewModel = ContentViewModel()
+    await viewModel?.prepareStartupIfNeeded()
+
+    XCTAssertEqual(service.currentUser?.user_name, "refreshed-user")
+    XCTAssertFalse(service.canAccess(.discovery))
+    XCTAssertTrue(service.canAccess(.search))
+    let paths = await ContentViewModelURLProtocol.stub.requestPaths()
+    XCTAssertEqual(paths.filter { $0 == "/api/v1/user/current" }.count, 1)
+  }
+
+  func testPrepareStartupLogsOutUnauthorizedTokenOnlySession() async throws {
+    XCTAssertTrue(URLProtocol.registerClass(ContentViewModelURLProtocol.self))
+    defer { URLProtocol.unregisterClass(ContentViewModelURLProtocol.self) }
+
+    await ContentViewModelURLProtocol.stub.reset()
+    await ContentViewModelURLProtocol.stub.setCurrentUserStatusCode(401)
+    let service = APIService.shared
+    let snapshot = ContentViewModelServiceSnapshot.capture(service: service)
+    let markerKey = APIService.sessionRefreshAppVersionKey
+    let originalMarker = UserDefaults.standard.string(forKey: markerKey)
+    var viewModel: ContentViewModel?
+    defer {
+      viewModel = nil
+      snapshot.restore(to: service)
+      restoreUserDefaultsString(originalMarker, forKey: markerKey)
+    }
+
+    clearCredential(account: "username")
+    clearCredential(account: "password")
+    UserDefaults.standard.set(AppVersionInfo.currentAppVersion(), forKey: markerKey)
+    service.baseURL = "https://startup-token-only.content-view-model-tests.local"
+    service.token = "expired-token"
+    service.currentUser = nil
+
+    viewModel = ContentViewModel()
+    await viewModel?.prepareStartupIfNeeded()
+
+    XCTAssertNil(service.token)
+    XCTAssertNil(service.currentUser)
+    XCTAssertFalse(viewModel?.isLoggedIn == true)
+  }
+
   func testAccountPermissionWarningClearsWhenCurrentUserRegainsRecommendedPermissions() async throws {
     XCTAssertTrue(URLProtocol.registerClass(ContentViewModelURLProtocol.self))
     defer { URLProtocol.unregisterClass(ContentViewModelURLProtocol.self) }
@@ -206,9 +301,19 @@ private struct ContentViewModelServiceSnapshot {
 
 private actor ContentViewModelURLProtocolStub {
   private var requests: [URLRequest] = []
+  private var currentUserStatusCode = 200
 
   func reset() {
     requests.removeAll()
+    currentUserStatusCode = 200
+  }
+
+  func setCurrentUserStatusCode(_ statusCode: Int) {
+    currentUserStatusCode = statusCode
+  }
+
+  func requestPaths() -> [String] {
+    requests.compactMap { $0.url?.path }
   }
 
   func response(for request: URLRequest) throws -> (HTTPURLResponse, Data) {
@@ -226,7 +331,11 @@ private actor ContentViewModelURLProtocolStub {
     }
 
     let data: Data
-    if url.path == "/api/v1/system/global" {
+    if url.path == "/api/v1/user/current" {
+      data =
+        #"{"id":1,"name":"refreshed-user","email":null,"is_active":true,"is_superuser":false,"avatar":null,"is_otp":false,"permissions":{"discovery":false,"search":true,"subscribe":false,"manage":false},"settings":{}}"#
+        .data(using: .utf8)!
+    } else if url.path == "/api/v1/system/global" {
       data =
         #"{"success":true,"data":{"TMDB_IMAGE_DOMAIN":"image.tmdb.org","GLOBAL_IMAGE_CACHE":true,"BACKEND_VERSION":"\#(backendVersion)","FRONTEND_VERSION":"v2.13.15"}}"#
         .data(using: .utf8)!
@@ -240,7 +349,7 @@ private actor ContentViewModelURLProtocolStub {
 
     let response = HTTPURLResponse(
       url: url,
-      statusCode: 200,
+      statusCode: url.path == "/api/v1/user/current" ? currentUserStatusCode : 200,
       httpVersion: nil,
       headerFields: ["Content-Type": "application/json"]
     )!

--- a/MoviePilot-TV-Tests/MediaDetailViewHeaderActionTests.swift
+++ b/MoviePilot-TV-Tests/MediaDetailViewHeaderActionTests.swift
@@ -435,6 +435,43 @@ final class MediaDetailViewHeaderActionTests: XCTestCase {
   }
 
   @MainActor
+  func testDetailReadyHandlerKeepsRetryPendingWhenSubscriptionRefreshFails() async throws {
+    XCTAssertTrue(URLProtocol.registerClass(DetailHeaderSubscriptionURLProtocol.self))
+    defer { URLProtocol.unregisterClass(DetailHeaderSubscriptionURLProtocol.self) }
+
+    let service = APIService.shared
+    let snapshot = DetailHeaderSubscriptionServiceSnapshot.capture(service: service)
+    defer { snapshot.restore(to: service) }
+
+    let tmdbId = 776_657
+    await DetailHeaderSubscriptionURLProtocol.stub.reset()
+    await DetailHeaderSubscriptionURLProtocol.stub.failLookup(tmdbId: tmdbId)
+    service.baseURL = "http://detail-header-subscription-tests.local"
+    configureDetailHeaderSubscriptionAccess(service)
+
+    let fullDetail = MediaInfo(tmdb_id: tmdbId, title: "订阅查询失败", type: "电影")
+    let preloadTask = MediaPreloadTask(partialMedia: fullDetail)
+    preloadTask.fullDetail = fullDetail
+    preloadTask.isSubscribed = true
+
+    let viewModel = MediaDetailViewModel(detail: MediaInfo(title: "占位详情", type: "电影"))
+    viewModel.preloadTask = preloadTask
+
+    let didRefreshSubscription = await MediaDetailView.applyReadyPreloadedDetail(
+      from: preloadTask,
+      to: viewModel,
+      hasRefreshedSubscription: false
+    )
+
+    let lookupCount = await DetailHeaderSubscriptionURLProtocol.stub.lookupRequestCount(
+      tmdbId: tmdbId
+    )
+    XCTAssertFalse(didRefreshSubscription)
+    XCTAssertEqual(preloadTask.isSubscribed, true)
+    XCTAssertEqual(lookupCount, 1)
+  }
+
+  @MainActor
   func testSubscriptionUpdateRefreshesPinnedPreloadTaskWithoutRefreshingPosterWallCache()
     async throws
   {
@@ -1203,6 +1240,7 @@ private actor DetailHeaderSubscriptionURLProtocolStub {
   private var resolvedSubscriptionsByTMDBID: [Int: Int?] = [:]
   private var queuedStatusesByTMDBID: [Int: [DetailHeaderSubscriptionQueuedStatus]] = [:]
   private var lookupCountsByTMDBID: [Int: Int] = [:]
+  private var failedLookupTMDBIDs: Set<Int> = []
   private var minimalPayloadTMDBIDs: Set<Int> = []
   private var customLookupPayloadsByTMDBID: [Int: String] = [:]
   private var deletedIDs: [Int] = []
@@ -1216,6 +1254,7 @@ private actor DetailHeaderSubscriptionURLProtocolStub {
     ]
     queuedStatusesByTMDBID.removeAll()
     lookupCountsByTMDBID.removeAll()
+    failedLookupTMDBIDs.removeAll()
     minimalPayloadTMDBIDs.removeAll()
     customLookupPayloadsByTMDBID.removeAll()
     deletedIDs.removeAll()
@@ -1230,6 +1269,10 @@ private actor DetailHeaderSubscriptionURLProtocolStub {
 
   func setResolvedSubscription(tmdbId: Int, id: Int?) {
     resolvedSubscriptionsByTMDBID[tmdbId] = id
+  }
+
+  func failLookup(tmdbId: Int) {
+    failedLookupTMDBIDs.insert(tmdbId)
   }
 
   func setCustomLookupPayload(tmdbId: Int, json: String) {
@@ -1302,6 +1345,9 @@ private actor DetailHeaderSubscriptionURLProtocolStub {
       let tmdbId = path.split(separator: ":").last.flatMap { Int($0) }
       if let tmdbId {
         lookupCountsByTMDBID[tmdbId, default: 0] += 1
+        if failedLookupTMDBIDs.contains(tmdbId) {
+          throw URLError(.notConnectedToInternet)
+        }
         if let customPayload = customLookupPayloadsByTMDBID[tmdbId] {
           return try jsonResponse(customPayload)
         }

--- a/MoviePilot-TV-Tests/MediaPreloadPermissionTests.swift
+++ b/MoviePilot-TV-Tests/MediaPreloadPermissionTests.swift
@@ -109,6 +109,57 @@ final class MediaPreloadPermissionTests: XCTestCase {
     XCTAssertFalse(paths.contains { $0.hasPrefix("/api/v1/subscribe/media/") })
   }
 
+  func testSubscriptionHandlerDoesNotOpenSheetWhenLookupFails() async throws {
+    XCTAssertTrue(URLProtocol.registerClass(MediaPreloadPermissionURLProtocol.self))
+    defer { URLProtocol.unregisterClass(MediaPreloadPermissionURLProtocol.self) }
+
+    let service = APIService.shared
+    let snapshot = MediaPreloadPermissionServiceSnapshot.capture(service: service)
+    defer { snapshot.restore(to: service) }
+
+    MediaPreloadPermissionURLProtocol.stub.reset()
+    MediaPreloadPermissionURLProtocol.stub.setSubscriptionLookupStatusCode(500)
+    configureStandardSubscriber(service)
+
+    let handler = SubscriptionHandler()
+    handler.handleSubscribe(MediaInfo(tmdb_id: 456, title: "查询失败", type: "电影"))
+
+    try await waitUntil("subscription handler finishes lookup") {
+      handler.sheetSubscribe != nil || handler.notificationSerial > 0
+    }
+    XCTAssertNil(handler.sheetSubscribe)
+    XCTAssertEqual(handler.notificationMessage, "暂时无法确认订阅状态，请稍后重试。")
+  }
+
+  func testMoviePreloadKeepsKnownSubscriptionStateWhenLookupFails() async throws {
+    XCTAssertTrue(URLProtocol.registerClass(MediaPreloadPermissionURLProtocol.self))
+    defer { URLProtocol.unregisterClass(MediaPreloadPermissionURLProtocol.self) }
+
+    let service = APIService.shared
+    let snapshot = MediaPreloadPermissionServiceSnapshot.capture(service: service)
+    defer { snapshot.restore(to: service) }
+
+    MediaPreloadPermissionURLProtocol.stub.reset()
+    MediaPreloadPermissionURLProtocol.stub.setSubscriptionLookupStatusCode(500)
+    configureStandardSubscriber(service)
+
+    let task = MediaPreloadTask(
+      partialMedia: MediaInfo(tmdb_id: 456, title: "查询失败", type: "电影")
+    )
+    task.isSubscribed = true
+    task.start()
+    defer { task.cancel() }
+
+    try await waitUntil("subscription lookup is requested") {
+      MediaPreloadPermissionURLProtocol.stub.requestPaths().contains {
+        $0.hasPrefix("/api/v1/subscribe/media/")
+      }
+    }
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    XCTAssertEqual(task.isSubscribed, true)
+  }
+
   func testSubscriptionStatusPermissionFailureSurfacesAndDoesNotLogoutOrRetryLogin() async throws {
     XCTAssertTrue(URLProtocol.registerClass(MediaPreloadPermissionURLProtocol.self))
     defer { URLProtocol.unregisterClass(MediaPreloadPermissionURLProtocol.self) }

--- a/MoviePilot-TV-Tests/ResourceResultViewModelTests.swift
+++ b/MoviePilot-TV-Tests/ResourceResultViewModelTests.swift
@@ -268,6 +268,67 @@ final class ResourceResultViewModelTests: XCTestCase {
     )
   }
 
+  func testSessionChangeEndsLoadingAndAllowsSearchToRestart() async throws {
+    XCTAssertTrue(URLProtocol.registerClass(ResourceResultViewModelURLProtocol.self))
+    defer { URLProtocol.unregisterClass(ResourceResultViewModelURLProtocol.self) }
+
+    let service = APIService.shared
+    let snapshot = ResourceResultViewModelServiceSnapshot.capture(service: service)
+    defer { snapshot.restore(to: service) }
+
+    await ResourceResultViewModelURLProtocol.stub.reset()
+    service.baseURL = "http://resource-result-tests.local"
+    configureResourceResultSearchSession(service)
+
+    let fallbackGate = ResourceResultAsyncGate()
+    await ResourceResultViewModelURLProtocol.stub.setStreamFailure(forKeyword: "session-change")
+    await ResourceResultViewModelURLProtocol.stub.setFallbackResults(
+      [resourceContextJSON(title: "Stale Result")],
+      forKeyword: "session-change"
+    )
+    await ResourceResultViewModelURLProtocol.stub.setFallbackGate(
+      fallbackGate, forKeyword: "session-change")
+
+    let viewModel = ResourceResultViewModel(keyword: "session-change")
+    defer { viewModel.cancelSearch() }
+    await viewModel.search()
+
+    try await withTimeout("resource search to enter fallback request") {
+      await ResourceResultViewModelURLProtocol.stub.waitForRequest(
+        path: "/api/v1/search/title", keyword: "session-change")
+    }
+
+    service.currentUser = Token(
+      access_token: service.token ?? "resource-result-search-token",
+      token_type: "bearer",
+      super_user: FlexibleBool(false),
+      permissions: [
+        "discovery": false,
+        "search": true,
+        "subscribe": false,
+        "manage": false,
+        "admin": false,
+      ],
+      user_name: "changed-resource-user",
+      avatar: nil
+    )
+    await fallbackGate.open()
+
+    let deadline = Date().addingTimeInterval(2)
+    while viewModel.isLoading && Date() < deadline {
+      try await Task.sleep(nanoseconds: 10_000_000)
+    }
+    XCTAssertFalse(viewModel.isLoading)
+    XCTAssertTrue(viewModel.results.isEmpty)
+
+    await viewModel.search()
+    let didRestart = await completesWithin {
+      await ResourceResultViewModelURLProtocol.stub.waitForRequest(
+        path: "/api/v1/search/title/stream", keyword: "session-change", count: 2)
+    }
+    XCTAssertTrue(didRestart)
+  }
+
   func testCompletedSearchDoesNotRestartAfterInFlightDisappearCancellation() async throws {
     XCTAssertTrue(URLProtocol.registerClass(ResourceResultViewModelURLProtocol.self))
     defer { URLProtocol.unregisterClass(ResourceResultViewModelURLProtocol.self) }
@@ -360,6 +421,7 @@ private actor ResourceResultViewModelURLProtocolStub {
   private var cancelledRequests: [ResourceResultRecordedRequest] = []
   private var streamFailureKeywords: Set<String> = []
   private var fallbackResultsByKeyword: [String: [String]] = [:]
+  private var fallbackGatesByKeyword: [String: ResourceResultAsyncGate] = [:]
   private var customFilterGate: ResourceResultAsyncGate?
 
   func reset() {
@@ -367,6 +429,7 @@ private actor ResourceResultViewModelURLProtocolStub {
     cancelledRequests.removeAll()
     streamFailureKeywords.removeAll()
     fallbackResultsByKeyword.removeAll()
+    fallbackGatesByKeyword.removeAll()
     customFilterGate = nil
   }
 
@@ -376,6 +439,10 @@ private actor ResourceResultViewModelURLProtocolStub {
 
   func setFallbackResults(_ results: [String], forKeyword keyword: String) {
     fallbackResultsByKeyword[keyword] = results
+  }
+
+  func setFallbackGate(_ gate: ResourceResultAsyncGate, forKeyword keyword: String) {
+    fallbackGatesByKeyword[keyword] = gate
   }
 
   func setCustomFilterGate(_ gate: ResourceResultAsyncGate) {
@@ -402,6 +469,9 @@ private actor ResourceResultViewModelURLProtocolStub {
     }
 
     if components.path == "/api/v1/search/title" {
+      if let gate = fallbackGatesByKeyword[keyword] {
+        await gate.wait()
+      }
       return ResourceResultHTTPStubResponse(
         statusCode: 200,
         data: Data("[\((fallbackResultsByKeyword[keyword] ?? []).joined(separator: ","))]".utf8)

--- a/MoviePilot-TV-Tests/SearchViewModelTests.swift
+++ b/MoviePilot-TV-Tests/SearchViewModelTests.swift
@@ -130,6 +130,78 @@ final class SearchViewModelTests: XCTestCase {
     )
   }
 
+  func testUnifiedSearchSessionChangeEndsLoading() async throws {
+    XCTAssertTrue(URLProtocol.registerClass(SearchViewModelURLProtocol.self))
+    defer { URLProtocol.unregisterClass(SearchViewModelURLProtocol.self) }
+
+    let service = APIService.shared
+    let snapshot = SearchViewModelServiceSnapshot.capture(service: service)
+    defer { snapshot.restore(to: service) }
+
+    await SearchViewModelURLProtocol.stub.reset()
+    let gate = SearchAsyncGate()
+    await SearchViewModelURLProtocol.stub.setGate(gate, forQuery: "session-change")
+    service.baseURL = "http://search-tests.local"
+    configureSearchPermissionSession(service)
+
+    let viewModel = SearchViewModel()
+    viewModel.searchType = .unified
+    viewModel.query = "session-change"
+
+    let searchTask = Task { @MainActor in
+      await viewModel.autoSearch()
+    }
+    defer { searchTask.cancel() }
+
+    try await withTimeout("unified search request to start") {
+      await SearchViewModelURLProtocol.stub.waitForRequest(query: "session-change")
+    }
+
+    configureChangedSearchPermissionSession(service)
+    await gate.open()
+    try await withTimeout("unified search to stop after session change") {
+      await searchTask.value
+    }
+
+    XCTAssertFalse(viewModel.isLoading)
+    XCTAssertFalse(viewModel.hasSearched)
+  }
+
+  func testResourceSearchSessionChangeEndsLoading() async throws {
+    XCTAssertTrue(URLProtocol.registerClass(SearchViewModelURLProtocol.self))
+    defer { URLProtocol.unregisterClass(SearchViewModelURLProtocol.self) }
+
+    let service = APIService.shared
+    let snapshot = SearchViewModelServiceSnapshot.capture(service: service)
+    defer { snapshot.restore(to: service) }
+
+    await SearchViewModelURLProtocol.stub.reset()
+    let gate = SearchAsyncGate()
+    await SearchViewModelURLProtocol.stub.setGate(gate, forQuery: "resource-session-change")
+    service.baseURL = "http://search-tests.local"
+    configureSearchPermissionSession(service)
+
+    let viewModel = SearchViewModel()
+    viewModel.searchType = .resource
+    viewModel.query = "resource-session-change"
+    await viewModel.autoSearch()
+
+    try await withTimeout("resource search request to start") {
+      await SearchViewModelURLProtocol.stub.waitForRequest(
+        path: "/api/v1/search/title/stream", query: "resource-session-change")
+    }
+
+    configureChangedSearchPermissionSession(service)
+    await gate.open()
+
+    let deadline = Date().addingTimeInterval(2)
+    while viewModel.isLoading && Date() < deadline {
+      try await Task.sleep(nanoseconds: 10_000_000)
+    }
+    XCTAssertFalse(viewModel.isLoading)
+    XCTAssertFalse(viewModel.hasSearched)
+  }
+
   func testCancelledResourceSearchFilteringDoesNotPublishOldResultsOrClearNewLoading()
     async throws
   {
@@ -476,6 +548,24 @@ private func configureSearchPermissionSession(_ service: APIService) {
       "admin": false,
     ],
     user_name: "search-user",
+    avatar: nil
+  )
+}
+
+@MainActor
+private func configureChangedSearchPermissionSession(_ service: APIService) {
+  service.currentUser = Token(
+    access_token: service.token ?? "search-permission-token",
+    token_type: "bearer",
+    super_user: FlexibleBool(false),
+    permissions: [
+      "discovery": false,
+      "search": true,
+      "subscribe": false,
+      "manage": false,
+      "admin": false,
+    ],
+    user_name: "changed-search-user",
     avatar: nil
   )
 }

--- a/MoviePilot-TV-Tests/SubscribeSeasonContentViewTests.swift
+++ b/MoviePilot-TV-Tests/SubscribeSeasonContentViewTests.swift
@@ -431,6 +431,33 @@ final class SubscribeSeasonContentViewTests: XCTestCase {
     XCTAssertEqual(subscribeRequestCount, 2)
   }
 
+  func testLatestForcedSubscriptionRefreshPropagatesErrorWithoutRetry() async throws {
+    XCTAssertTrue(URLProtocol.registerClass(SubscriptionSnapshotURLProtocol.self))
+    defer { URLProtocol.unregisterClass(SubscriptionSnapshotURLProtocol.self) }
+
+    let service = APIService.shared
+    let snapshot = SubscriptionSnapshotServiceSnapshot.capture(service: service)
+    defer { snapshot.restore(to: service) }
+
+    await SubscriptionSnapshotURLProtocol.stub.reset()
+    try await SubscriptionSnapshotURLProtocol.stub.enqueueServerError()
+    try await SubscriptionSnapshotURLProtocol.stub.setDefaultSubscriptions([])
+    service.baseURL = "http://subscription-snapshot-tests.local"
+    configureSubscriptionSnapshotAccess(service)
+
+    do {
+      _ = try await service.fetchSubscriptions(forceRefresh: true)
+      XCTFail("The latest subscription snapshot failure must reach the caller.")
+    } catch is CancellationError {
+      XCTFail("A server failure must not be converted into cancellation.")
+    } catch {
+      // Expected.
+    }
+
+    let subscribeRequestCount = await SubscriptionSnapshotURLProtocol.stub.subscribeRequestCount()
+    XCTAssertEqual(subscribeRequestCount, 1)
+  }
+
   func testFetchSubscriptionsThrowsWhenCancelledAfterCachedSnapshotIsRead() async throws {
     XCTAssertTrue(URLProtocol.registerClass(SubscriptionSnapshotURLProtocol.self))
     defer { URLProtocol.unregisterClass(SubscriptionSnapshotURLProtocol.self) }

--- a/MoviePilot-TV-Tests/SubscribeSeasonContentViewTests.swift
+++ b/MoviePilot-TV-Tests/SubscribeSeasonContentViewTests.swift
@@ -503,7 +503,7 @@ final class SubscribeSeasonContentViewTests: XCTestCase {
     XCTAssertEqual(subscribeRequestCount, 1)
   }
 
-  func testMultiSeasonDetailRetriesAfterSeasonSubscriptionRefreshFailure() async throws {
+  func testMultiSeasonDetailCanRefreshAfterSeasonSubscriptionFailure() async throws {
     XCTAssertTrue(URLProtocol.registerClass(SubscriptionSnapshotURLProtocol.self))
     defer { URLProtocol.unregisterClass(SubscriptionSnapshotURLProtocol.self) }
 
@@ -546,6 +546,15 @@ final class SubscribeSeasonContentViewTests: XCTestCase {
     let requestCountAfterSeasonRefreshes =
       await SubscriptionSnapshotURLProtocol.stub.subscribeRequestCount()
     XCTAssertEqual(requestCountAfterSeasonRefreshes, 2)
+  }
+
+  func testInitialEpisodeGroupSeedsSeasonSelection() {
+    let viewModel = SubscribeSeasonViewModel(
+      mediaInfo: MediaInfo(tmdb_id: 817_002, title: "剧集组导航", type: "电视剧"),
+      initialEpisodeGroup: "group-a"
+    )
+
+    XCTAssertEqual(viewModel.selectedGroupId, "group-a")
   }
 
   func testFetchSubscriptionsThrowsWhenCancelledAfterCachedSnapshotIsRead() async throws {

--- a/MoviePilot-TV-Tests/SubscribeSeasonContentViewTests.swift
+++ b/MoviePilot-TV-Tests/SubscribeSeasonContentViewTests.swift
@@ -458,6 +458,96 @@ final class SubscribeSeasonContentViewTests: XCTestCase {
     XCTAssertEqual(subscribeRequestCount, 1)
   }
 
+  func testSharedSubscriptionSnapshotFailureReachesAllWaitersWithoutRetry() async throws {
+    XCTAssertTrue(URLProtocol.registerClass(SubscriptionSnapshotURLProtocol.self))
+    defer { URLProtocol.unregisterClass(SubscriptionSnapshotURLProtocol.self) }
+
+    let service = APIService.shared
+    let snapshot = SubscriptionSnapshotServiceSnapshot.capture(service: service)
+    defer { snapshot.restore(to: service) }
+
+    await SubscriptionSnapshotURLProtocol.stub.reset()
+    let responseGate = SubscriptionSnapshotAsyncGate()
+    try await SubscriptionSnapshotURLProtocol.stub.enqueueServerError(waitFor: responseGate)
+    try await SubscriptionSnapshotURLProtocol.stub.setDefaultSubscriptions([])
+    service.baseURL = "http://subscription-snapshot-tests.local"
+    configureSubscriptionSnapshotAccess(service)
+
+    let firstWaiter = Task {
+      do {
+        _ = try await service.fetchSubscriptions()
+        return false
+      } catch {
+        return !(error is CancellationError)
+      }
+    }
+    await responseGate.waitForWaiter()
+
+    let secondWaiter = Task {
+      do {
+        _ = try await service.fetchSubscriptions()
+        return false
+      } catch {
+        return !(error is CancellationError)
+      }
+    }
+    await Task.yield()
+    await responseGate.open()
+
+    let firstFailed = await firstWaiter.value
+    let secondFailed = await secondWaiter.value
+    let subscribeRequestCount = await SubscriptionSnapshotURLProtocol.stub.subscribeRequestCount()
+
+    XCTAssertTrue(firstFailed)
+    XCTAssertTrue(secondFailed)
+    XCTAssertEqual(subscribeRequestCount, 1)
+  }
+
+  func testMultiSeasonDetailRetriesAfterSeasonSubscriptionRefreshFailure() async throws {
+    XCTAssertTrue(URLProtocol.registerClass(SubscriptionSnapshotURLProtocol.self))
+    defer { URLProtocol.unregisterClass(SubscriptionSnapshotURLProtocol.self) }
+
+    let service = APIService.shared
+    let snapshot = SubscriptionSnapshotServiceSnapshot.capture(service: service)
+    defer { snapshot.restore(to: service) }
+
+    await SubscriptionSnapshotURLProtocol.stub.reset()
+    try await SubscriptionSnapshotURLProtocol.stub.enqueueServerError()
+    try await SubscriptionSnapshotURLProtocol.stub.enqueueSubscriptions([
+      Subscribe(id: 901, name: "分季刷新重试", type: "电视剧", season: 1, tmdbid: 817_001)
+    ])
+    service.baseURL = "http://subscription-snapshot-tests.local"
+    configureSubscriptionSnapshotAccess(service)
+
+    let detail = MediaInfo(tmdb_id: 817_001, title: "分季刷新重试", type: "电视剧")
+    let preloadTask = MediaPreloadTask(partialMedia: detail)
+    preloadTask.fullDetail = detail
+
+    let viewModel = MediaDetailViewModel(detail: MediaInfo(title: "占位详情", type: "电视剧"))
+    viewModel.preloadTask = preloadTask
+
+    let refreshedBeforeSeasonData = await MediaDetailView.applyReadyPreloadedDetail(
+      from: preloadTask,
+      to: viewModel,
+      hasRefreshedSubscription: false
+    )
+    XCTAssertFalse(refreshedBeforeSeasonData)
+    let requestCountBeforeSeasonData =
+      await SubscriptionSnapshotURLProtocol.stub.subscribeRequestCount()
+    XCTAssertEqual(requestCountBeforeSeasonData, 0)
+
+    preloadTask.seasonViewModel = SubscribeSeasonViewModel(mediaInfo: detail)
+    let firstSeasonRefresh = await viewModel.refreshSubscriptionStatus()
+    let secondSeasonRefresh = await viewModel.refreshSubscriptionStatus()
+
+    XCTAssertFalse(firstSeasonRefresh)
+    XCTAssertTrue(secondSeasonRefresh)
+    XCTAssertEqual(preloadTask.seasonViewModel?.subscribedSeasons, Set([1]))
+    let requestCountAfterSeasonRefreshes =
+      await SubscriptionSnapshotURLProtocol.stub.subscribeRequestCount()
+    XCTAssertEqual(requestCountAfterSeasonRefreshes, 2)
+  }
+
   func testFetchSubscriptionsThrowsWhenCancelledAfterCachedSnapshotIsRead() async throws {
     XCTAssertTrue(URLProtocol.registerClass(SubscriptionSnapshotURLProtocol.self))
     defer { URLProtocol.unregisterClass(SubscriptionSnapshotURLProtocol.self) }

--- a/MoviePilot-TV/Models/Models.swift
+++ b/MoviePilot-TV/Models/Models.swift
@@ -1993,6 +1993,7 @@ struct GlobalSettings: Codable {
 struct SubscribeSeasonRequest: Hashable, Codable {
   let mediaInfo: MediaInfo
   let initialSeason: Int?
+  let initialEpisodeGroup: String?
 }
 
 // MARK: - Transfer History Models

--- a/MoviePilot-TV/Services/APIService.swift
+++ b/MoviePilot-TV/Services/APIService.swift
@@ -2214,9 +2214,7 @@ class APIService: ObservableObject {
       do {
         subscriptions = try await fetch.task.value
       } catch is CancellationError {
-        let isCurrent =
-          subscriptionSnapshotFetchGeneration == generation
-          && subscriptionSnapshotFetchTaskRevision == fetch.revision
+        let wasSuperseded = subscriptionSnapshotFetchRevision != fetch.revision
         clearSubscriptionSnapshotFetchTaskIfCurrent(
           generation: generation,
           revision: fetch.revision
@@ -2226,15 +2224,13 @@ class APIService: ObservableObject {
           canReadCache = true
           continue
         }
-        guard isCurrent else {
+        guard !wasSuperseded else {
           canReadCache = true
           continue
         }
         throw CancellationError()
       } catch {
-        let isCurrent =
-          subscriptionSnapshotFetchGeneration == generation
-          && subscriptionSnapshotFetchTaskRevision == fetch.revision
+        let wasSuperseded = subscriptionSnapshotFetchRevision != fetch.revision
         clearSubscriptionSnapshotFetchTaskIfCurrent(
           generation: generation,
           revision: fetch.revision
@@ -2243,7 +2239,7 @@ class APIService: ObservableObject {
           canReadCache = true
           continue
         }
-        guard isCurrent else {
+        guard !wasSuperseded else {
           canReadCache = true
           continue
         }

--- a/MoviePilot-TV/Services/APIService.swift
+++ b/MoviePilot-TV/Services/APIService.swift
@@ -707,15 +707,26 @@ class APIService: ObservableObject {
     }
   }
 
-  private func recoverCurrentUserFromCurrentUserEndpoint() async -> Bool {
-    guard let accessToken = token, !accessToken.isEmpty else { return false }
+  func refreshCurrentUserForStartup() async {
+    _ = await recoverCurrentUserFromCurrentUserEndpoint(
+      retryOn401: true,
+      logoutOnUnauthorized: true
+    )
+  }
+
+  private func recoverCurrentUserFromCurrentUserEndpoint(
+    retryOn401: Bool = false,
+    logoutOnUnauthorized: Bool = false
+  ) async -> Bool {
+    guard token?.isEmpty == false else { return false }
     do {
       let data = try await makeRequest(
         endpoint: "/user/current",
-        retryOn401: false,
-        logoutOnUnauthorized: false
+        retryOn401: retryOn401,
+        logoutOnUnauthorized: logoutOnUnauthorized
       )
       let user = try JSONDecoder().decode(CurrentUserResponse.self, from: data)
+      guard let accessToken = token, !accessToken.isEmpty else { return false }
       let recoveredUser = user.token(accessToken: accessToken)
       guard recoveredUser.hasLoginAccessibleFeature else {
         logout()

--- a/MoviePilot-TV/Services/APIService.swift
+++ b/MoviePilot-TV/Services/APIService.swift
@@ -2203,6 +2203,9 @@ class APIService: ObservableObject {
       do {
         subscriptions = try await fetch.task.value
       } catch is CancellationError {
+        let isCurrent =
+          subscriptionSnapshotFetchGeneration == generation
+          && subscriptionSnapshotFetchTaskRevision == fetch.revision
         clearSubscriptionSnapshotFetchTaskIfCurrent(
           generation: generation,
           revision: fetch.revision
@@ -2212,12 +2215,15 @@ class APIService: ObservableObject {
           canReadCache = true
           continue
         }
-        guard fetch.revision == subscriptionSnapshotFetchTaskRevision else {
+        guard isCurrent else {
           canReadCache = true
           continue
         }
         throw CancellationError()
       } catch {
+        let isCurrent =
+          subscriptionSnapshotFetchGeneration == generation
+          && subscriptionSnapshotFetchTaskRevision == fetch.revision
         clearSubscriptionSnapshotFetchTaskIfCurrent(
           generation: generation,
           revision: fetch.revision
@@ -2226,7 +2232,7 @@ class APIService: ObservableObject {
           canReadCache = true
           continue
         }
-        guard fetch.revision == subscriptionSnapshotFetchTaskRevision else {
+        guard isCurrent else {
           canReadCache = true
           continue
         }

--- a/MoviePilot-TV/ViewModels/ContentViewModel.swift
+++ b/MoviePilot-TV/ViewModels/ContentViewModel.swift
@@ -29,6 +29,7 @@ class ContentViewModel: ObservableObject {
     // 初始状态
     isLoggedIn = apiService.isLoggedIn
     currentUser = apiService.currentUser
+    updateAccountPermissionWarning(for: currentUser)
 
     // 监听令牌变化 -> 在登录或令牌更新时触发设置获取
     apiService.$token
@@ -114,7 +115,14 @@ class ContentViewModel: ObservableObject {
 
     if apiService.isLoggedIn {
       isPreparingStartupSession = true
-      _ = await apiService.refreshStoredSessionAfterAppUpdateIfNeeded()
+      let hadRestoredCurrentUser = apiService.currentUser != nil
+      let refreshResult = await apiService.refreshStoredSessionAfterAppUpdateIfNeeded()
+      if refreshResult != .refreshed,
+        apiService.isLoggedIn,
+        hadRestoredCurrentUser || apiService.currentUser == nil
+      {
+        await apiService.refreshCurrentUserForStartup()
+      }
       isPreparingStartupSession = false
       isLoggedIn = apiService.isLoggedIn
     }

--- a/MoviePilot-TV/ViewModels/MediaDetailViewModel.swift
+++ b/MoviePilot-TV/ViewModels/MediaDetailViewModel.swift
@@ -346,7 +346,7 @@ class MediaDetailViewModel: ObservableObject {
         didRefreshAll = didRefreshAll && didRefresh
       }
     }
-    return resultCount == 0 || didRefreshAll
+    return resultCount > 0 && didRefreshAll
   }
 
   private func deleteResolvedSubscription() async -> Bool {

--- a/MoviePilot-TV/ViewModels/MediaPreloader.swift
+++ b/MoviePilot-TV/ViewModels/MediaPreloader.swift
@@ -205,7 +205,6 @@ class MediaPreloadTask: ObservableObject {
       self.isSubscribed = subscribed
     } catch {
       print("[MediaPreloadTask] 检查订阅状态失败: \(error)")
-      self.isSubscribed = false
     }
   }
 

--- a/MoviePilot-TV/ViewModels/ResourceResultViewModel.swift
+++ b/MoviePilot-TV/ViewModels/ResourceResultViewModel.swift
@@ -20,6 +20,7 @@ class ResourceResultViewModel: ObservableObject {
   @Published var searchProgress: Double = 0.0
 
   private var searchStreamTask: Task<Void, Never>?
+  private var searchGeneration = 0
   private let searchStreamDoneCloseDelay: UInt64 = 1_500_000_000
 
   private let apiService = APIService.shared
@@ -42,6 +43,7 @@ class ResourceResultViewModel: ObservableObject {
   }
 
   func cancelSearch() {
+    searchGeneration += 1
     searchStreamTask?.cancel()
     searchStreamTask = nil
     hasSearched = false
@@ -50,6 +52,7 @@ class ResourceResultViewModel: ObservableObject {
 
   func cancelInFlightSearch() {
     let wasInFlight = isLoading
+    searchGeneration += 1
     searchStreamTask?.cancel()
     searchStreamTask = nil
     isLoading = false
@@ -63,6 +66,8 @@ class ResourceResultViewModel: ObservableObject {
     guard !hasSearched else { return }
     hasSearched = true
     isLoading = true
+    searchGeneration += 1
+    let currentSearchGeneration = searchGeneration
 
     // 取消可能正在进行的流式搜索
     searchStreamTask?.cancel()
@@ -82,9 +87,17 @@ class ResourceResultViewModel: ObservableObject {
 
     searchStreamTask = Task { @MainActor [weak self] in
       var accumulatedResults: [Context] = []
+      defer {
+        self?.finishSearchIfCurrent(
+          generation: currentSearchGeneration,
+          sessionSnapshot: sessionSnapshot
+        )
+      }
 
-      let canContinue: @MainActor () -> Bool = {
-        apiService.isSessionUnchanged(from: sessionSnapshot)
+      let canContinue: @MainActor () -> Bool = { [weak self] in
+        guard let self else { return false }
+        return self.searchGeneration == currentSearchGeneration
+          && apiService.isSessionUnchanged(from: sessionSnapshot)
           && apiService.canAccess(.search)
           && !Task.isCancelled
       }
@@ -190,7 +203,6 @@ class ResourceResultViewModel: ObservableObject {
           guard canContinue() else { return }
 
           self.results = filteredResults
-          self.isLoading = false
         }
       } catch {
         print("Search Stream error: \(error)")
@@ -216,10 +228,23 @@ class ResourceResultViewModel: ObservableObject {
             print("Search fallback error: \(error)")
           }
           guard canContinue() else { return }
-
-          self?.isLoading = false
         }
       }
+    }
+  }
+
+  private func finishSearchIfCurrent(
+    generation: Int,
+    sessionSnapshot: APIServiceSessionSnapshot
+  ) {
+    guard searchGeneration == generation else { return }
+    isLoading = false
+    searchStreamTask = nil
+    if Task.isCancelled
+      || !apiService.isSessionUnchanged(from: sessionSnapshot)
+      || !apiService.canAccess(.search)
+    {
+      hasSearched = false
     }
   }
 

--- a/MoviePilot-TV/ViewModels/SearchViewModel.swift
+++ b/MoviePilot-TV/ViewModels/SearchViewModel.swift
@@ -268,6 +268,12 @@ class SearchViewModel: ObservableObject {
       
       searchStreamTask = Task { @MainActor in
         var accumulatedResults: [Context] = []
+        defer {
+          self.finishSearchIfCurrent(
+            generation: currentSearchGeneration,
+            sessionSnapshot: sessionSnapshot
+          )
+        }
         
         do {
           guard canPublishSearchResult(
@@ -322,8 +328,6 @@ class SearchViewModel: ObservableObject {
           else { return }
 
           self.resourceResults = filteredResults
-          self.isLoading = false
-          self.hasSearched = true
         } catch {
           print("Stream Search error: \(error)")
           guard canPublishSearchResult(
@@ -351,14 +355,17 @@ class SearchViewModel: ObservableObject {
           guard canPublishSearchResult(
             generation: currentSearchGeneration, sessionSnapshot: sessionSnapshot)
           else { return }
-
-          self.isLoading = false
-          self.hasSearched = true
         }
       }
       return
 
     case .unified:
+      defer {
+        finishSearchIfCurrent(
+          generation: currentSearchGeneration,
+          sessionSnapshot: sessionSnapshot
+        )
+      }
       // 聚合搜索：创建代理 Fetcher 和 Paginators
       setupPaginators(query: submittedQuery)
 
@@ -394,11 +401,18 @@ class SearchViewModel: ObservableObject {
         shares: sharePag?.items ?? []
       )
     }
-    guard canPublishSearchResult(
-      generation: currentSearchGeneration, sessionSnapshot: sessionSnapshot)
-    else { return }
+  }
+
+  private func finishSearchIfCurrent(
+    generation: Int,
+    sessionSnapshot: APIServiceSessionSnapshot
+  ) {
+    guard searchGeneration == generation else { return }
     isLoading = false
-    hasSearched = true
+    searchStreamTask = nil
+    hasSearched = !Task.isCancelled
+      && apiService.isSessionUnchanged(from: sessionSnapshot)
+      && apiService.canAccess(.search)
   }
 
   private func canPublishSearchResult(

--- a/MoviePilot-TV/ViewModels/SubscribeSeasonViewModel.swift
+++ b/MoviePilot-TV/ViewModels/SubscribeSeasonViewModel.swift
@@ -99,9 +99,14 @@ class SubscribeSeasonViewModel: ObservableObject {
   private let initialSeason: Int?
   private var hasLoaded = false
 
-  init(mediaInfo: MediaInfo, initialSeason: Int? = nil) {
+  init(
+    mediaInfo: MediaInfo,
+    initialSeason: Int? = nil,
+    initialEpisodeGroup: String? = nil
+  ) {
     self.mediaInfo = mediaInfo
     self.initialSeason = initialSeason
+    self.selectedGroupId = initialEpisodeGroup ?? ""
   }
 
   func loadData(forceRefreshSubscriptions: Bool = true) async {

--- a/MoviePilot-TV/ViewModels/SubscriptionHandler.swift
+++ b/MoviePilot-TV/ViewModels/SubscriptionHandler.swift
@@ -19,19 +19,24 @@ class SubscriptionHandler: ObservableObject {
 
     if item.canDirectlySubscribe {
       Task {
-        var isSubscribed = try? await apiService.checkSubscription(media: item)
-        // 豆瓣/Bangumi 来源：后端可能用 TMDB ID 存储订阅，用预加载识别的 tmdbId 补查
-        if isSubscribed != true, item.tmdb_id == nil,
-          let tmdbId = MediaPreloader.shared.peekTask(for: item)?.tmdbId
-        {
-          let tmdbMedia = MediaInfo(tmdb_id: tmdbId, type: item.type)
-          isSubscribed = try? await apiService.checkSubscription(media: tmdbMedia)
-        }
-        if isSubscribed == true {
-          self.showNotification(message: "已订阅，请勿重复操作", type: .warning)
-        } else {
-          // For movies or direct-subscribable TV, show edit sheet
-          self.sheetSubscribe = mediaInfoToSubscribeRequest(item)
+        do {
+          var isSubscribed = try await apiService.checkSubscription(media: item)
+          // 豆瓣/Bangumi 来源：后端可能用 TMDB ID 存储订阅，用预加载识别的 tmdbId 补查
+          if !isSubscribed, item.tmdb_id == nil,
+            let tmdbId = MediaPreloader.shared.peekTask(for: item)?.tmdbId
+          {
+            let tmdbMedia = MediaInfo(tmdb_id: tmdbId, type: item.type)
+            isSubscribed = try await apiService.checkSubscription(media: tmdbMedia)
+          }
+          if isSubscribed {
+            self.showNotification(message: "已订阅，请勿重复操作", type: .warning)
+          } else {
+            // For movies or direct-subscribable TV, show edit sheet
+            self.sheetSubscribe = mediaInfoToSubscribeRequest(item)
+          }
+        } catch {
+          Logger.error("Failed to check subscription before opening editor: \(error)")
+          self.showNotification(message: "暂时无法确认订阅状态，请稍后重试。", type: .error)
         }
       }
     } else {

--- a/MoviePilot-TV/ViewModels/SubscriptionHandler.swift
+++ b/MoviePilot-TV/ViewModels/SubscriptionHandler.swift
@@ -41,7 +41,11 @@ class SubscriptionHandler: ObservableObject {
       }
     } else {
       // 多季电视剧：导航到 SubscribeSeasonView
-      self.tvSubscribeRequest = SubscribeSeasonRequest(mediaInfo: item, initialSeason: nil)
+      self.tvSubscribeRequest = SubscribeSeasonRequest(
+        mediaInfo: item,
+        initialSeason: nil,
+        initialEpisodeGroup: nil
+      )
     }
   }
 

--- a/MoviePilot-TV/Views/Pages/ExploreView.swift
+++ b/MoviePilot-TV/Views/Pages/ExploreView.swift
@@ -49,7 +49,11 @@ struct ExploreView: View {
         ResourceResultView(request: request)
       }
       .navigationDestination(for: SubscribeSeasonRequest.self) { request in
-        SubscribeSeasonView(mediaInfo: request.mediaInfo, initialSeason: request.initialSeason)
+        SubscribeSeasonView(
+          mediaInfo: request.mediaInfo,
+          initialSeason: request.initialSeason,
+          initialEpisodeGroup: request.initialEpisodeGroup
+        )
       }
     }
     .mediaSubscriptionAlerts(using: subscriptionHandler, navigationPath: $path)

--- a/MoviePilot-TV/Views/Pages/HomeView.swift
+++ b/MoviePilot-TV/Views/Pages/HomeView.swift
@@ -101,7 +101,11 @@ struct HomeView: View {
         ResourceResultView(request: request)
       }
       .navigationDestination(for: SubscribeSeasonRequest.self) { request in
-        SubscribeSeasonView(mediaInfo: request.mediaInfo, initialSeason: request.initialSeason)
+        SubscribeSeasonView(
+          mediaInfo: request.mediaInfo,
+          initialSeason: request.initialSeason,
+          initialEpisodeGroup: request.initialEpisodeGroup
+        )
       }
     }
   }

--- a/MoviePilot-TV/Views/Pages/MediaDetailView.swift
+++ b/MoviePilot-TV/Views/Pages/MediaDetailView.swift
@@ -302,18 +302,7 @@ struct MediaDetailView: View {
       }
     }
     .task(id: preloadTask.partialMedia.id) {
-      // 初次查询失败时借用已有循环最多补偿两次；未订阅内容不会进入常驻轮询。
-      var remainingInitialSubscriptionRefreshAttempts = 2
       await Self.runActiveSubscriptionRefreshLoop {
-        if !hasRefreshedSubscriptionAfterFullDetail,
-          preloadTask.fullDetail != nil,
-          remainingInitialSubscriptionRefreshAttempts > 0
-        {
-          remainingInitialSubscriptionRefreshAttempts -= 1
-          hasRefreshedSubscriptionAfterFullDetail = await viewModel.refreshSubscriptionStatus()
-          return
-        }
-
         guard Self.shouldRefreshActiveSubscriptionStatus(
           preloadTask: preloadTask,
           viewModel: viewModel
@@ -863,14 +852,16 @@ struct MediaDetailView: View {
             onSeasonTap: { season in
               let request = SubscribeSeasonRequest(
                 mediaInfo: viewModel.detail,
-                initialSeason: season.season_number
+                initialSeason: season.season_number,
+                initialEpisodeGroup: seasonVM.selectedGroupId
               )
               navigationPath.append(request)
             },
             onMoreTapped: {
               let request = SubscribeSeasonRequest(
                 mediaInfo: viewModel.detail,
-                initialSeason: nil
+                initialSeason: nil,
+                initialEpisodeGroup: seasonVM.selectedGroupId
               )
               navigationPath.append(request)
             }

--- a/MoviePilot-TV/Views/Pages/MediaDetailView.swift
+++ b/MoviePilot-TV/Views/Pages/MediaDetailView.swift
@@ -367,7 +367,9 @@ struct MediaDetailView: View {
       {
         viewModel.isFirstRowReady = true
         Task { @MainActor in
-          await viewModel.refreshSubscriptionStatus()
+          let didRefresh = await viewModel.refreshSubscriptionStatus()
+          hasRefreshedSubscriptionAfterFullDetail =
+            didRefresh || hasRefreshedSubscriptionAfterFullDetail
         }
       }
     }

--- a/MoviePilot-TV/Views/Pages/MediaDetailView.swift
+++ b/MoviePilot-TV/Views/Pages/MediaDetailView.swift
@@ -302,7 +302,18 @@ struct MediaDetailView: View {
       }
     }
     .task(id: preloadTask.partialMedia.id) {
+      // 初次查询失败时借用已有循环最多补偿两次；未订阅内容不会进入常驻轮询。
+      var remainingInitialSubscriptionRefreshAttempts = 2
       await Self.runActiveSubscriptionRefreshLoop {
+        if !hasRefreshedSubscriptionAfterFullDetail,
+          preloadTask.fullDetail != nil,
+          remainingInitialSubscriptionRefreshAttempts > 0
+        {
+          remainingInitialSubscriptionRefreshAttempts -= 1
+          hasRefreshedSubscriptionAfterFullDetail = await viewModel.refreshSubscriptionStatus()
+          return
+        }
+
         guard Self.shouldRefreshActiveSubscriptionStatus(
           preloadTask: preloadTask,
           viewModel: viewModel
@@ -417,8 +428,7 @@ struct MediaDetailView: View {
       return true
     }
 
-    await viewModel.refreshSubscriptionStatus()
-    return true
+    return await viewModel.refreshSubscriptionStatus()
   }
 
   static let activeSubscriptionRefreshIntervalNanoseconds: UInt64 = 60 * 1_000_000_000

--- a/MoviePilot-TV/Views/Pages/RecommendView.swift
+++ b/MoviePilot-TV/Views/Pages/RecommendView.swift
@@ -60,7 +60,11 @@ struct RecommendView: View {
         ResourceResultView(request: request)
       }
       .navigationDestination(for: SubscribeSeasonRequest.self) { request in
-        SubscribeSeasonView(mediaInfo: request.mediaInfo, initialSeason: request.initialSeason)
+        SubscribeSeasonView(
+          mediaInfo: request.mediaInfo,
+          initialSeason: request.initialSeason,
+          initialEpisodeGroup: request.initialEpisodeGroup
+        )
       }
     }
     .mediaSubscriptionAlerts(using: subscriptionHandler, navigationPath: $path)

--- a/MoviePilot-TV/Views/Pages/SearchView.swift
+++ b/MoviePilot-TV/Views/Pages/SearchView.swift
@@ -197,7 +197,11 @@ struct SearchView: View {
         ResourceResultView(request: request)
       }
       .navigationDestination(for: SubscribeSeasonRequest.self) { request in
-        SubscribeSeasonView(mediaInfo: request.mediaInfo, initialSeason: request.initialSeason)
+        SubscribeSeasonView(
+          mediaInfo: request.mediaInfo,
+          initialSeason: request.initialSeason,
+          initialEpisodeGroup: request.initialEpisodeGroup
+        )
       }
       .mediaSubscriptionAlerts(using: subscriptionHandler, navigationPath: $path)
       .sheet(item: $subscriptionHandler.forkSheetRequest) { share in

--- a/MoviePilot-TV/Views/Pages/SubscribeSeasonView.swift
+++ b/MoviePilot-TV/Views/Pages/SubscribeSeasonView.swift
@@ -4,10 +4,17 @@ import SwiftUI
 struct SubscribeSeasonView: View {
   @StateObject private var viewModel: SubscribeSeasonViewModel
 
-  init(mediaInfo: MediaInfo, initialSeason: Int? = nil) {
+  init(
+    mediaInfo: MediaInfo,
+    initialSeason: Int? = nil,
+    initialEpisodeGroup: String? = nil
+  ) {
     _viewModel = StateObject(
       wrappedValue: SubscribeSeasonViewModel(
-        mediaInfo: mediaInfo, initialSeason: initialSeason))
+        mediaInfo: mediaInfo,
+        initialSeason: initialSeason,
+        initialEpisodeGroup: initialEpisodeGroup
+      ))
   }
 
   var body: some View {

--- a/docs/backend-compatibility-tests.md
+++ b/docs/backend-compatibility-tests.md
@@ -103,6 +103,8 @@ xcodebuild test \
 
 `MOVIEPILOT_COMPAT_SIDE_EFFECT_SUBSCRIPTION_LIMIT` 控制订阅测试取几条现有订阅，默认 `3`。`MOVIEPILOT_COMPAT_REORGANIZE_HISTORY_LIMIT` 控制整理测试取几条最近历史，默认 `2`。`MOVIEPILOT_COMPAT_REORGANIZE_CONCURRENT_COUNT` 控制手动重新整理的并发数量，默认 `2`。
 
+订阅状态恢复使用 15 秒清理时限：超过时限后会请求取消，待恢复操作真正结束后报告超期，避免未完成清理与后续副作用步骤或账号切换并发修改状态；这不是强制终止请求的硬超时。
+
 ## 新增测试的副作用规则
 
 新增或修改真实后端兼容测试前，必须先判断它是否会改变真实后端状态或触发后台任务。只读套件只能读取、搜索并解码数据，不能调用订阅搜索、订阅 reset、订阅 update/delete、暂停/恢复、添加/删除下载、手动整理、AI 整理等接口。

--- a/docs/backend-compatibility-tests.md
+++ b/docs/backend-compatibility-tests.md
@@ -92,10 +92,10 @@ xcodebuild test \
 
 如果配置了额外账号，副作用套件也会用每个账号执行同一批流程；这会按账号重复触发真实后台动作。
 
-- `MOVIEPILOT_COMPAT_TEST_SUBSCRIPTION_SEARCH=true`：取现有订阅列表中有 ID 和原始状态的条目，触发订阅搜索；执行后会把订阅恢复为原始状态，包括原本已暂停的 `state=S`。
+- `MOVIEPILOT_COMPAT_TEST_SUBSCRIPTION_SEARCH=true`：取现有订阅列表中有 ID 且 `state=R/S` 的条目，触发订阅搜索；执行后只会把订阅的 `state` 字段写回测试前的值，包括原本已暂停的 `state=S`，已经触发的后台搜索或下载任务无法撤销。
 - `MOVIEPILOT_COMPAT_TEST_SUBSCRIPTION_UPDATE=true`：读取现有订阅详情，然后用原详情原样保存一次，不修改参数。
-- `MOVIEPILOT_COMPAT_TEST_SUBSCRIPTION_PAUSE_RESUME=true`：只取正在订阅的 `state=R` 条目，先暂停为 `S`，再恢复为 `R`；不会把原本已暂停的 `S` 条目恢复。
-- `MOVIEPILOT_COMPAT_TEST_SUBSCRIPTION_RESET_SEARCH=true`：取现有订阅列表中有 ID 和原始状态的条目，重置订阅后立即触发同一条订阅搜索；执行后会把订阅恢复为原始状态，包括原本已暂停的 `state=S`。
+- `MOVIEPILOT_COMPAT_TEST_SUBSCRIPTION_PAUSE_RESUME=true`：取 `state=R/S` 条目并临时切换到另一状态，再写回测试前的状态；原本暂停的 `state=S` 会在测试期间短暂恢复为 `R`，可能参与后台调度。
+- `MOVIEPILOT_COMPAT_TEST_SUBSCRIPTION_RESET_SEARCH=true`：取现有订阅列表中有 ID 且 `state=R/S` 的条目，重置订阅后立即触发同一条订阅搜索；执行后只会把订阅的 `state` 字段写回测试前的值，包括原本已暂停的 `state=S`。reset 清除的已下载/已入库记录无法恢复，search 触发的后台搜索或下载任务也无法撤销。
 - `MOVIEPILOT_COMPAT_TEST_MANUAL_REORGANIZE=true`：取整理历史第一页最近几条，按 TV 端 `ReorganizeForm` 编码后并发触发后台手动重新整理。
 - `MOVIEPILOT_COMPAT_TEST_AI_REORGANIZE=true`：取整理历史第一页最近几条，批量触发 AI 重新整理，并检查返回的进度流。
 


### PR DESCRIPTION
## 修改内容

- 修复共享订阅快照失败时的错误传播：复用同一请求的调用方共同收到该次失败，不再按等待者数量重复请求。
- 订阅查询失败时保留已知状态；操作前无法确认订阅状态时停止操作，详情页只在实际完成查询后标记首次刷新成功，不增加 Web 端没有的自动重试。
- 修复多季电视剧在分季查询尚未建立时误报刷新成功，并在分季数据加载后回写刷新结果。
- 分季订阅导航透传当前剧集组，与 MoviePilot Web v2.14.5 的行为对齐。
- 兼容测试的订阅状态恢复在独立清理任务中执行；超过 15 秒清理时限后请求取消，但仍等待恢复操作结束，避免清理任务逃逸并与后续测试并发修改状态。
- 文档明确 reset/search 不可逆，以及 pause/resume 会短暂处理暂停订阅。
- App 冷启动时刷新持久化用户权限，并立即生成已恢复受限账号的权限警告。
- 资源搜索和聚合搜索统一使用请求代际安全收尾，避免会话变化后永久停在 Loading。

## 根因

订阅快照清理发生在 revision 判断之前；部分查询错误被当成明确的 `false`；详情预加载可能在分季查询尚未建立时误报刷新成功；搜索 Loading 只在正常完成路径收尾；持久化用户权限此前只在版本迁移时刷新。

## 范围边界

- 不处理 App 运行期间的权限动态变化，也未修改 Explore、Home 或真实后端兼容权限矩阵。
- 不为 MoviePilot 后端增加 Web 端不具备的自动重试或差异化容错。
- 15 秒是清理时限诊断，不是强制终止请求的硬超时；测试会等待恢复操作真正结束后再继续。
- reset/search 的不可逆副作用仅在文档中明确说明。

## 验证

- Xcode 依赖解析通过。
- Apple TV（tvOS 26.5）Simulator clean build 通过。
- 兼容清理定向测试 2/2 通过。
- 完整串行测试 322/322 通过。
- 真实后端只读与副作用兼容套件随完整测试执行并通过。
- `git diff --check` 通过。