### PR TITLE
[AI] feat/changelog: 增加版本更新历史与升级提示

### DIFF
--- a/.agents/prompts/release.md
+++ b/.agents/prompts/release.md
@@ -12,10 +12,11 @@
 2. Release Notes 必须先给用户确认。用户确认前，禁止创建 GitHub Release。
 3. 禁止用 `swift build`、`swift test` 或 `swift package resolve` 冒充本项目验证。
 4. 禁止把未完成、未合并、未验证的内容写进 Release Notes。
-5. Release Notes 必须使用本文固定格式，不要临场模仿其他格式。
-6. AI 不得为了“完成任务”而跳过 Release Notes 用户确认；发布动作必须是用户确认 Release Notes 之后的第二步。
+5. Release Notes 必须使用本文固定格式，并与代码内对应版本的 Changelog 内容一致，不要临场模仿或二次改写。
+6. AI 不得为了“完成任务”而跳过 Changelog 内容确认、代码合并和正式发布确认；GitHub 发布动作必须发生在对应条目已合并且用户再次明确确认正式发布之后。
 7. 发布版本号必须同时同步 README 与 Xcode 工程版本号，不能只改其中一个。
 8. 正式发布是 `AGENTS.md` Git 工作流的唯一例外：用户确认 Release Notes 并明确允许 commit、Push 后，必须确认本地 `main` 与远端 `main` 一致，然后直接提交并推送 `main`，不要创建发布分支或 Pull Request。该例外不适用于其他任务。
+9. `MoviePilot-TV/Models/AppChangelog.swift` 是版本说明的单一事实来源。新版本必须先在普通功能分支写入并经用户确认、验证、推送和合并，之后才能进入正式发布；这些 Git 动作仍分别需要用户明确授权。
 
 ## 发布模式判断
 
@@ -27,8 +28,11 @@
 2. 检查版本号格式。
 3. 检查现有版本记录是否已有同名版本。
 4. 收集从上一个版本到当前发布目标分支的变更。
-5. 按本文固定格式生成 Release Notes 草稿。
+5. 按本文固定格式生成 Changelog 草稿；`更新内容` 标题下最前面的摘要条目用于弹窗，后续小节是完整说明。
 6. 将草稿发给用户确认。
+7. 用户确认内容后，在普通 `ai/xxx` 分支把该版本作为 `AppChangelog.entries` 的第一项写入代码，并补充或更新测试。
+8. 按 `AGENTS.md` 完成验证；commit、Push、创建 PR 和合并都必须分别取得用户明确授权。
+9. Changelog 改动未合并到 `main` 前，不得进入正式发布。
 
 准备发布阶段不得创建 GitHub Release。
 
@@ -55,6 +59,11 @@
    - 两处 `MARKETING_VERSION` 必须改为不带 `v` 的版本号，例如发布 `v0.3.1` 时写 `0.3.1`。
    - 默认不要修改 `CURRENT_PROJECT_VERSION`，除非用户明确要求递增 build number。
    - 不要修改 `MoviePilot-TV-Tests` test target 的 `MARKETING_VERSION = 1.0`。
+3. `MoviePilot-TV/Models/AppChangelog.swift`
+   - 对应版本条目必须已经作为第一项合并到 `main`。
+   - `version` 必须与发布版本号完全一致，`releaseDate` 使用发布日期。
+   - `compatibleMoviePilotVersion` 必须与该版本实际兼容基线一致。
+   - 不要在正式发布阶段临时改写已确认的 `highlights`、`updates`、`fixes` 或 `optimizations`。
 
 ## Release Notes 固定格式
 
@@ -65,30 +74,45 @@ Release Notes 必须使用下面的固定 Markdown 格式。不得自行更改�
 
 - ...
 
-## 修复
+### 新增功能
 
 - ...
 
-## 优化
+### 修复
+
+- ...
+
+### 优化
 
 - ...
 ```
 
+代码字段与 Markdown 内容固定对应：`highlights` → `更新内容` 标题下最前面的摘要条目、`updates` → `新增功能`、`fixes` → `修复`、`optimizations` → `优化`。GitHub Release Notes 必须从已合并的对应 `AppChangelogEntry` 逐项复制，保持文字和顺序一致。
+
 ## 小节写法
 
-### `## 更新内容`
+### `## 更新内容` 下的摘要
+
+这是新版本首次进入设置页时弹窗显示的唯一内容，必须简短并满足：
+
+1. 只有兼容 MoviePilot 后端基线相对上一发布版本发生变化时，才写一条 `兼容 MoviePilot 后端 vX.Y.Z。`；基线未变化时省略。首个版本的初始兼容基线只保留在版本信息中，不作为摘要更新。
+2. 只写用户容易感知的新功能、重大体验或性能优化、重大 Bug 修复。
+3. 不写小角标、小范围样式调整、内部重构、测试、Prompt、工作流等细节。
+4. 每条只概括结果，具体行为和修复范围写在后面的完整小节。
+
+### `### 新增功能`
 
 写用户可感知的新功能、新页面、新交互或重要能力。
 
 不要把内部 Prompt、Agent 工作流、代码审查规则等包装成普通用户功能。如果本次只是内部维护、文档、CI 或发布流程调整，没有用户可感知新能力，可以省略本节。
 
