### PR TITLE
[AI] feat/tmdb: 预加载详情并复用源海报

### DIFF
--- a/MoviePilot-TV-Tests/TMDBDetailPreloadTests.swift
+++ b/MoviePilot-TV-Tests/TMDBDetailPreloadTests.swift
@@ -48,7 +48,7 @@ final class TMDBDetailPreloadTests: XCTestCase {
   }
 
   @MainActor
-  func testTMDBPreloadTargetRequiresSettingSourceAndRecognizedID() {
+  func testTMDBPreloadTargetRequiresSettingSourceAndSettledDetail() {
     let douban = MediaInfo(
       douban_id: "1295644",
       title: "这个杀手不太冷",
@@ -59,32 +59,30 @@ final class TMDBDetailPreloadTests: XCTestCase {
     XCTAssertNil(
       MediaDetailContainerView.tmdbPreloadTarget(
         for: douban,
-        tmdbId: 101,
+        fullDetail: douban,
+        recognizedTmdbId: 101,
+        didFailToLoadDetail: false,
         isEnabled: false
       )
     )
     XCTAssertNil(
       MediaDetailContainerView.tmdbPreloadTarget(
         for: douban,
-        tmdbId: nil,
+        fullDetail: nil,
+        recognizedTmdbId: 101,
+        didFailToLoadDetail: false,
         isEnabled: true
       )
     )
     XCTAssertNil(
       MediaDetailContainerView.tmdbPreloadTarget(
         for: MediaInfo(tmdb_id: 101, title: "TMDB", type: "电影"),
-        tmdbId: 101,
+        fullDetail: MediaInfo(tmdb_id: 101, title: "TMDB", type: "电影"),
+        recognizedTmdbId: 101,
+        didFailToLoadDetail: false,
         isEnabled: true
       )
     )
-
-    let target = MediaDetailContainerView.tmdbPreloadTarget(
-      for: douban,
-      tmdbId: 101,
-      isEnabled: true
-    )
-    XCTAssertEqual(target?.tmdb_id, 101)
-    XCTAssertNil(target?.poster_path)
 
     let bangumi = MediaInfo(
       bangumi_id: 265,
@@ -94,11 +92,45 @@ final class TMDBDetailPreloadTests: XCTestCase {
     )
     let bangumiTarget = MediaDetailContainerView.tmdbPreloadTarget(
       for: bangumi,
-      tmdbId: 890,
+      fullDetail: nil,
+      recognizedTmdbId: 890,
+      didFailToLoadDetail: true,
       isEnabled: true
     )
     XCTAssertEqual(bangumiTarget?.tmdb_id, 890)
     XCTAssertNil(bangumiTarget?.poster_path)
+  }
+
+  @MainActor
+  func testTMDBPreloadUsesFullDetailIDAndMatchesJumpTarget() {
+    let source = MediaInfo(
+      douban_id: "1295644",
+      title: "旧标题",
+      year: "2023"
+    )
+    let fullDetail = MediaInfo(
+      tmdb_id: 101,
+      douban_id: "1295644",
+      title: "完整标题",
+      type: "电视剧",
+      year: "2024",
+      season: 1
+    )
+
+    let preloadTarget = MediaDetailContainerView.tmdbPreloadTarget(
+      for: source,
+      fullDetail: fullDetail,
+      recognizedTmdbId: nil,
+      didFailToLoadDetail: false,
+      isEnabled: true
+    )
+    let jumpTarget = MediaActionHandler.tmdbJumpTarget(for: fullDetail, tmdbId: 101)
+
+    XCTAssertEqual(preloadTarget?.id, jumpTarget.id)
+    XCTAssertEqual(preloadTarget?.title, jumpTarget.title)
+    XCTAssertEqual(preloadTarget?.type, jumpTarget.type)
+    XCTAssertEqual(preloadTarget?.year, jumpTarget.year)
+    XCTAssertEqual(preloadTarget?.season, jumpTarget.season)
   }
 
   func testSystemViewExposesTMDBPreloadToggleAndDescription() throws {

--- a/MoviePilot-TV-Tests/TMDBDetailPreloadTests.swift
+++ b/MoviePilot-TV-Tests/TMDBDetailPreloadTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+
+@testable import MoviePilot_TV
+
+final class TMDBDetailPreloadTests: XCTestCase {
+  private let settingKey = "preloadTMDBDetails"
+
+  @MainActor
+  func testPreloadSettingDefaultsOnAndPersistsChanges() {
+    let originalValue = UserDefaults.standard.object(forKey: settingKey)
+    defer {
+      if let originalValue {
+        UserDefaults.standard.set(originalValue, forKey: settingKey)
+      } else {
+        UserDefaults.standard.removeObject(forKey: settingKey)
+      }
+    }
+
+    UserDefaults.standard.removeObject(forKey: settingKey)
+    let viewModel = SystemViewModel()
+
+    XCTAssertTrue(viewModel.preloadTMDBDetails)
+    XCTAssertTrue(SystemViewModel.shouldPreloadTMDBDetails)
+
+    viewModel.preloadTMDBDetails = false
+    XCTAssertFalse(SystemViewModel.shouldPreloadTMDBDetails)
+  }
+
+  @MainActor
+  func testTMDBJumpTargetKeepsImagesOutOfPartialObjectAndPassesPosterToTransition() async {
+    let source = MediaInfo(
+      douban_id: "1295644",
+      title: "这个杀手不太冷",
+      type: "电影",
+      poster_path: "https://example.com/douban-poster.jpg",
+      backdrop_path: "https://example.com/douban-backdrop.jpg"
+    )
+
+    MediaCardTransition.loadingPosterURL = nil
+    defer { MediaCardTransition.loadingPosterURL = nil }
+
+    let target = await MediaActionHandler().getTMDBJumpTarget(for: source, targetTmdbId: 101)
+
+    XCTAssertEqual(target?.tmdb_id, 101)
+    XCTAssertNil(target?.poster_path)
+    XCTAssertNil(target?.backdrop_path)
+    XCTAssertEqual(MediaCardTransition.loadingPosterURL, source.imageURLs.poster)
+  }
+
+  @MainActor
+  func testTMDBPreloadTargetRequiresSettingSourceAndRecognizedID() {
+    let douban = MediaInfo(
+      douban_id: "1295644",
+      title: "这个杀手不太冷",
+      type: "电影",
+      poster_path: "https://example.com/douban-poster.jpg"
+    )
+
+    XCTAssertNil(
+      MediaDetailContainerView.tmdbPreloadTarget(
+        for: douban,
+        tmdbId: 101,
+        isEnabled: false
+      )
+    )
+    XCTAssertNil(
+      MediaDetailContainerView.tmdbPreloadTarget(
+        for: douban,
+        tmdbId: nil,
+        isEnabled: true
+      )
+    )
+    XCTAssertNil(
+      MediaDetailContainerView.tmdbPreloadTarget(
+        for: MediaInfo(tmdb_id: 101, title: "TMDB", type: "电影"),
+        tmdbId: 101,
+        isEnabled: true
+      )
+    )
+
+    let target = MediaDetailContainerView.tmdbPreloadTarget(
+      for: douban,
+      tmdbId: 101,
+      isEnabled: true
+    )
+    XCTAssertEqual(target?.tmdb_id, 101)
+    XCTAssertNil(target?.poster_path)
+
+    let bangumi = MediaInfo(
+      bangumi_id: 265,
+      title: "新世纪福音战士",
+      type: "电视剧",
+      poster_path: "https://example.com/bangumi-poster.jpg"
+    )
+    let bangumiTarget = MediaDetailContainerView.tmdbPreloadTarget(
+      for: bangumi,
+      tmdbId: 890,
+      isEnabled: true
+    )
+    XCTAssertEqual(bangumiTarget?.tmdb_id, 890)
+    XCTAssertNil(bangumiTarget?.poster_path)
+  }
+
+  func testSystemViewExposesTMDBPreloadToggleAndDescription() throws {
+    let testFileURL = URL(fileURLWithPath: #filePath)
+    let repositoryRoot = testFileURL.deletingLastPathComponent().deletingLastPathComponent()
+    let source = try String(
+      contentsOf: repositoryRoot.appendingPathComponent("MoviePilot-TV/Views/Pages/SystemView.swift")
+    )
+
+    XCTAssertTrue(source.contains("预加载 TMDB 详情"))
+    XCTAssertTrue(source.contains("viewModel.preloadTMDBDetails"))
+    XCTAssertTrue(source.contains("case .preloadTMDBDetails:"))
+  }
+}

--- a/MoviePilot-TV/ViewModels/MediaActionHandler.swift
+++ b/MoviePilot-TV/ViewModels/MediaActionHandler.swift
@@ -46,6 +46,12 @@ class MediaActionHandler: ObservableObject {
       return nil
     }
 
+    // 海报只供本次加载过渡使用，不写入 TMDB 导航用的部分对象。
+    MediaCardTransition.loadingPosterURL = item.imageURLs.poster
+    return Self.tmdbJumpTarget(for: item, tmdbId: tmdbId)
+  }
+
+  static func tmdbJumpTarget(for item: MediaInfo, tmdbId: Int) -> MediaInfo {
     return MediaInfo(
       tmdb_id: tmdbId,
       douban_id: nil,
@@ -66,6 +72,8 @@ class MediaActionHandler: ObservableObject {
       // 此处创建的 MediaInfo 是一个用于导航的“部分对象”。
       // 如果保留旧的 poster/backdrop 路径，新页面在加载完成前会短暂显示旧页面的图像，导致闪烁。
       // 将其设为 nil 可确保新页面在获取到自己的完整详情前不显示任何背景。
+      // 加载动画需要复用源海报时，必须通过 MediaCardTransition.loadingPosterURL 单独传递。
+      // 禁止为复用加载海报而修改这里的 nil，否则会重新引入旧图闪烁。
       poster_path: nil,
       backdrop_path: nil,
       overview: item.overview,

--- a/MoviePilot-TV/ViewModels/SystemViewModel.swift
+++ b/MoviePilot-TV/ViewModels/SystemViewModel.swift
@@ -34,12 +34,20 @@ class SystemViewModel: ObservableObject {
   // MARK: - 详情页设置
 
   private static let waitMediaDetailBackgroundImageKey = "waitMediaDetailBackgroundImage"
+  private static let preloadTMDBDetailsKey = "preloadTMDBDetails"
   private static let autoSearchNewSubscriptionsKey = "autoSearchNewSubscriptions"
 
   /// 是否在 MediaDetail 首屏等待背景/海报预加载完成。默认开启。
   @Published var waitMediaDetailBackgroundImage: Bool = true {
     didSet {
       UserDefaults.standard.set(waitMediaDetailBackgroundImage, forKey: Self.waitMediaDetailBackgroundImageKey)
+    }
+  }
+
+  /// 是否在豆瓣/Bangumi 详情识别完成后预加载对应 TMDB 详情。默认开启。
+  @Published var preloadTMDBDetails: Bool = true {
+    didSet {
+      UserDefaults.standard.set(preloadTMDBDetails, forKey: Self.preloadTMDBDetailsKey)
     }
   }
 
@@ -142,6 +150,7 @@ class SystemViewModel: ObservableObject {
 
   init() {
     waitMediaDetailBackgroundImage = Self.shouldWaitMediaDetailBackgroundImage
+    preloadTMDBDetails = Self.shouldPreloadTMDBDetails
     autoSearchNewSubscriptions = Self.shouldAutoSearchNewSubscriptions
     checkKeychainStatus()
   }
@@ -383,6 +392,13 @@ class SystemViewModel: ObservableObject {
       return true
     }
     return UserDefaults.standard.bool(forKey: waitMediaDetailBackgroundImageKey)
+  }
+
+  static var shouldPreloadTMDBDetails: Bool {
+    guard UserDefaults.standard.object(forKey: preloadTMDBDetailsKey) != nil else {
+      return true
+    }
+    return UserDefaults.standard.bool(forKey: preloadTMDBDetailsKey)
   }
 
   static var shouldAutoSearchNewSubscriptions: Bool {

--- a/MoviePilot-TV/Views/Components/MediaCard.swift
+++ b/MoviePilot-TV/Views/Components/MediaCard.swift
@@ -487,8 +487,11 @@ struct DetailCardView: View, Equatable {
 
 /// 存储最后一次点击的 MediaCard 海报在屏幕上的 frame，
 /// 供 MediaDetailContainerView 的加载动画作为起始位置使用。
+/// 同时保存本次 TMDB 跳转加载动画需要复用的源海报 URL。
 @MainActor
 enum MediaCardTransition {
   /// 最后一次点击的卡片海报在屏幕坐标系中的 frame（已包含焦点缩放）
   static var sourceFrame: CGRect = .zero
+  /// 仅供本次详情页加载动画使用的源海报
+  static var loadingPosterURL: URL?
 }

--- a/MoviePilot-TV/Views/Pages/MediaDetailContainerView.swift
+++ b/MoviePilot-TV/Views/Pages/MediaDetailContainerView.swift
@@ -210,19 +210,22 @@ struct MediaDetailContainerView: View {
 
   @MainActor
   static func tmdbPreloadTarget(
-    for media: MediaInfo,
-    tmdbId: Int?,
+    for sourceMedia: MediaInfo,
+    fullDetail: MediaInfo?,
+    recognizedTmdbId: Int?,
+    didFailToLoadDetail: Bool,
     isEnabled: Bool = SystemViewModel.shouldPreloadTMDBDetails
   ) -> MediaInfo? {
     guard isEnabled,
-      media.tmdb_id == nil,
-      media.douban_id != nil || media.bangumi_id != nil,
-      let tmdbId
+      sourceMedia.tmdb_id == nil,
+      sourceMedia.douban_id != nil || sourceMedia.bangumi_id != nil,
+      let jumpSource = fullDetail ?? (didFailToLoadDetail ? sourceMedia : nil),
+      let tmdbId = recognizedTmdbId ?? fullDetail?.tmdb_id
     else {
       return nil
     }
 
-    return MediaActionHandler.tmdbJumpTarget(for: media, tmdbId: tmdbId)
+    return MediaActionHandler.tmdbJumpTarget(for: jumpSource, tmdbId: tmdbId)
   }
 
   var body: some View {
@@ -277,6 +280,15 @@ private struct MediaDetailContainerContent: View {
       || preloadTask.isDetailFailed
   }
 
+  private var tmdbPreloadTarget: MediaInfo? {
+    MediaDetailContainerView.tmdbPreloadTarget(
+      for: media,
+      fullDetail: preloadTask.fullDetail,
+      recognizedTmdbId: preloadTask.tmdbId,
+      didFailToLoadDetail: preloadTask.isDetailFailed
+    )
+  }
+
   var body: some View {
     // ⚠️ 焦点恢复核心设计：
     // MediaDetailView 无条件渲染（从第一帧就存在），用 partialMedia 初始化。
@@ -321,14 +333,8 @@ private struct MediaDetailContainerContent: View {
         }
       }
     }
-    .task(id: preloadTask.tmdbId) {
-      guard
-        let target = MediaDetailContainerView.tmdbPreloadTarget(
-          for: media,
-          tmdbId: preloadTask.tmdbId
-        )
-      else { return }
-
+    .task(id: tmdbPreloadTarget?.id) {
+      guard let target = tmdbPreloadTarget else { return }
       MediaPreloader.shared.preload(for: target)
     }
   }

--- a/MoviePilot-TV/Views/Pages/MediaDetailContainerView.swift
+++ b/MoviePilot-TV/Views/Pages/MediaDetailContainerView.swift
@@ -125,8 +125,9 @@ private struct MediaLoadingView: View {
       hasAnimated = true
 
       let source = MediaCardTransition.sourceFrame
-      // 清除源 frame，防止预加载命中或后续入口复用脏数据
+      // 清除本次过渡数据，防止预加载命中或后续入口复用脏数据
       MediaCardTransition.sourceFrame = .zero
+      MediaCardTransition.loadingPosterURL = nil
 
       // 数据已预加载完毕，跳过所有动画
       guard !isAlreadyLoaded else {
@@ -207,6 +208,23 @@ struct MediaDetailContainerView: View {
     _preloadTask = State(wrappedValue: MediaPreloader.shared.preload(for: media))
   }
 
+  @MainActor
+  static func tmdbPreloadTarget(
+    for media: MediaInfo,
+    tmdbId: Int?,
+    isEnabled: Bool = SystemViewModel.shouldPreloadTMDBDetails
+  ) -> MediaInfo? {
+    guard isEnabled,
+      media.tmdb_id == nil,
+      media.douban_id != nil || media.bangumi_id != nil,
+      let tmdbId
+    else {
+      return nil
+    }
+
+    return MediaActionHandler.tmdbJumpTarget(for: media, tmdbId: tmdbId)
+  }
+
   var body: some View {
     // 直接传入 preloadTask（非 Optional，无条件分支）
     MediaDetailContainerContent(
@@ -235,6 +253,8 @@ private struct MediaDetailContainerContent: View {
   @State private var isContentReady = false
   /// 记录首次出现时数据是否已预加载完毕（在 init 中设置，确保第一帧就生效）
   @State private var wasPreloaded: Bool
+  /// 记录进入页面时的加载海报，避免清除全局过渡状态后图片消失
+  @State private var loadingPosterURL: URL?
   /// 最短展示时间是否已过（防止加载太快导致动画闪烁）
   @State private var minTimeElapsed = false
 
@@ -244,6 +264,9 @@ private struct MediaDetailContainerContent: View {
     self.preloadTask = preloadTask
     // 在 init 中判断，确保第一帧 isReady 就正确
     _wasPreloaded = State(initialValue: preloadTask.isDetailReady)
+    _loadingPosterURL = State(
+      initialValue: MediaCardTransition.loadingPosterURL ?? media.imageURLs.poster
+    )
   }
 
   /// 数据是否就绪（加载成功或失败均算就绪，且首行内容已加载）
@@ -275,7 +298,7 @@ private struct MediaDetailContainerContent: View {
       // Loading 遮罩层 — 始终存在于视图树中，通过 opacity 控制显隐
       MediaLoadingView(
         title: media.cleanedTitle ?? media.title,
-        posterUrl: media.imageURLs.poster,
+        posterUrl: loadingPosterURL,
         type: media.type,
         year: media.year,
         rating: media.vote_average,
@@ -297,6 +320,16 @@ private struct MediaDetailContainerContent: View {
           }
         }
       }
+    }
+    .task(id: preloadTask.tmdbId) {
+      guard
+        let target = MediaDetailContainerView.tmdbPreloadTarget(
+          for: media,
+          tmdbId: preloadTask.tmdbId
+        )
+      else { return }
+
+      MediaPreloader.shared.preload(for: target)
     }
   }
 }

--- a/MoviePilot-TV/Views/Pages/SystemView.swift
+++ b/MoviePilot-TV/Views/Pages/SystemView.swift
@@ -196,6 +196,16 @@ struct SystemView: View {
 
       section("详情页") {
         Toggle(
+          "预加载 TMDB 详情",
+          isOn: Binding(
+            get: { viewModel.preloadTMDBDetails },
+            set: { viewModel.preloadTMDBDetails = $0 }
+          )
+        )
+        .font(.body.weight(.semibold))
+        .focused($focusedItem, equals: .preloadTMDBDetails)
+
+        Toggle(
           "等待背景海报加载",
           isOn: Binding(
             get: { viewModel.waitMediaDetailBackgroundImage },
@@ -592,6 +602,8 @@ struct SystemView: View {
         return "新增订阅后立即开始搜索，无需等待 MoviePilot 稍后自动处理。（只影响 TV 端）"
       case .waitBackgroundImage:
         return "进入媒体详情页前的加载动画会等待背景海报就绪实现平滑过渡，网络较慢时可关闭以更快进入详情页。（只影响 TV 端）"
+      case .preloadTMDBDetails:
+        return "进入豆瓣或 Bangumi 详情页并识别到对应 TMDB 条目后，提前加载其详情，以缩短后续跳转等待时间。（只影响 TV 端）"
       case .siteSelection:
         return "设置资源搜索默认使用的站点。（只影响 TV 端）"
       case .hardFilter:
@@ -685,6 +697,7 @@ private enum SystemSettingsFocus: Hashable {
   case site(Int)
   case appInfo
   case autoSearch
+  case preloadTMDBDetails
   case waitBackgroundImage
   case hardFilter
   case softFilter


### PR DESCRIPTION
## 改动内容

- 豆瓣、Bangumi 跳转 TMDB 详情页时，加载动画复用来源竖向海报。
- TMDB 导航部分对象继续保持 `poster_path` 和 `backdrop_path` 为空，加载海报通过独立的过渡状态传递，避免旧来源图片在详情层闪烁。
- 豆瓣、Bangumi 详情识别到 TMDB ID 后立即预加载 TMDB 详情。
- 设置页新增“预加载 TMDB 详情”开关，默认开启。
- 覆盖详情页按钮和卡片长按菜单跳转，并补充回归测试。

## 根因

TMDB 跳转使用的部分对象按设计不携带图片路径，而加载遮罩直接读取该对象的海报，因此冷加载时只能显示黑色占位图。现在复用现有过渡状态单独传递来源海报，不改变部分对象的防闪烁语义。

## 验证

- `xcodebuild` 针对性测试：通过
- tvOS Simulator Clean Build：通过
- tvOS Simulator 完整串行测试：通过
- `git diff --check`：通过