### PR TITLE
[AI] fix/detail: 结束 TMDB 识别失败后的加载状态

### DIFF
--- a/MoviePilot-TV-Tests/MediaPreloadPermissionTests.swift
+++ b/MoviePilot-TV-Tests/MediaPreloadPermissionTests.swift
@@ -109,7 +109,7 @@ final class MediaPreloadPermissionTests: XCTestCase {
     XCTAssertFalse(paths.contains { $0.hasPrefix("/api/v1/subscribe/media/") })
   }
 
-  func testFailedTMDBRecognitionFinishesLoadingState() async throws {
+  func testFailedTMDBRecognitionFromFallbackSourceFinishesLoadingState() async throws {
     XCTAssertTrue(URLProtocol.registerClass(MediaPreloadPermissionURLProtocol.self))
     defer { URLProtocol.unregisterClass(MediaPreloadPermissionURLProtocol.self) }
 
@@ -122,7 +122,8 @@ final class MediaPreloadPermissionTests: XCTestCase {
 
     let task = MediaPreloadTask(
       partialMedia: MediaInfo(
-        bangumi_id: 987,
+        mediaid_prefix: "bangumi",
+        media_id: "987",
         title: "无法识别的 Bangumi 条目",
         type: "电视剧"
       )
@@ -131,10 +132,11 @@ final class MediaPreloadPermissionTests: XCTestCase {
     defer { task.cancel() }
 
     try await waitUntil("TMDB recognition finishes") {
-      task.isTmdbRecognitionFinished
+      task.isTmdbRecognitionFinished && task.isDetailReady
     }
 
     XCTAssertNil(task.tmdbId)
+    XCTAssertEqual(task.fullDetail?.bangumi_id, 987)
   }
 
   func testSubscriptionHandlerDoesNotOpenSheetWhenLookupFails() async throws {
@@ -776,6 +778,8 @@ private final class MediaPreloadPermissionURLProtocolStub: @unchecked Sendable {
       return (200, jsonData(#"{"tmdb_id":123,"title":"Limited Show","type":"电视剧"}"#))
     case "/api/v1/media/tmdb:456":
       return (200, jsonData(#"{"tmdb_id":456,"title":"Limited Movie","type":"电影"}"#))
+    case "/api/v1/media/bangumi:987":
+      return (200, jsonData(#"{"bangumi_id":987,"title":"无法识别的 Bangumi 条目","type":"电视剧"}"#))
     case "/api/v1/media/groups/123",
       "/api/v1/media/seasons",
       "/api/v1/subscribe/":

--- a/MoviePilot-TV-Tests/MediaPreloadPermissionTests.swift
+++ b/MoviePilot-TV-Tests/MediaPreloadPermissionTests.swift
@@ -109,6 +109,34 @@ final class MediaPreloadPermissionTests: XCTestCase {
     XCTAssertFalse(paths.contains { $0.hasPrefix("/api/v1/subscribe/media/") })
   }
 
+  func testFailedTMDBRecognitionFinishesLoadingState() async throws {
+    XCTAssertTrue(URLProtocol.registerClass(MediaPreloadPermissionURLProtocol.self))
+    defer { URLProtocol.unregisterClass(MediaPreloadPermissionURLProtocol.self) }
+
+    let service = APIService.shared
+    let snapshot = MediaPreloadPermissionServiceSnapshot.capture(service: service)
+    defer { snapshot.restore(to: service) }
+
+    MediaPreloadPermissionURLProtocol.stub.reset()
+    configureLimitedUser(service)
+
+    let task = MediaPreloadTask(
+      partialMedia: MediaInfo(
+        bangumi_id: 987,
+        title: "无法识别的 Bangumi 条目",
+        type: "电视剧"
+      )
+    )
+    task.start()
+    defer { task.cancel() }
+
+    try await waitUntil("TMDB recognition finishes") {
+      task.isTmdbRecognitionFinished
+    }
+
+    XCTAssertNil(task.tmdbId)
+  }
+
   func testSubscriptionHandlerDoesNotOpenSheetWhenLookupFails() async throws {
     XCTAssertTrue(URLProtocol.registerClass(MediaPreloadPermissionURLProtocol.self))
     defer { URLProtocol.unregisterClass(MediaPreloadPermissionURLProtocol.self) }

--- a/MoviePilot-TV/ViewModels/MediaPreloader.swift
+++ b/MoviePilot-TV/ViewModels/MediaPreloader.swift
@@ -50,9 +50,10 @@ class MediaPreloadTask: ObservableObject {
       Task {
         // ⑤ TMDB 识别 — 必须先于 checkSubscription 完成，否则 fallback 查询会因 tmdbId 为 nil 而跳过
         // 与 loadDetail 并发启动（两者互不依赖），但都在依赖任务之前完成
+        let sourcePrefix = MediaIdentifier.mediaIdComponents(self.partialMedia.apiMediaId)?.prefix
         async let tmdbRecognition: Void = {
           if self.partialMedia.tmdb_id == nil
-            && (self.partialMedia.douban_id != nil || self.partialMedia.bangumi_id != nil)
+            && (sourcePrefix == "douban" || sourcePrefix == "bangumi")
           {
             await self.recognizeTmdb()
           }

--- a/MoviePilot-TV/ViewModels/MediaPreloader.swift
+++ b/MoviePilot-TV/ViewModels/MediaPreloader.swift
@@ -18,6 +18,7 @@ class MediaPreloadTask: ObservableObject {
 
   // 可选预加载数据（持久存在，加载完直接显示）
   @Published var tmdbId: Int?
+  @Published var isTmdbRecognitionFinished = false
   @Published var isSubscribed: Bool?
   @Published var seasonViewModel: SubscribeSeasonViewModel?
   /// 分季数据是否已实际加载完毕（seasonViewModel 创建时 isLoading=true，loadData 完成后才设为 true）
@@ -244,6 +245,7 @@ class MediaPreloadTask: ObservableObject {
   // MARK: - ⑤ TMDB 识别
 
   private func recognizeTmdb() async {
+    defer { isTmdbRecognitionFinished = true }
     let result = await APIService.shared.recognizeTmdbId(
       title: partialMedia.title ?? "",
       year: partialMedia.year,

--- a/MoviePilot-TV/Views/Pages/MediaDetailView.swift
+++ b/MoviePilot-TV/Views/Pages/MediaDetailView.swift
@@ -679,7 +679,8 @@ struct MediaDetailView: View {
             // TMDB Jump Button — 复用 MediaActionHandler 逻辑，传入预加载的 tmdbId
             if canJumpToTMDB {
               let targetTmdbId = preloadTask.tmdbId ?? viewModel.detail.tmdb_id
-              let isButtonLoading = targetTmdbId == nil
+              let isButtonLoading =
+                targetTmdbId == nil && !preloadTask.isTmdbRecognitionFinished
 
               Button(action: {
                 Task {


### PR DESCRIPTION
## 变更

- 为 TMDB 预加载识别补充明确的完成状态，空结果也会结束加载。
- 详情页按钮只在识别尚未完成时显示转圈；失败后恢复可点击，并沿用现有实时重试与失败提示。
- 新增 Bangumi 条目识别失败的回归测试。

## 根因

详情页原先直接用 `tmdbId == nil` 判断加载中，无法区分“仍在识别”和“识别已失败”，因此失败返回 `nil` 后按钮会永久转圈。

## 用户影响

Bangumi 或豆瓣条目未能识别到匹配 TMDB 条目时，TMDB 详情页按钮不再永久停留在加载状态，用户可以再次点击重试。

## 验证

- `xcodebuild -resolvePackageDependencies -project MoviePilot-TV.xcodeproj -scheme MoviePilot-TV -skipPackagePluginValidation`
- `xcodebuild clean build -project MoviePilot-TV.xcodeproj -scheme MoviePilot-TV -configuration Debug -destination 'platform=tvOS Simulator,name=Apple TV' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -skipPackagePluginValidation`
- `xcodebuild test -project MoviePilot-TV.xcodeproj -scheme MoviePilot-TV -configuration Debug -destination 'platform=tvOS Simulator,name=Apple TV' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -skipPackagePluginValidation`：329 项测试全部通过。