-### `## 修复`
+### `### 修复`
 
 写明确修复的 Bug、崩溃、状态错误、接口异常、焦点问题、订阅状态错误等。
 
 必须基于已经合并到发布目标分支的提交，不得写待办或猜测。
 
-### `## 优化`
+### `### 优化`
 
 写性能优化、体验优化、代码结构优化、稳定性增强等。
 
@@ -96,9 +120,10 @@ Release Notes 必须使用下面的固定 Markdown 格式。不得自行更改�
 
 ## 空小节规则
 
-1. `## 更新内容`、`## 修复`、`## 优化` 如果确实没有内容，可以省略整个小节。
-2. 不允许保留空标题。
-3. 不要写“无”。
+1. `## 更新内容` 不得省略；标题下最前面的摘要不得为空。兼容基线未变化时，不要为了满足格式添加兼容说明。
+2. `### 新增功能`、`### 修复`、`### 优化` 如果确实没有内容，可以省略整个小节。
+3. 不允许保留空标题。
+4. 不要写“无”。
 
 ## 草稿确认规则
 
@@ -118,9 +143,11 @@ Release Notes 必须使用下面的固定 Markdown 格式。不得自行更改�
 5. CI 是否通过。
 6. README Release 徽章和安装示例 tag 是否已经同步到用户提供的版本号。
 7. `MoviePilot-TV` App target 的 Debug / Release `MARKETING_VERSION` 是否已经同步到用户提供的不带 `v` 版本号。
-8. 如果运行在真实 Mac/Xcode 环境，必须按 `AGENTS.md` 的标准 `xcodebuild` 命令完成本地构建/测试。
-9. 如果运行在非真实开发环境，必须说明无法本地测试，并确认 GitHub Actions 或真实 Mac/Xcode 环境已经完成验证。
-10. 如果检查失败，必须停止发布，并向用户列出阻塞项。
+8. `main` 中是否已有版本号、发布日期和兼容后端版本一致的 `AppChangelogEntry`，且更新摘要和完整小节已经用户确认。
+9. GitHub Release Notes 草稿是否逐项复用了该条目，而不是重新从提交记录生成。
+10. 如果运行在真实 Mac/Xcode 环境，必须按 `AGENTS.md` 的标准 `xcodebuild` 命令完成本地构建/测试。
+11. 如果运行在非真实开发环境，必须说明无法本地测试，并确认 GitHub Actions 或真实 Mac/Xcode 环境已经完成验证。
+12. 如果检查失败，必须停止发布，并向用户列出阻塞项。
 
 ## 本项目发布事实
 
@@ -140,11 +167,12 @@ Release Notes 必须使用下面的固定 Markdown 格式。不得自行更改�
 ## 正式发布步骤
 
 1. 确认用户已提供版本号。
-2. 确认 README 与 Xcode 工程版本号已同步。
-3. 确认用户已审核并批准 Release Notes。
-4. 确认测试/CI 状态满足发布门禁。
-5. 确认本地 `main` 与远端 `main` 一致，将版本同步和本次发布相关改动直接提交并推送 `main`。
-6. 创建 GitHub Release。
-7. 等待 GitHub Actions 发布流程。
-8. 检查 `MoviePilot-TV-unsigned.ipa` 是否成功上传到 Release。
-9. 向用户报告：Release 链接、版本号、workflow 状态、产物名称、是否 unsigned。
+2. 确认对应 `AppChangelogEntry` 已经按普通分支/PR 流程合并到 `main`。
+3. 确认 README 与 Xcode 工程版本号已同步。
+4. 确认用户已审核并批准从该条目生成的 Release Notes。
+5. 确认测试/CI 状态满足发布门禁。
+6. 确认本地 `main` 与远端 `main` 一致，将版本同步和本次发布相关改动直接提交并推送 `main`。
+7. 使用已合并 Changelog 的对应内容创建 GitHub Release。
+8. 等待 GitHub Actions 发布流程。
+9. 检查 `MoviePilot-TV-unsigned.ipa` 是否成功上传到 Release。
+10. 向用户报告：Release 链接、版本号、workflow 状态、产物名称、是否 unsigned。

--- a/MoviePilot-TV-Tests/AppChangelogTests.swift
+++ b/MoviePilot-TV-Tests/AppChangelogTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+
+@testable import MoviePilot_TV
+
+final class AppChangelogTests: XCTestCase {
+  func testHistoryContainsEveryPublishedVersionAndCompatibilityBaseline() {
+    let expectedVersions = [
+      "v0.3.5", "v0.3.4", "v0.3.3", "v0.3.2", "v0.3.1",
+      "v0.3.0", "v0.2.0", "v0.1.2", "v0.1.1", "v0.1.0",
+    ]
+    let expectedCompatibility = [
+      "v2.14.6", "v2.14.4", "v2.14.0", "v2.13.14", "v2.13.2",
+      "v2.10.9", "v2.9.13", "v2.9.13", "v2.9.13", "v2.9.7",
+    ]
+
+    XCTAssertEqual(AppChangelog.entries.map(\.version), expectedVersions)
+    XCTAssertEqual(
+      AppChangelog.entries.map(\.compatibleMoviePilotVersion),
+      expectedCompatibility
+    )
+    XCTAssertTrue(AppChangelog.entries[0].highlights.contains("兼容 MoviePilot 后端 v2.14.6。"))
+    XCTAssertTrue(AppChangelog.entries[1].highlights.contains("兼容 MoviePilot 后端 v2.14.4。"))
+    XCTAssertFalse(AppChangelog.entries[6].highlights.contains("兼容 MoviePilot 后端 v2.9.13。"))
+    XCTAssertFalse(AppChangelog.entries[7].highlights.contains("兼容 MoviePilot 后端 v2.9.13。"))
+    XCTAssertTrue(AppChangelog.entries[8].highlights.contains("兼容 MoviePilot 后端 v2.9.13。"))
+    XCTAssertFalse(AppChangelog.entries[9].highlights.contains("兼容 MoviePilot 后端 v2.9.7。"))
+  }
+
+  func testUpdateNoticeIsShownOnceAndOnlyForANewerVersion() throws {
+    let suiteName = "AppChangelogTests.\(UUID().uuidString)"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    let firstNotice = try XCTUnwrap(
+      AppChangelog.pendingUpdate(appVersion: "v0.3.4", defaults: defaults)
+    )
+    XCTAssertEqual(firstNotice.version, "v0.3.4")
+
+    AppChangelog.markPresented(firstNotice, defaults: defaults)
+    XCTAssertNil(AppChangelog.pendingUpdate(appVersion: "v0.3.4", defaults: defaults))
+    XCTAssertEqual(
+      AppChangelog.pendingUpdate(appVersion: "v0.3.5", defaults: defaults)?.version,
+      "v0.3.5"
+    )
+
+    defaults.set("v0.3.5", forKey: AppChangelog.presentedVersionKey)
+    XCTAssertNil(AppChangelog.pendingUpdate(appVersion: "v0.3.4", defaults: defaults))
+  }
+
+  func testUpdateNoticeOnlyUsesHighlightsAndPointsToFullHistory() throws {
+    let entry = try XCTUnwrap(AppChangelog.entry(for: "0.3.5"))
+    let message = AppChangelog.updateNoticeMessage(for: entry)
+
+    XCTAssertTrue(entry.highlights.allSatisfy { message.contains($0) })
+    XCTAssertTrue(message.contains("设置 > 版本更新历史"))
+    XCTAssertFalse(message.contains("修复 TMDB 识别失败后详情页持续加载的问题。"))
+  }
+}

--- a/MoviePilot-TV-Tests/SystemViewDefaultStyleTests.swift
+++ b/MoviePilot-TV-Tests/SystemViewDefaultStyleTests.swift
@@ -54,14 +54,48 @@ final class SystemViewDefaultStyleTests: XCTestCase {
     XCTAssertTrue(source.contains("sourceSession: sourceSession"))
   }
 
-  func testSystemViewKeepsConnectionAndAppInfoEntryPoints() throws {
+  func testSystemViewKeepsConnectionAppInfoAndChangelogEntryPoints() throws {
     let source = try Self.source(at: "MoviePilot-TV/Views/Pages/SystemView.swift")
 
     XCTAssertTrue(source.contains("\"连接与APP信息\""))
     XCTAssertTrue(source.contains("\"连接\""))
     XCTAssertTrue(source.contains("\"APP 信息\""))
+    XCTAssertTrue(source.contains("\"版本更新历史\""))
+    XCTAssertTrue(source.contains("row(\"版本更新历史\", showsDisclosure: true)"))
+    XCTAssertTrue(source.contains("push(.changelog)"))
     XCTAssertTrue(source.contains("\"MoviePilot TV APP\""))
     XCTAssertFalse(source.contains("\"连接与版本\""))
+  }
+
+  func testUpdateNoticeOnlyChecksWhenSettingsTabIsSelected() throws {
+    let source = try Self.source(at: "MoviePilot-TV/Views/Pages/SystemView.swift")
+
+    XCTAssertTrue(source.contains(".onChange(of: isSelected)"))
+    XCTAssertTrue(source.contains("guard isSelected, updateNotice == nil else { return }"))
+    XCTAssertTrue(source.contains("AppChangelog.markPresented(entry)"))
+    XCTAssertTrue(source.contains(".alert(item: $updateNotice)"))
+  }
+
+  func testChangelogSheetUsesReadableTvOSLayout() throws {
+    let source = try Self.source(at: "MoviePilot-TV/Views/Pages/SystemView.swift")
+
+    XCTAssertTrue(source.contains(".frame(width: 1_440, height: 1_025)"))
+    XCTAssertTrue(source.contains(".font(.callout)"))
+    XCTAssertTrue(source.contains(".font(isPrimary ? .headline.bold() : .subheadline.bold())"))
+    XCTAssertTrue(source.contains("Text(entry.releaseDate)"))
+    XCTAssertTrue(source.contains("value: \"\\(entry.releaseDate) · MoviePilot \\(entry.compatibleMoviePilotVersion)\""))
+  }
+
+  func testReleaseWorkflowUsesMergedChangelogAsReleaseNotesSource() throws {
+    let source = try Self.source(at: ".agents/prompts/release.md")
+
+    XCTAssertTrue(source.contains("## 更新内容"))
+    XCTAssertTrue(source.contains("### 新增功能"))
+    XCTAssertFalse(source.contains("## 主要更新"))
+    XCTAssertTrue(source.contains("只有兼容 MoviePilot 后端基线相对上一发布版本发生变化时"))
+    XCTAssertTrue(source.contains("`highlights` → `更新内容` 标题下最前面的摘要条目"))
+    XCTAssertTrue(source.contains("Changelog 改动未合并到 `main` 前，不得进入正式发布"))
+    XCTAssertTrue(source.contains("保持文字和顺序一致"))
   }
 
   func testSearchSettingsAndHeaderKeepPermissionAndLayoutContract() throws {

--- a/MoviePilot-TV/Models/AppChangelog.swift
+++ b/MoviePilot-TV/Models/AppChangelog.swift
@@ -1,0 +1,270 @@
+import Foundation
+
+nonisolated struct AppChangelogEntry: Identifiable, Equatable, Sendable {
+  let version: String
+  let releaseDate: String
+  let compatibleMoviePilotVersion: String
+  let highlights: [String]
+  let updates: [String]
+  let fixes: [String]
+  let optimizations: [String]
+
+  var id: String { version }
+}
+
+nonisolated enum AppChangelog {
+  static let presentedVersionKey = "lastPresentedChangelogVersion"
+
+  static let entries: [AppChangelogEntry] = [
+    AppChangelogEntry(
+      version: "v0.3.5",
+      releaseDate: "2026-07-22",
+      compatibleMoviePilotVersion: "v2.14.6",
+      highlights: [
+        "兼容 MoviePilot 后端 v2.14.6。",
+        "TMDB 详情跳转支持预加载，并在加载期间延续来源海报。",
+        "修复 TMDB 识别、订阅状态和搜索加载的重要异常。",
+      ],
+      updates: [
+        "TMDB 详情跳转支持预加载，并在加载期间延续来源海报。"
+      ],
+      fixes: [
+        "修复 TMDB 识别失败后详情页持续加载的问题。",
+        "修复订阅分享丢失 Bangumi ID、订阅状态刷新及搜索加载状态异常。",
+      ],
+      optimizations: [
+        "同步 MoviePilot v2.14.6 兼容基线。"
+      ]
+    ),
+    AppChangelogEntry(
+      version: "v0.3.4",
+      releaseDate: "2026-07-16",
+      compatibleMoviePilotVersion: "v2.14.4",
+      highlights: [
+        "兼容 MoviePilot 后端 v2.14.4。",
+        "修复详情页、列表与弹窗的焦点和状态反馈问题。",
+        "修复分季取消订阅与 MoviePilot 行为不一致的问题。",
+      ],
+      updates: [],
+      fixes: [
+        "修复详情页、列表与弹窗的焦点和状态反馈问题。",
+        "修复分季取消订阅与 MoviePilot v2.14.4 行为不一致的问题。",
+      ],
+      optimizations: [
+        "适配 MoviePilot v2.14.4。"
+      ]
+    ),
+    AppChangelogEntry(
+      version: "v0.3.3",
+      releaseDate: "2026-07-02",
+      compatibleMoviePilotVersion: "v2.14.0",
+      highlights: [
+        "兼容 MoviePilot 后端 v2.14.0。",
+        "修复部分电视剧无分季信息或加载失败时无法继续订阅的问题。",
+      ],
+      updates: [
+        "适配 MoviePilot v2.14.0。"
+      ],
+      fixes: [
+        "修复部分电视剧详情页无分季信息时的显示异常。",
+        "修复分季信息加载失败时无法进入分季订阅的问题。",
+      ],
+      optimizations: []
+    ),
+    AppChangelogEntry(
+      version: "v0.3.2",
+      releaseDate: "2026-07-01",
+      compatibleMoviePilotVersion: "v2.13.14",
+      highlights: [
+        "兼容 MoviePilot 后端 v2.13.14。",
+        "重新设计设置页面，并新增 Apple TV 自动续签脚本。",
+        "修复权限、异步页面状态与订阅流程中的多项重要问题。",
+      ],
+      updates: [
+        "重新设计设置页面 UI。",
+        "适配 MoviePilot v2.13.14。",
+        "新增 Apple TV 自动续签脚本。",
+      ],
+      fixes: [
+        "对齐 MoviePilot Web 权限规则，非超级用户不再访问或显示仅限超级用户的功能。",
+        "修复下载、搜索、资源搜索和订阅中的旧请求覆盖当前页面状态问题。",
+        "修复分季订阅、取消订阅确认、订阅缓存刷新和订阅分享去重问题。",
+        "修复部分合集识别、人物图片解析和图片代理地址兼容问题。",
+      ],
+      optimizations: [
+        "增强订阅状态、媒体详情和异步刷新过程的稳定性。"
+      ]
+    ),
+    AppChangelogEntry(
+      version: "v0.3.1",
+      releaseDate: "2026-05-29",
+      compatibleMoviePilotVersion: "v2.13.2",
+      highlights: [
+        "兼容 MoviePilot 后端 v2.13.2。",
+        "优化手动整理、资源搜索和订阅状态同步。",
+        "修复图片代理、搜索结束时机与订阅状态异常。",
+      ],
+      updates: [
+        "适配 MoviePilot v2.13.2。",
+        "优化手动整理、资源搜索和订阅状态同步。",
+      ],
+      fixes: [
+        "修复部分图片代理地址被截断的问题。",
+        "修复搜索完成后可能过早结束的问题。",
+        "修复部分场景订阅状态不同步的问题。",
+      ],
+      optimizations: []
+    ),
+    AppChangelogEntry(
+      version: "v0.3.0",
+      releaseDate: "2026-05-02",
+      compatibleMoviePilotVersion: "v2.10.9",
+      highlights: [
+        "兼容 MoviePilot 后端 v2.10.9。",
+        "新增搜索过滤、默认站点、SSE 流式搜索和首页卡片快捷操作。",
+        "显著优化页面渲染、详情加载和图片预取性能。",
+        "修复页面返回焦点重置及部分详情页白屏问题。",
+      ],
+      updates: [
+        "搜索过滤功能大幅增强，支持硬过滤（排除）与软过滤（置尾）组合规则。",
+        "支持配置默认资源搜索站点，并在全局搜索中应用。",
+        "首页“最近添加”卡片增加长按菜单，支持快速跳转、查看详情及搜索资源。",
+        "适配 MoviePilot v2.10.9 批量 AI 整理接口。",
+        "系统设置页面增加连接信息显示，包含后端地址、当前用户及版本。",
+        "适配 SSE 流式搜索，显著提升资源搜索的响应速度。",
+        "增加账号状态检测与手动刷新功能。",
+      ],
+      fixes: [
+        "修复页面返回时焦点重置、部分详情页因 API 空数据导致白屏等问题。"
+      ],
+      optimizations: [
+        "优化 SwiftUI 渲染性能，提升 UI 操作与滚动流畅度。",
+        "优化详情页加载过渡动画及数据预加载逻辑，减少进入页面的等待感。",
+        "改进搜索匹配逻辑。",
+        "实现分页图片预取策略，优化列表滚动时的图片加载体验。",
+        "针对 tvOS 26.0 至 26.4 调整 Sheet 组件样式与兼容性。",
+        "扩大添加下载弹窗尺寸及标题描述的显示行数。",
+        "优化轮询刷新逻辑，确保应用从后台唤醒后正常触发数据更新。",
+      ]
+    ),
+    AppChangelogEntry(
+      version: "v0.2.0",
+      releaseDate: "2026-03-14",
+      compatibleMoviePilotVersion: "v2.9.13",
+      highlights: [
+        "新增订阅分享、整理历史与手动整理功能。",
+        "首页媒体支持直接播放，发现页新增热门订阅推荐。",
+        "重构系统状态页面并提升稳定性。",
+      ],
+      updates: [
+        "新增订阅分享浏览、搜索与复用功能。",
+        "新增整理历史浏览与手动整理功能。",
+        "首页媒体卡片支持直接跳转播放。",
+        "发现页新增热门订阅推荐。",
+      ],
+      fixes: [],
+      optimizations: [
+        "重构系统状态页面，优化数据模型和稳定性。",
+        "增强 UI 交互。",
+        "优化首页、订阅页的卡片显示，订阅卡片增加更新时间。",
+      ]
+    ),
+    AppChangelogEntry(
+      version: "v0.1.2",
+      releaseDate: "2026-03-09",
+      compatibleMoviePilotVersion: "v2.9.13",
+      highlights: [
+        "优化下载任务页交互和刷新性能。",
+        "改进搜索结果布局与流行趋势展示。",
+      ],
+      updates: [
+        "搜索页根据最佳结果数量动态调整展示行数。",
+        "流行趋势支持在全部内容和榜单中显示。",
+      ],
+      fixes: [
+        "修复提交按钮在加载状态下的显示问题。",
+        "修复下载任务行的部分交互问题。",
+        "优化部分语言名称的简体中文翻译。",
+      ],
+      optimizations: [
+        "优化下载任务页的 UI 刷新性能。"
+      ]
+    ),
+    AppChangelogEntry(
+      version: "v0.1.1",
+      releaseDate: "2026-03-08",
+      compatibleMoviePilotVersion: "v2.9.13",
+      highlights: [
+        "兼容 MoviePilot 后端 v2.9.13。",
+        "统一分页加载并增加接口缓存，提升列表和详情加载性能。",
+        "修复合集分页、分季缓存及详情页加载问题。",
+      ],
+      updates: [],
+      fixes: [
+        "修复详情页加载不完整、内容跳动与闪烁问题。",
+        "修复合集详情页只显示第一页的问题。",
+        "修复分季信息缓存错误。",
+      ],
+      optimizations: [
+        "引入通用分页加载器，统一推荐、探索、搜索、人物及合集页面的数据加载。",
+        "增加接口缓存并优化分季和详情页加载体验。",
+        "增强分页重置、任务取消和加载状态的稳定性。",
+      ]
+    ),
+    AppChangelogEntry(
+      version: "v0.1.0",
+      releaseDate: "2026-03-06",
+      compatibleMoviePilotVersion: "v2.9.7",
+      highlights: [
+        "首次发布 MoviePilot Apple TV 原生客户端。",
+        "支持媒体浏览、搜索、详情、订阅与 Siri Remote 快捷操作。",
+      ],
+      updates: [
+        "发布首个基于 SwiftUI 的 MoviePilot Apple TV 原生客户端。",
+        "支持媒体库、推荐、探索、聚合搜索及媒体、人物和合集详情。",
+        "支持媒体订阅、资源搜索与添加下载。",
+        "支持 Siri Remote 海报长按快捷操作和持久化登录。",
+      ],
+      fixes: [],
+      optimizations: [
+        "针对电视大屏与 Siri Remote 交互设计原生界面和详情加载流程。"
+      ]
+    ),
+  ]
+
+  static var latest: AppChangelogEntry? { entries.first }
+
+  static func entry(for appVersion: String) -> AppChangelogEntry? {
+    entries.first { $0.version == AppVersionInfo.displayAppVersion(shortVersion: appVersion) }
+  }
+
+  static func pendingUpdate(
+    appVersion: String,
+    defaults: UserDefaults = .standard
+  ) -> AppChangelogEntry? {
+    guard let current = entry(for: appVersion) else { return nil }
+    guard let presentedVersion = defaults.string(forKey: presentedVersionKey) else {
+      return current
+    }
+    guard presentedVersion != current.version else { return nil }
+    guard
+      AppVersionInfo.compareMoviePilotVersion(current.version, to: presentedVersion)
+        == .orderedDescending
+    else {
+      return nil
+    }
+    return current
+  }
+
+  static func markPresented(
+    _ entry: AppChangelogEntry,
+    defaults: UserDefaults = .standard
+  ) {
+    defaults.set(entry.version, forKey: presentedVersionKey)
+  }
+
+  static func updateNoticeMessage(for entry: AppChangelogEntry) -> String {
+    let highlights = entry.highlights.map { "• \($0)" }.joined(separator: "\n")
+    return "\(highlights)\n\n完整更新日志请前往“设置 > 版本更新历史”查看。"
+  }
+}

--- a/MoviePilot-TV/Views/Pages/SystemView.swift
+++ b/MoviePilot-TV/Views/Pages/SystemView.swift
@@ -21,6 +21,8 @@ struct SystemView: View {
   @StateObject private var recommendViewModel = RecommendViewModel(selectShelf: false)
   @ObservedObject private var apiService = APIService.shared
   @State private var showAppInfo = false
+  @State private var selectedChangelogEntry: AppChangelogEntry?
+  @State private var updateNotice: AppChangelogEntry?
   @State private var showLogoutConfirmation = false
   @State private var route: [SystemSettingsPage] = []
   @State private var displayedRoute: [SystemSettingsPage] = []
@@ -97,10 +99,12 @@ struct SystemView: View {
       pageOffsetDepth = route.count
       viewModel.checkKeychainStatus()
       refreshFilterRulesForEntryIfNeeded()
+      presentUpdateNoticeIfNeeded()
     }
     .onChange(of: isSelected) { _, selected in
       guard selected else { return }
       refreshFilterRulesForEntryIfNeeded()
+      presentUpdateNoticeIfNeeded()
     }
     .task {
       await viewModel.loadSystemInfo()
@@ -108,6 +112,19 @@ struct SystemView: View {
     }
     .sheet(isPresented: $showAppInfo) {
       appInfoSheet
+    }
+    .sheet(item: $selectedChangelogEntry) { entry in
+      changelogDetailSheet(entry)
+    }
+    .alert(item: $updateNotice) { entry in
+      Alert(
+        title: Text("已更新到 \(entry.version)"),
+        message: Text(AppChangelog.updateNoticeMessage(for: entry))
+          .font(.callout),
+        dismissButton: .default(Text("知道了")) {
+          AppChangelog.markPresented(entry)
+        }
+      )
     }
   }
 
@@ -175,6 +192,8 @@ struct SystemView: View {
             if canConfigureRecommendations {
               recommendationPage
             }
+          case .changelog:
+            changelogPage
           }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -302,6 +321,13 @@ struct SystemView: View {
           row("APP 信息", value: viewModel.appVersion)
         }
         .focused($focusedItem, equals: .appInfo)
+
+        Button {
+          push(.changelog)
+        } label: {
+          row("版本更新历史", showsDisclosure: true)
+        }
+        .focused($focusedItem, equals: .changelog)
       }
     }
   }
@@ -384,6 +410,69 @@ struct SystemView: View {
       .padding(.bottom, 46)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+  }
+
+  private var changelogPage: some View {
+    section(nil) {
+      ForEach(AppChangelog.entries) { entry in
+        Button {
+          selectedChangelogEntry = entry
+        } label: {
+          row(
+            entry.version,
+            value: "\(entry.releaseDate) · MoviePilot \(entry.compatibleMoviePilotVersion)",
+            showsDisclosure: true
+          )
+        }
+        .focused($focusedItem, equals: .changelogVersion(entry.version))
+      }
+    }
+  }
+
+  private func changelogDetailSheet(_ entry: AppChangelogEntry) -> some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 28) {
+        VStack(alignment: .leading, spacing: 10) {
+          Text(entry.version)
+            .font(.title2.bold())
+          Text(entry.releaseDate)
+            .font(.callout)
+            .foregroundStyle(.secondary)
+        }
+
+        Divider()
+
+        changelogSection("更新内容", items: entry.highlights, isPrimary: true)
+        changelogSection("新增功能", items: entry.updates)
+        changelogSection("修复", items: entry.fixes)
+        changelogSection("优化", items: entry.optimizations)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .padding(.horizontal, 72)
+      .padding(.vertical, 54)
+    }
+    .frame(width: 1_440, height: 1_025)
+  }
+
+  @ViewBuilder
+  private func changelogSection(
+    _ title: String,
+    items: [String],
+    isPrimary: Bool = false
+  ) -> some View {
+    if !items.isEmpty {
+      VStack(alignment: .leading, spacing: 16) {
+        Text(title)
+          .font(isPrimary ? .headline.bold() : .subheadline.bold())
+
+        ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+          Text("• \(item)")
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+    }
   }
 
   private var recommendationPage: some View {
@@ -592,6 +681,8 @@ struct SystemView: View {
     switch poppedPage {
     case .connection, .root:
       target = .connection
+    case .changelog:
+      target = .changelog
     case .mediaSourceSelection:
       target = .mediaSourceSelection
     case .siteSelection:
@@ -616,6 +707,8 @@ struct SystemView: View {
       target = .waitBackgroundImage
     case .connection:
       target = .relogin
+    case .changelog:
+      target = AppChangelog.latest.map { .changelogVersion($0.version) } ?? .changelog
     case .mediaSourceSelection:
       target = .defaultMediaSource
     case .siteSelection:
@@ -637,7 +730,7 @@ struct SystemView: View {
     switch route.last {
     case .softFilter:
       return .softFilterNone
-    case .root, .connection, .mediaSourceSelection, .siteSelection, .hardFilter,
+    case .root, .connection, .changelog, .mediaSourceSelection, .siteSelection, .hardFilter,
       .recommendation, .none:
       return .hardFilterNone
     }
@@ -647,7 +740,7 @@ struct SystemView: View {
     switch route.last {
     case .softFilter:
       return .softFilterRule(ruleId)
-    case .root, .connection, .mediaSourceSelection, .siteSelection, .hardFilter,
+    case .root, .connection, .changelog, .mediaSourceSelection, .siteSelection, .hardFilter,
       .recommendation, .none:
       return .hardFilterRule(ruleId)
     }
@@ -672,6 +765,12 @@ struct SystemView: View {
     Task {
       await viewModel.loadCustomFilterRules()
     }
+  }
+
+  private func presentUpdateNoticeIfNeeded() {
+    guard isSelected, updateNotice == nil else { return }
+    guard let entry = AppChangelog.pendingUpdate(appVersion: viewModel.appVersion) else { return }
+    updateNotice = entry
   }
 
   private func toggleDefaultSearchSite(_ siteId: Int) {
@@ -714,9 +813,11 @@ struct SystemView: View {
         return "查看当前登录状态、服务器地址和后端连接状态。"
       case .appInfo:
         return nil
+      case .changelog:
+        return "查看 MoviePilot TV 各版本的更新摘要、完整改动和后端兼容版本。"
       case .allSites, .site, .defaultMediaSource, .mediaSource, .relogin, .logout,
         .hardFilterNone, .softFilterNone, .hardFilterRule, .softFilterRule,
-        .recommendationShelf:
+        .recommendationShelf, .changelogVersion:
         break
       }
     }
@@ -737,6 +838,8 @@ struct SystemView: View {
       return nil
     case .connection:
       return "查看当前登录状态、服务器地址和后端连接状态。"
+    case .changelog:
+      return "查看 MoviePilot TV 各版本的更新摘要、完整改动和后端兼容版本。"
     case .mediaSourceSelection:
       return "设置聚合搜索默认使用的媒体来源。（只影响 TV 端）"
     case .siteSelection:
@@ -794,6 +897,7 @@ struct SystemView: View {
 private enum SystemSettingsPage: Hashable {
   case root
   case connection
+  case changelog
   case mediaSourceSelection
   case siteSelection
   case hardFilter
@@ -803,6 +907,8 @@ private enum SystemSettingsPage: Hashable {
 
 private enum SystemSettingsFocus: Hashable {
   case connection
+  case changelog
+  case changelogVersion(String)
   case mediaSourceSelection
   case defaultMediaSource
   case mediaSource(MediaSearchSource)


### PR DESCRIPTION
## 变更内容

- 在设置“连接与APP信息”中增加“版本更新历史”入口，展示全部历史版本 Changelog。
- 新版本首次进入设置页时显示一次升级提示；提示记录使用全局版本 marker，不按账号隔离。
- 详情 Sheet 调整为更宽更高的布局，并缩小完整 Changelog 字号。
- 发布流程改为先维护代码内 Changelog，再复用到 GitHub Release Notes；兼容后端版本仅在基线发生变化时写入摘要。

## 验证

- `AppChangelogTests` + `SystemViewDefaultStyleTests`：36/36 通过。
- 按用户要求未运行兼容测试。
- tvOS Simulator Debug 构建通过。

当前 commit：`5ed48e7`。